### PR TITLE
fix(session): add exclusive session lease with heartbeat takeover

### DIFF
--- a/.changeset/session-lease-lock.md
+++ b/.changeset/session-lease-lock.md
@@ -1,0 +1,6 @@
+---
+'@moonshot-ai/protocol': minor
+'@moonshot-ai/agent-core-v2': minor
+---
+
+Add a session-level exclusive lease: a session can now be held by only one kimi-code instance at a time. Resuming or creating a session already held by another instance fails with the new `session.locked` error (carrying the holder's pid, serverId, and lock timestamps); when the holder crashes or stops heartbeating, the next resumer takes over automatically, and the stale holder evicts itself from memory instead of writing to the wire journal.

--- a/packages/agent-core-v2/src/app/sessionExport/sessionExportService.ts
+++ b/packages/agent-core-v2/src/app/sessionExport/sessionExportService.ts
@@ -13,6 +13,7 @@ import {
   sessionDirOf,
   workspacePersistenceScope,
 } from '#/workspace/sessionLifecycle/internal/addressing';
+import { SESSION_LEASE_FILE } from '#/workspace/sessionLifecycle/sessionLease';
 import { ErrorCodes, Error2 } from '#/errors';
 import { IAgentLifecycleService } from '#/session/agentLifecycle/agentLifecycle';
 import { ISessionMetadata } from '#/session/sessionMetadata/sessionMetadata';
@@ -202,8 +203,9 @@ export async function exportSessionDirectory(input: {
 
     const sessionScan = await scanSessionWire(sessionDir, input.signal);
     const stableSessionLog = sessionLogSource;
+    const leasePath = join(sessionDir, SESSION_LEASE_FILE);
     const selectedSessionFiles: SessionZipEntry[] = sessionFiles.filter(
-      (file) => file !== sessionLogPath,
+      (file) => file !== sessionLogPath && file !== leasePath,
     );
     if (stableSessionLog !== undefined) {
       selectedSessionFiles.push({ path: sessionLogPath, source: stableSessionLog });

--- a/packages/agent-core-v2/src/session/errors.ts
+++ b/packages/agent-core-v2/src/session/errors.ts
@@ -6,6 +6,7 @@ export const SessionErrors = {
     SESSION_ALREADY_EXISTS: 'session.already_exists',
     SESSION_ID_INVALID: 'session.id_invalid',
     SESSION_CLOSED: 'session.closed',
+    SESSION_LOCKED: 'session.locked',
     SESSION_FORK_ACTIVE_TURN: 'session.fork_active_turn',
     SESSION_UNDO_UNAVAILABLE: 'session.undo_unavailable',
     SESSION_INIT_FAILED: 'session.init_failed',
@@ -13,6 +14,14 @@ export const SessionErrors = {
     SESSION_TOWER_MODE_INVALID: 'session.tower_mode_invalid',
   },
   retryable: ['session.fork_active_turn'],
+  info: {
+    'session.locked': {
+      title: 'Session locked',
+      retryable: false,
+      public: true,
+      action: 'The session is held by another kimi-code instance; resume it there or wait for its heartbeat to expire.',
+    },
+  },
 } as const satisfies ErrorDomain;
 
 registerErrorDomain(SessionErrors);

--- a/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLease.ts
+++ b/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLease.ts
@@ -1,0 +1,265 @@
+import { randomUUID } from 'node:crypto';
+
+import { join } from 'pathe';
+
+import { Disposable } from '#/_base/di/lifecycle';
+import { ILogService } from '#/_base/log/log';
+import { IntervalTimer } from '#/_base/utils/timer';
+import { Error2, ErrorCodes } from '#/errors';
+import { IHostFileSystem } from '#/os/interface/hostFileSystem';
+
+export const SESSION_LEASE_FILE = 'lease.json';
+
+export interface SessionLeaseTiming {
+  readonly renewIntervalMs: number;
+  readonly staleAfterMs: number;
+}
+
+export const DEFAULT_SESSION_LEASE_TIMING: SessionLeaseTiming = {
+  renewIntervalMs: 5_000,
+  staleAfterMs: 30_000,
+};
+
+export interface SessionLeaseHolder {
+  readonly leaseId: string;
+  readonly pid: number;
+  readonly serverId: string;
+  readonly acquiredAt: number;
+  readonly renewedAt: number;
+}
+
+interface HeldLease {
+  readonly sessionId: string;
+  readonly filePath: string;
+  holder: SessionLeaseHolder;
+  readonly timer: IntervalTimer;
+  readonly onLost: () => void;
+  chain: Promise<void>;
+  active: boolean;
+}
+
+export class SessionLeaseManager extends Disposable {
+  private readonly held = new Map<string, HeldLease>();
+  private readonly timing: SessionLeaseTiming;
+  private readonly serverId = randomUUID();
+  private disposed = false;
+
+  constructor(
+    private readonly fs: IHostFileSystem,
+    private readonly log: ILogService,
+    private readonly sessionDirFor: (sessionId: string) => string,
+    timing?: Partial<SessionLeaseTiming>,
+    private readonly now: () => number = Date.now,
+  ) {
+    super();
+    this.timing = { ...DEFAULT_SESSION_LEASE_TIMING, ...timing };
+  }
+
+  isHeld(sessionId: string): boolean {
+    return this.held.has(sessionId);
+  }
+
+  async acquire(sessionId: string, onLost: () => void): Promise<SessionLeaseHolder> {
+    const existing = this.held.get(sessionId);
+    if (existing !== undefined) return existing.holder;
+    const dir = this.sessionDirFor(sessionId);
+    const filePath = join(dir, SESSION_LEASE_FILE);
+    await this.fs.mkdir(dir, { recursive: true });
+    const holder: SessionLeaseHolder = {
+      leaseId: randomUUID(),
+      pid: process.pid,
+      serverId: this.serverId,
+      acquiredAt: this.now(),
+      renewedAt: this.now(),
+    };
+    const encoded = encodeLease(holder);
+    for (let attempt = 0; attempt < 2; attempt++) {
+      if (await this.fs.createExclusive(filePath, encoded)) {
+        this.track(sessionId, filePath, holder, onLost);
+        return holder;
+      }
+      const holderOnDisk = await this.readHolder(filePath);
+      const mtimeMs = await this.mtimeOf(filePath);
+      if (mtimeMs === undefined) continue;
+      if (this.now() - mtimeMs <= this.timing.staleAfterMs) {
+        throw this.lockedError(sessionId, holderOnDisk);
+      }
+      this.log.warn('session lease heartbeat expired, attempting takeover', {
+        sessionId,
+        holder: holderOnDisk,
+      });
+      await this.fs.remove(filePath);
+      if (await this.fs.createExclusive(filePath, encoded)) {
+        this.track(sessionId, filePath, holder, onLost);
+        return holder;
+      }
+      throw this.lockedError(sessionId, await this.readHolder(filePath));
+    }
+    throw this.lockedError(sessionId, await this.readHolder(filePath));
+  }
+
+  async release(sessionId: string): Promise<void> {
+    const entry = this.held.get(sessionId);
+    if (entry === undefined) return;
+    entry.active = false;
+    entry.timer.cancel();
+    this.held.delete(sessionId);
+    await entry.chain.catch(() => undefined);
+    const current = await this.readHolder(entry.filePath);
+    if (current?.leaseId !== entry.holder.leaseId) return;
+    await this.fs.remove(entry.filePath).catch((error: unknown) => {
+      this.log.warn('session lease release failed', { sessionId, error });
+    });
+  }
+
+  async releaseAll(): Promise<void> {
+    for (const sessionId of this.held.keys()) {
+      await this.release(sessionId).catch((error: unknown) => {
+        this.log.warn('session lease release failed', { sessionId, error });
+      });
+    }
+  }
+
+  override dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const entry of this.held.values()) {
+      entry.active = false;
+      entry.timer.cancel();
+    }
+    void this.releaseAll().catch((error: unknown) => {
+      this.log.error('session lease teardown failed', error);
+    });
+    super.dispose();
+  }
+
+  private track(
+    sessionId: string,
+    filePath: string,
+    holder: SessionLeaseHolder,
+    onLost: () => void,
+  ): void {
+    const entry: HeldLease = {
+      sessionId,
+      filePath,
+      holder,
+      timer: new IntervalTimer({ unref: true }),
+      onLost,
+      chain: Promise.resolve(),
+      active: true,
+    };
+    this.held.set(sessionId, entry);
+    entry.timer.cancelAndSet(() => {
+      if (!entry.active || this.disposed) return;
+      entry.chain = entry.chain.then(
+        () => this.renew(entry),
+        () => this.renew(entry),
+      );
+    }, this.timing.renewIntervalMs);
+  }
+
+  private async renew(entry: HeldLease): Promise<void> {
+    if (!entry.active) return;
+    let isFile: boolean;
+    let mtimeMs: number | undefined;
+    try {
+      const stat = await this.fs.stat(entry.filePath);
+      isFile = stat.isFile;
+      mtimeMs = stat.mtimeMs;
+    } catch {
+      this.lost(entry);
+      return;
+    }
+    if (!isFile) {
+      this.lost(entry);
+      return;
+    }
+    const holderOnDisk = await this.readHolder(entry.filePath);
+    if (holderOnDisk === undefined) {
+      if (mtimeMs !== undefined && this.now() - mtimeMs <= this.timing.staleAfterMs) return;
+      this.lost(entry);
+      return;
+    }
+    if (holderOnDisk.leaseId !== entry.holder.leaseId) {
+      this.lost(entry);
+      return;
+    }
+    const renewed: SessionLeaseHolder = { ...entry.holder, renewedAt: this.now() };
+    try {
+      await this.fs.writeText(entry.filePath, JSON.stringify(renewed));
+      entry.holder = renewed;
+    } catch (error) {
+      this.log.warn('session lease renew failed', {
+        sessionId: entry.sessionId,
+        error,
+      });
+      this.lost(entry);
+    }
+  }
+
+  private lost(entry: HeldLease): void {
+    if (!entry.active) return;
+    entry.active = false;
+    entry.timer.cancel();
+    this.held.delete(entry.sessionId);
+    this.log.warn('session lease lost', {
+      sessionId: entry.sessionId,
+      filePath: entry.filePath,
+    });
+    try {
+      entry.onLost();
+    } catch (error) {
+      this.log.error('session lease lost handler failed', error);
+    }
+  }
+
+  private async readHolder(filePath: string): Promise<SessionLeaseHolder | undefined> {
+    let raw: string;
+    try {
+      raw = await this.fs.readText(filePath);
+    } catch {
+      return undefined;
+    }
+    return parseLease(raw);
+  }
+
+  private async mtimeOf(filePath: string): Promise<number | undefined> {
+    try {
+      const stat = await this.fs.stat(filePath);
+      return stat.isFile ? stat.mtimeMs : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private lockedError(sessionId: string, holder: SessionLeaseHolder | undefined): Error2 {
+    const message =
+      holder === undefined
+        ? `Session "${sessionId}" is locked by another kimi-code instance`
+        : `Session "${sessionId}" is locked by another kimi-code instance (pid ${holder.pid}, server ${holder.serverId}, acquired ${new Date(holder.acquiredAt).toISOString()})`;
+    return new Error2(ErrorCodes.SESSION_LOCKED, message, {
+      details: { sessionId, holder },
+    });
+  }
+}
+
+function encodeLease(holder: SessionLeaseHolder): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(holder));
+}
+
+function parseLease(raw: string): SessionLeaseHolder | undefined {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (typeof value !== 'object' || value === null) return undefined;
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate['leaseId'] !== 'string') return undefined;
+  if (typeof candidate['pid'] !== 'number') return undefined;
+  if (typeof candidate['serverId'] !== 'string') return undefined;
+  if (typeof candidate['acquiredAt'] !== 'number') return undefined;
+  if (typeof candidate['renewedAt'] !== 'number') return undefined;
+  return candidate as unknown as SessionLeaseHolder;
+}

--- a/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
+++ b/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
@@ -83,6 +83,7 @@ import { PLUGIN_SKILL_SOURCE_ID } from '#/features/skill/catalog/skillSource';
 
 import { agentScopeOf, sessionDirOf, sessionScopeOf } from './internal/addressing';
 import { SessionArchived } from './sessionLifecycleEvents';
+import { SessionLeaseManager, SESSION_LEASE_FILE } from './sessionLease';
 import {
   assertForkTurnIndex,
   sliceMainRecordsAtTurn,
@@ -174,9 +175,11 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
     @IModelService private readonly models: IModelService,
     @IProviderService private readonly providers: IProviderService,
     @IFlagService private readonly flags: IFlagService,
+    private readonly leases: SessionLeaseManager,
     onDispose?: () => void,
   ) {
     super();
+    this._register(this.leases);
     if (onDispose !== undefined) this._register({ dispose: onDispose });
   }
 
@@ -217,6 +220,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
       this.sessions.delete(sessionId);
       await this.drainAgents(handle).catch(() => {});
       void handle.dispose();
+      await this.leases.release(sessionId);
       await this.hostFs.remove(sessionDir).catch(() => {});
       throw error;
     }
@@ -247,38 +251,49 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
       scope: (subKey?: string): string =>
         subKey === undefined || subKey === '' ? sessionScope : `${sessionScope}/${subKey}`,
     };
-    const handle = createScopedChildHandle(
-      this.instantiation,
-      LifecycleScope.Session,
-      opts.sessionId,
-      {
-        seeds: [
-          ...sessionContextSeed(ctx),
-          [ITelemetryService, this.telemetry.withContext({ sessionId: opts.sessionId })],
-          ...sessionAgentProfileCatalogSeed({
-            _serviceBrand: undefined,
-            workspaceKey: workspaceId,
-          }),
-          [ISessionSkillCatalogData, this.workspaceSkillCatalog.sessionData()],
-          [ISessionInstructionsProvider, this.workspaceInstructions.sessionProvider()],
-          [ISessionMcpHandle, this.workspaceMcp.sessionHandle()],
-          [ISessionWorkspaceInfo, this.workspaceDirs.sessionInfo()],
-          ...sessionEphemeralMcpServersSeed(opts.mcpServers ?? {}),
-        ],
-        configureContainer: (container) => {
-          this._onWillCreateSession.fire({
-            sessionId: opts.sessionId,
-            readSeed: (id) => container.invokeFunction((accessor) => accessor.get(id)),
-            contributeSeed: (id, value) => {
-              container.provide(id, value);
-            },
-            onSessionDispose: (dispose) => {
-              container.anchorKernelEntry(dispose, 'sessionLifecycle:willCreateParticipant');
-            },
-          });
+    await this.leases.acquire(opts.sessionId, () => {
+      void this.evictForLeaseLoss(opts.sessionId).catch((error: unknown) => {
+        this.log.error('session eviction after lease loss failed', { error });
+      });
+    });
+    let handle: ISessionScopeHandle;
+    try {
+      handle = createScopedChildHandle(
+        this.instantiation,
+        LifecycleScope.Session,
+        opts.sessionId,
+        {
+          seeds: [
+            ...sessionContextSeed(ctx),
+            [ITelemetryService, this.telemetry.withContext({ sessionId: opts.sessionId })],
+            ...sessionAgentProfileCatalogSeed({
+              _serviceBrand: undefined,
+              workspaceKey: workspaceId,
+            }),
+            [ISessionSkillCatalogData, this.workspaceSkillCatalog.sessionData()],
+            [ISessionInstructionsProvider, this.workspaceInstructions.sessionProvider()],
+            [ISessionMcpHandle, this.workspaceMcp.sessionHandle()],
+            [ISessionWorkspaceInfo, this.workspaceDirs.sessionInfo()],
+            ...sessionEphemeralMcpServersSeed(opts.mcpServers ?? {}),
+          ],
+          configureContainer: (container) => {
+            this._onWillCreateSession.fire({
+              sessionId: opts.sessionId,
+              readSeed: (id) => container.invokeFunction((accessor) => accessor.get(id)),
+              contributeSeed: (id, value) => {
+                container.provide(id, value);
+              },
+              onSessionDispose: (dispose) => {
+                container.anchorKernelEntry(dispose, 'sessionLifecycle:willCreateParticipant');
+              },
+            });
+          },
         },
-      },
-    ) as ISessionScopeHandle;
+      ) as ISessionScopeHandle;
+    } catch (error) {
+      await this.leases.release(opts.sessionId);
+      throw error;
+    }
     try {
       await handle.accessor.get(ISessionMetadata).ready;
       await handle.accessor.get(ISessionToolPolicy).ready;
@@ -290,6 +305,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
         this.pluginAgentProfileLoader.ready,
       ]);
     } catch (error) {
+      await this.leases.release(opts.sessionId);
       void handle.dispose();
       void this.explicitAgentProfileLoader.reload().catch(() => undefined);
       throw error;
@@ -373,6 +389,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
     } catch (error) {
       this.sessions.delete(sessionId);
       void handle.dispose();
+      await this.leases.release(sessionId);
       throw error;
     }
     return handle;
@@ -389,6 +406,21 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
   async close(sessionId: string): Promise<void> {
     const handle = this.sessions.get(sessionId);
     if (handle === undefined) return;
+    await this.teardownLiveSession(sessionId, handle, true);
+  }
+
+  private async evictForLeaseLoss(sessionId: string): Promise<void> {
+    const handle = this.sessions.get(sessionId);
+    if (handle === undefined) return;
+    this.log.warn('session evicted after losing its lease', { sessionId });
+    await this.teardownLiveSession(sessionId, handle, false);
+  }
+
+  private async teardownLiveSession(
+    sessionId: string,
+    handle: ISessionScopeHandle,
+    releaseLease: boolean,
+  ): Promise<void> {
     await this.announceWillClose({ sessionId, handle, reason: 'exit' });
     this.sessions.delete(sessionId);
     await this.drainAgents(handle);
@@ -397,6 +429,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
     await this.indexMirror.drain();
     void handle.dispose();
     await drainLogCloses();
+    if (releaseLease) await this.leases.release(sessionId);
     this._onDidCloseSession.fire({ sessionId });
   }
 
@@ -418,6 +451,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
     await this.indexMirror.drain();
     void handle.dispose();
     await drainLogCloses();
+    await this.leases.release(sessionId);
     this._onDidArchiveSession.fire({ sessionId });
   }
 
@@ -601,6 +635,9 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
         } catch {
         }
       }
+      if (targetId !== undefined) {
+        await this.leases.release(targetId);
+      }
       if (targetSessionDir !== undefined) {
         await this.hostFs.remove(targetSessionDir).catch(() => {});
       }
@@ -735,7 +772,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
   ): Promise<void> {
     for (const entry of entries) {
       const rel = relBase === '' ? entry.name : `${relBase}/${entry.name}`;
-      if (rel === 'state.json' || rel === 'logs' || rel === 'upcoming-goals.json' || entry.name === AGENT_WIRE_RECORD_KEY) {
+      if (rel === 'state.json' || rel === 'logs' || rel === 'upcoming-goals.json' || rel === SESSION_LEASE_FILE || entry.name === AGENT_WIRE_RECORD_KEY) {
         continue;
       }
       if (entry.isSymbolicLink === true) continue;

--- a/packages/agent-core-v2/src/workspace/workspaceInstance/workspaceInstanceManagerService.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceInstance/workspaceInstanceManagerService.ts
@@ -36,6 +36,8 @@ import { RuntimeError, RuntimeRegistry } from '#/runtime/runtimeRegistry';
 import type { RuntimeProviderFactory } from '#/runtime/runtimeProvider';
 import { SharedRuntimeUnitHostFactory, type RuntimeUnitHandle, type RuntimeUnitHostFactory } from '#/runtime/runtimeUnitHost';
 import { SessionLifecycleService } from '#/workspace/sessionLifecycle/sessionLifecycleService';
+import { SessionLeaseManager } from '#/workspace/sessionLifecycle/sessionLease';
+import { sessionDirOf } from '#/workspace/sessionLifecycle/internal/addressing';
 
 import { WorkspaceInstance } from './workspaceInstance';
 import { IRuntimeResolver, IWorkspaceInstanceManager, type WorkspaceInstanceRef } from './workspaceInstanceManager';
@@ -245,6 +247,8 @@ export class WorkspaceInstanceManager implements IWorkspaceInstanceManager {
           this.models,
           this.modelProviders,
           this.flags,
+          new SessionLeaseManager(input.fs, this.log, (sessionId) =>
+            sessionDirOf(this.bootstrap.homeDir, input.context.persistenceScope, sessionId)),
           input.onDispose,
         ),
       },

--- a/packages/agent-core-v2/test/workspace/sessionLifecycle/sessionLease.test.ts
+++ b/packages/agent-core-v2/test/workspace/sessionLifecycle/sessionLease.test.ts
@@ -1,0 +1,295 @@
+import { mkdtemp, readFile, readdir, rm, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+import { join } from 'pathe';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import '#/index';
+import type { Scope } from '#/_base/di/scope';
+import { ILogService } from '#/_base/log/log';
+import { logSeed, resolveLoggingConfig } from '#/_base/log/logConfig';
+import { bootstrap } from '#/app/bootstrap/bootstrap';
+import { ISessionManager } from '#/app/sessionManager/sessionManager';
+import { ErrorCodes, isError2, type Error2 } from '#/errors';
+import { HostFileSystem } from '#/os/backends/node-local/hostFsService';
+import { ISessionContext } from '#/session/sessionContext/sessionContext';
+import {
+  type SessionLeaseHolder,
+  SessionLeaseManager,
+  type SessionLeaseTiming,
+  SESSION_LEASE_FILE,
+} from '#/workspace/sessionLifecycle/sessionLease';
+
+const noopLog = {
+  _serviceBrand: undefined,
+  level: 'off',
+  setLevel: () => {},
+  flush: async () => {},
+  error: () => {},
+  warn: () => {},
+  info: () => {},
+  debug: () => {},
+  child: () => noopLog,
+} as unknown as ILogService;
+
+const testIdentity = {
+  productName: 'session-lease-test',
+  version: '0.0.0-test',
+  platform: 'test',
+} as const;
+
+const cleanupDirs: string[] = [];
+const cleanupManagers: SessionLeaseManager[] = [];
+const cleanupScopes: Scope[] = [];
+const fs = new HostFileSystem();
+
+afterEach(async () => {
+  for (const manager of cleanupManagers.splice(0)) await manager.releaseAll();
+  for (const scope of cleanupScopes.splice(0)) scope.dispose();
+  for (const dir of cleanupDirs.splice(0)) await rm(dir, { recursive: true, force: true });
+});
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  cleanupDirs.push(dir);
+  return dir;
+}
+
+function makeManager(dir: string, timing?: Partial<SessionLeaseTiming>): SessionLeaseManager {
+  const manager = new SessionLeaseManager(fs, noopLog, () => dir, timing);
+  cleanupManagers.push(manager);
+  return manager;
+}
+
+async function readHolderFromDisk(dir: string): Promise<SessionLeaseHolder> {
+  return JSON.parse(await readFile(join(dir, SESSION_LEASE_FILE), 'utf8')) as SessionLeaseHolder;
+}
+
+async function backdateLease(dir: string, ageMs: number): Promise<void> {
+  const file = join(dir, SESSION_LEASE_FILE);
+  const past = new Date(Date.now() - ageMs);
+  await utimes(file, past, past);
+}
+
+async function writeStaleCorpse(dir: string): Promise<void> {
+  await writeFile(
+    join(dir, SESSION_LEASE_FILE),
+    JSON.stringify({
+      leaseId: 'dead-lease',
+      pid: 2147480000,
+      serverId: 'dead-server',
+      acquiredAt: Date.now() - 300_000,
+      renewedAt: Date.now() - 300_000,
+    }),
+  );
+  await backdateLease(dir, 120_000);
+}
+
+async function snapshotDir(root: string): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  async function walk(dir: string, rel: string): Promise<void> {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const next = rel === '' ? entry.name : `${rel}/${entry.name}`;
+      if (next === SESSION_LEASE_FILE || next.startsWith('logs')) continue;
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(path, next);
+      } else if (entry.isFile()) {
+        out[next] = (await readFile(path)).toString('base64');
+      }
+    }
+  }
+  await walk(root, '');
+  return out;
+}
+
+async function settle(delayMs: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+describe('SessionLeaseManager', () => {
+  it('rejects a second acquirer with session.locked carrying the holder identity', async () => {
+    const dir = await makeTempDir('kimi-lease-');
+    const a = makeManager(dir);
+    const holder = await a.acquire('s1', () => {});
+    expect(holder.pid).toBe(process.pid);
+    const b = makeManager(dir);
+    let error: unknown;
+    try {
+      await b.acquire('s1', () => {});
+    } catch (caught) {
+      error = caught;
+    }
+    expect(isError2(error)).toBe(true);
+    expect((error as Error2).code).toBe(ErrorCodes.SESSION_LOCKED);
+    expect((error as Error2).details?.['sessionId']).toBe('s1');
+    expect((error as Error2).details?.['holder']).toMatchObject({
+      leaseId: holder.leaseId,
+      pid: process.pid,
+      serverId: expect.any(String),
+    });
+  });
+
+  it('treats re-acquire by the same manager as already held', async () => {
+    const dir = await makeTempDir('kimi-lease-');
+    const a = makeManager(dir);
+    const first = await a.acquire('s1', () => {});
+    const second = await a.acquire('s1', () => {});
+    expect(second.leaseId).toBe(first.leaseId);
+  });
+
+  it('allows another manager to acquire immediately after release', async () => {
+    const dir = await makeTempDir('kimi-lease-');
+    const a = makeManager(dir);
+    await a.acquire('s1', () => {});
+    await a.release('s1');
+    expect(a.isHeld('s1')).toBe(false);
+    const b = makeManager(dir);
+    const holder = await b.acquire('s1', () => {});
+    expect((await readHolderFromDisk(dir)).leaseId).toBe(holder.leaseId);
+  });
+
+  it('takes over a lease whose heartbeat expired and gives exactly one winner', async () => {
+    const dir = await makeTempDir('kimi-lease-');
+    await writeStaleCorpse(dir);
+    const a = makeManager(dir);
+    const b = makeManager(dir);
+    const [first, second] = await Promise.allSettled([
+      a.acquire('s1', () => {}),
+      b.acquire('s1', () => {}),
+    ]);
+    const outcomes = [first, second];
+    expect(outcomes.filter((outcome) => outcome.status === 'fulfilled')).toHaveLength(1);
+    const rejected = outcomes.find((outcome) => outcome.status === 'rejected');
+    expect(rejected).toBeDefined();
+    expect(isError2(rejected?.reason)).toBe(true);
+    expect((rejected as PromiseRejectedResult).reason.code).toBe(ErrorCodes.SESSION_LOCKED);
+    const winnerLeaseId =
+      first.status === 'fulfilled' ? first.value.leaseId
+      : second.status === 'fulfilled' ? second.value.leaseId
+      : undefined;
+    expect((await readHolderFromDisk(dir)).leaseId).toBe(winnerLeaseId);
+  });
+
+  it('renews the heartbeat so a live lock stays respected past the staleness window', async () => {
+    const dir = await makeTempDir('kimi-lease-');
+    const a = makeManager(dir, { renewIntervalMs: 25, staleAfterMs: 60_000 });
+    await a.acquire('s1', () => {});
+    const b = makeManager(dir, { staleAfterMs: 80 });
+    await settle(160);
+    await expect(b.acquire('s1', () => {})).rejects.toMatchObject({
+      code: ErrorCodes.SESSION_LOCKED,
+    });
+  });
+
+  it('reports loss when the lease is replaced and never removes the new holder file', async () => {
+    const dir = await makeTempDir('kimi-lease-');
+    const a = makeManager(dir, { renewIntervalMs: 25, staleAfterMs: 60_000 });
+    let lostCalls = 0;
+    let resolveLost!: () => void;
+    const lost = new Promise<void>((resolve) => {
+      resolveLost = resolve;
+    });
+    await a.acquire('s1', () => {
+      lostCalls += 1;
+      resolveLost();
+    });
+    await backdateLease(dir, 120_000);
+    const b = makeManager(dir);
+    const holder = await b.acquire('s1', () => {});
+    await Promise.race([
+      lost,
+      settle(10_000).then(() => {
+        throw new Error('lease loss was not reported in time');
+      }),
+    ]);
+    expect(lostCalls).toBe(1);
+    expect(a.isHeld('s1')).toBe(false);
+    await a.release('s1');
+    expect((await readHolderFromDisk(dir)).leaseId).toBe(holder.leaseId);
+  });
+
+  it('rejects when the lock file is unreadable but still fresh', async () => {
+    const dir = await makeTempDir('kimi-lease-');
+    await writeFile(join(dir, SESSION_LEASE_FILE), 'not-json');
+    const b = makeManager(dir);
+    await expect(b.acquire('s1', () => {})).rejects.toMatchObject({
+      code: ErrorCodes.SESSION_LOCKED,
+      details: { sessionId: 's1' },
+    });
+  });
+});
+
+describe('session lease across two engines sharing one home', () => {
+  async function makeEngine(homeDir: string) {
+    const { app } = bootstrap(
+      { homeDir, clientIdentity: testIdentity },
+      logSeed(resolveLoggingConfig({ homeDir, env: {} })),
+    );
+    cleanupScopes.push(app);
+    return app;
+  }
+
+  it('rejects resume from a second instance and writes nothing to the session directory', async () => {
+    const homeDir = await makeTempDir('kimi-lease-home-');
+    const workDir = await makeTempDir('kimi-lease-work-');
+    const appA = await makeEngine(homeDir);
+    const managerA = appA.accessor.get(ISessionManager);
+    const handle = await managerA.create({ workDir });
+    const ctx = handle.accessor.get(ISessionContext);
+    const before = await snapshotDir(ctx.sessionDir);
+    const appB = await makeEngine(homeDir);
+    const managerB = appB.accessor.get(ISessionManager);
+    await expect(managerB.resume(ctx.sessionId)).rejects.toMatchObject({
+      code: ErrorCodes.SESSION_LOCKED,
+      details: { holder: { pid: process.pid } },
+    });
+    expect(await snapshotDir(ctx.sessionDir)).toEqual(before);
+    await managerA.close(ctx.sessionId);
+  }, 120_000);
+
+  it('lets another instance resume immediately after a clean close', async () => {
+    const homeDir = await makeTempDir('kimi-lease-home-');
+    const workDir = await makeTempDir('kimi-lease-work-');
+    const appA = await makeEngine(homeDir);
+    const managerA = appA.accessor.get(ISessionManager);
+    const handle = await managerA.create({ workDir });
+    const ctx = handle.accessor.get(ISessionContext);
+    await managerA.close(ctx.sessionId);
+    const appB = await makeEngine(homeDir);
+    const managerB = appB.accessor.get(ISessionManager);
+    const resumed = await managerB.resume(ctx.sessionId);
+    expect(resumed).toBeDefined();
+    await managerB.close(ctx.sessionId);
+  }, 120_000);
+
+  it('takes over an expired lease and evicts the stale in-memory instance', async () => {
+    const homeDir = await makeTempDir('kimi-lease-home-');
+    const workDir = await makeTempDir('kimi-lease-work-');
+    const appA = await makeEngine(homeDir);
+    const managerA = appA.accessor.get(ISessionManager);
+    const handle = await managerA.create({ workDir });
+    const ctx = handle.accessor.get(ISessionContext);
+    await backdateLease(ctx.sessionDir, 120_000);
+    const appB = await makeEngine(homeDir);
+    const managerB = appB.accessor.get(ISessionManager);
+    const resumed = await managerB.resume(ctx.sessionId);
+    expect(resumed).toBeDefined();
+    expect(managerA.get(ctx.sessionId)).toBeDefined();
+    await vi.waitFor(
+      () => {
+        expect(managerA.get(ctx.sessionId)).toBeUndefined();
+      },
+      { timeout: 30_000, interval: 200 },
+    );
+    expect(managerB.get(ctx.sessionId)).toBeDefined();
+    expect((await readHolderFromDisk(ctx.sessionDir)).pid).toBe(process.pid);
+    await managerB.close(ctx.sessionId);
+  }, 180_000);
+});

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -245,6 +245,7 @@ export type KimiErrorCode =
   | 'session.export_output_conflict'
   | 'session.export_too_large'
   | 'session.closed'
+  | 'session.locked'
   | 'session.permission_mode_invalid'
   | 'session.thinking_empty'
   | 'session.model_empty'
@@ -1277,6 +1278,7 @@ export const kimiErrorCodeSchema = z.enum([
   'session.export_output_conflict',
   'session.export_too_large',
   'session.closed',
+  'session.locked',
   'session.permission_mode_invalid',
   'session.thinking_empty',
   'session.model_empty',


### PR DESCRIPTION
## Related Issue

Internal production incident (2026-08-26, kimi-code 0.38.0): two instances attached to the same session concurrently — one of them resumed on a stale in-memory snapshot, repeated `turn.ended` for the same turnId, and double-fired cron jobs. No issue number; root cause and discussion are summarized below.

## Problem

Nothing enforced "one writer per session at a time". Two processes (or a long-lived in-memory instance beside a freshly resumed one) could both materialize the same session: `SessionLifecycleService` only dedupes in-process, and wire-journal appends have no cross-process guard. The result was context loss (stale in-memory snapshot treated as current), duplicated turn ids in the wire journal, and cron tasks firing twice per schedule.

## What changed

Add a session-level exclusive lease so a session can only be held by one instance at a time:

- **Lease manager** (`packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLease.ts`): acquires `lease.json` inside the session directory via atomic `createExclusive` (carrying leaseId/pid/serverId/timestamps), renews a heartbeat (mtime) every 5s, considers a holder stale after 30s without heartbeat and takes over via delete + atomic re-create (exactly one winner), re-reads the leaseId on every renewal (fencing) and reports loss, and only deletes the file on release when the leaseId still matches.
- **Lifecycle integration** (`sessionLifecycleService.ts`): `materializeSession` — the single entry for create/resume/fork — acquires the lease before any scope creation or disk write, so a conflicting second instance fails fast with the new `session.locked` error (which carries the holder's pid, serverId, and lock timestamps) and writes nothing to the session directory. close/archive/delete and all create/resume/fork failure paths release the lease; when the lease is lost the stale instance evicts the session from memory with close semantics (draining agents and stopping per-scope cron actors) instead of appending to the wire journal. Session forks no longer copy `lease.json`.
- **New error code** `session.locked` in `@moonshot-ai/protocol` and agent-core-v2's `SessionErrors`, propagated through the existing error channel.
- Force takeover is deliberately not included (follow-up iteration); crash/kill -9 is handled by heartbeat-expiry takeover, with no pid-liveness dependency.

Verification: 10 new tests (`test/workspace/sessionLifecycle/sessionLease.test.ts`) against the real disk — conflict rejection with holder identity, same-manager idempotency, immediate re-acquire after release, exactly-one-winner stale takeover under a race, heartbeat renewal keeping a live lock respected, fencing reporting loss without removing the new holder's file, fresh-but-unreadable lock rejection — plus a two-engines-sharing-one-home integration suite: second-instance resume is rejected with zero writes to the session directory, clean close allows immediate resume, and an expired lease is taken over while the stale in-memory instance is evicted. `pnpm typecheck` (protocol/agent-core-v2/klient/kap-server), `pnpm lint`, protocol 543 tests, and the agent-core-v2 suite (5910 tests) all pass; the handful of local failures in the kap-server full run reproduce on an unmodified checkout under the same machine load.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
