### PR TITLE
fix(cli): show the full remote control link in the startup output

### DIFF
--- a/apps/kimi-code/src/cli/sub/web/remote-control.ts
+++ b/apps/kimi-code/src/cli/sub/web/remote-control.ts
@@ -130,9 +130,7 @@ export function formatRemoteControlOutput(options: RemoteControlOutputOptions): 
   const muted = (text: string): string => chalk.hex(darkColors.textMuted)(text);
   const status = (text: string): string => chalk.hex(darkColors.success)(text);
   const link = (url: string): string =>
-    supportsHyperlinks()
-      ? toTerminalHyperlink(accent(shortRemoteControlUrl(url)), url)
-      : accent(url);
+    supportsHyperlinks() ? toTerminalHyperlink(accent(url), url) : accent(url);
   const docs = toTerminalHyperlink('docs', 'https://kimi.com/code/docs/remote-control');
   const feedback = toTerminalHyperlink('feedback', 'https://kimi.com/code/feedback');
   return [
@@ -171,17 +169,6 @@ export function formatRemoteControlStatus(status: RemoteControlStatus): string {
     case 'device_disconnected':
       return `  ${value('→')} ${label('Remote device disconnected')}\n`;
   }
-}
-
-function shortRemoteControlUrl(url: string): string {
-  const parsed = new URL(url);
-  const parts = parsed.pathname.split('/');
-  const deviceIndex = parts.indexOf('devices');
-  const deviceId = deviceIndex >= 0 ? parts[deviceIndex + 1] : undefined;
-  if (deviceId !== undefined && deviceId.length > 12) {
-    parts[deviceIndex + 1] = `${deviceId.slice(0, 6)}…${deviceId.slice(-4)}`;
-  }
-  return `${parsed.host}${parts.join('/')}`;
 }
 
 export function buildRemoteControlUrl(

--- a/apps/kimi-code/test/cli/web/remote-control.test.ts
+++ b/apps/kimi-code/test/cli/web/remote-control.test.ts
@@ -83,7 +83,7 @@ describe('Remote Control output', () => {
     pngPath: '/tmp/example-qr.png',
   };
 
-  it('keeps the full URL clickable while showing a short link and the setup contract', () => {
+  it('shows the full URL as the clickable link text alongside the setup contract', () => {
     vi.stubEnv('FORCE_HYPERLINK', '1');
     const output = formatRemoteControlOutput(outputOptions);
     const url = outputOptions.url;
@@ -91,8 +91,12 @@ describe('Remote Control output', () => {
     expect(output).toContain('1.');
     expect(output).toContain('2.');
     expect(output).toContain('3.');
-    expect(output).toContain('example.test/devices/exampl…vice/');
     expect(output).toContain(`\u001B]8;;${url}`);
+    const plain = output
+      .replaceAll(/\u001B\]8;;.*?\u0007/g, '')
+      .replaceAll(/\u001B\[[0-9;]*m/g, '');
+    expect(plain).toContain(`open ${url}`);
+    expect(plain).not.toContain('exampl…');
     expect(output).toContain('Connected to example.test');
     expect(output).toContain('This device:');
     expect(output).not.toContain('Manage devices');


### PR DESCRIPTION
## Related Issue

No linked issue — this is a small display fix to the experimental remote control startup output.

## Problem

When remote control starts, the printed "open <link>" line showed a shortened URL in hyperlink-capable terminals: the device id was truncated with `…`, and the scheme and query parameters were dropped. The full URL only existed as the OSC-8 hyperlink target, so users who wanted to read or copy the link directly could not see it in full. Terminals without hyperlink support already printed the full URL, so the two paths were also inconsistent.

## What changed

- `formatRemoteControlOutput` now renders the full URL as the visible link text in both the hyperlink and plain-text paths. The OSC-8 wrapper is kept, so the link stays clickable in supporting terminals.
- Removed the now-unused `shortRemoteControlUrl` helper.
- Updated the remote control output test to assert the full URL is the visible text and that no truncated form appears.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (This PR needs no changeset.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No doc update needed.)
