### PR TITLE
ci: add VS Code extension publish workflow

### DIFF
--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -1,0 +1,155 @@
+name: Publish VS Code extension
+
+# 把 0.7.3 手动发版流程固化成 CI 流水线：
+#
+#   pnpm install → package:platform（全 6 平台）→ package:verify
+#   → extension host 冒烟（xvfb）→ publish:vsix → publish:ovsx
+#
+# 触发语义（参照 kimi-code-app 仓 desktop release.yml 的判定方式）：
+# 只在"本次 push 改动了 apps/vscode/package.json 的 version"时发布，
+# 即 changesets 版本 PR（"ci: release packages"）合入后自动触发；
+# 普通 PR 合入不会改变版本号，不会发布。版本号比较基于 push 的 SHA
+# （git show），不依赖工作区状态。workflow_dispatch 为手动兜底，
+# 跳过版本号变化检查，直接走后续幂等闸门。
+#
+# 幂等（两道保险，可安全重跑，失败即停不自动重试）：
+# 1. 发布前查询 VS Marketplace（vsce show）与 Open VSX（REST）线上版本，
+#    已在线的市场跳过对应发布步骤；
+# 2. 发布脚本自身带 --skip-duplicate（vsce）/ already-exists 跳过（ovsx）。
+#
+# 前置条件：仓库管理员需先配置 secrets VSCE_PAT / OVSX_PAT，
+# 未配置时 publish 步骤会失败，属预期。
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish VSIX to marketplaces
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'MoonshotAI'
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # 需要 GITHUB_SHA~1 比较版本号
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Resolve publish gate
+        id: gate
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          pkg="apps/vscode/package.json"
+          version="$(node -p "require('./${pkg}').version")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "extension version: ${version}"
+
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "manual dispatch — skipping version-change check"
+          else
+            prev=""
+            if git show "${GITHUB_SHA}~1:${pkg}" > /tmp/prev-vscode-pkg.json 2> /dev/null; then
+              prev="$(node -p "require('/tmp/prev-vscode-pkg.json').version")"
+            fi
+            if [ "${prev}" = "${version}" ]; then
+              echo "apps/vscode version unchanged in this push (${version}) — nothing to publish"
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "version changed ${prev:-<none>} -> ${version} — release push"
+          fi
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+
+          # 线上闸门：已在线的市场跳过对应 publish 步骤（fail-closed：
+          # 查询失败视为未发布，交给 publish 步骤决定成败）。
+          if curl -fsS -o /dev/null "https://open-vsx.org/api/moonshot-ai/kimi-code/${version}"; then
+            echo "${version} is already on Open VSX — publish:ovsx will be skipped"
+            echo "ovsx_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ovsx_published=false" >> "$GITHUB_OUTPUT"
+          fi
+          if pnpm --filter kimi-code exec vsce show moonshot-ai.kimi-code --json \
+              | node -e "const v=process.argv[1];let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{const j=JSON.parse(d);process.exit((j.versions||[]).some(x=>x.version===v)?0:1)})" "${version}"; then
+            echo "${version} is already on VS Marketplace — publish:vsix will be skipped"
+            echo "vsix_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "vsix_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check publish secrets
+        if: steps.gate.outputs.should_publish == 'true'
+        shell: bash
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -z "${VSCE_PAT:-}" ] && missing+=(VSCE_PAT)
+          [ -z "${OVSX_PAT:-}" ] && missing+=(OVSX_PAT)
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::missing repository secrets: ${missing[*]} — a repo admin must configure them before publishing"
+            exit 1
+          fi
+
+      - name: Package all platform VSIX
+        if: steps.gate.outputs.should_publish == 'true'
+        run: pnpm --filter kimi-code run package:platform
+
+      - name: Verify VSIX packages
+        if: steps.gate.outputs.should_publish == 'true'
+        run: pnpm --filter kimi-code run package:verify
+
+      - name: Upload VSIX artifacts
+        if: steps.gate.outputs.should_publish == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: kimi-code-vsix-${{ steps.gate.outputs.version }}
+          path: apps/vscode/artifacts/vsix/*.vsix
+          retention-days: 14
+
+      - name: Install extension-host smoke dependencies
+        if: steps.gate.outputs.should_publish == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb libgtk-3-0 libgbm1 libasound2t64
+
+      - name: Extension host smoke test
+        if: steps.gate.outputs.should_publish == 'true'
+        # 1.100.0 即 package.json engines.vscode 下限，与 0.7.3 手动发版的冒烟口径一致
+        run: xvfb-run -a pnpm --filter kimi-code run test:extension-host -- --version 1.100.0
+
+      - name: Publish to VS Marketplace
+        if: steps.gate.outputs.should_publish == 'true' && steps.gate.outputs.vsix_published != 'true'
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: pnpm --filter kimi-code run publish:vsix
+
+      - name: Publish to Open VSX
+        if: steps.gate.outputs.should_publish == 'true' && steps.gate.outputs.ovsx_published != 'true'
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: pnpm --filter kimi-code run publish:ovsx

--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -8,13 +8,16 @@ name: Publish VS Code extension
 # 触发语义（参照 kimi-code-app 仓 desktop release.yml 的判定方式）：
 # 只在"本次 push 改动了 apps/vscode/package.json 的 version"时发布，
 # 即 changesets 版本 PR（"ci: release packages"）合入后自动触发；
-# 普通 PR 合入不会改变版本号，不会发布。版本号比较基于 push 的 SHA
-# （git show），不依赖工作区状态。workflow_dispatch 为手动兜底，
+# 普通 PR 合入不会改变版本号，不会发布。版本号比较以 push 事件的
+# before SHA 为基准（git show），可覆盖一次 push 含多个 commit 的情况，
+# 不依赖工作区状态。workflow_dispatch 为手动兜底，
 # 跳过版本号变化检查，直接走后续幂等闸门。
 #
 # 幂等（两道保险，可安全重跑，失败即停不自动重试）：
-# 1. 发布前查询 VS Marketplace（vsce show）与 Open VSX（REST）线上版本，
-#    已在线的市场跳过对应发布步骤；
+# 1. 发布前逐平台核验 VS Marketplace（vsce show）与 Open VSX（REST）
+#    线上版本：6 个 targetPlatform（darwin/linux/win32 × x64/arm64）
+#    全部在线才跳过对应发布步骤；任一平台缺失（如上次部分发布失败）
+#    即放行给发布步骤补齐，重跑可补齐；
 # 2. 发布脚本自身带 --skip-duplicate（vsce）/ already-exists 跳过（ovsx）。
 #
 # 前置条件：仓库管理员需先配置 secrets VSCE_PAT / OVSX_PAT，
@@ -41,7 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # 需要 GITHUB_SHA~1 比较版本号
+          fetch-depth: 0 # 需要按 push 事件的 before SHA 取旧版本号比较
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -60,6 +63,7 @@ jobs:
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
           pkg="apps/vscode/package.json"
@@ -70,9 +74,16 @@ jobs:
           if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
             echo "manual dispatch — skipping version-change check"
           else
+            # 以 push 事件的 before SHA 为比较基准（覆盖多 commit 的单次 push）。
+            # before 为空或全 0（如新分支首推）时无法比较，prev 视为空 →
+            # 判定版本变化放行 —— 宁可多查一次线上闸门，不可漏发。
             prev=""
-            if git show "${GITHUB_SHA}~1:${pkg}" > /tmp/prev-vscode-pkg.json 2> /dev/null; then
-              prev="$(node -p "require('/tmp/prev-vscode-pkg.json').version")"
+            if [ -n "${BEFORE_SHA}" ] && [ -n "${BEFORE_SHA//0/}" ]; then
+              if git show "${BEFORE_SHA}:${pkg}" > /tmp/prev-vscode-pkg.json 2> /dev/null; then
+                prev="$(node -p "require('/tmp/prev-vscode-pkg.json').version")"
+              fi
+            else
+              echo "push event has no usable before SHA ('${BEFORE_SHA}') — treating as a version change"
             fi
             if [ "${prev}" = "${version}" ]; then
               echo "apps/vscode version unchanged in this push (${version}) — nothing to publish"
@@ -83,17 +94,28 @@ jobs:
           fi
           echo "should_publish=true" >> "$GITHUB_OUTPUT"
 
-          # 线上闸门：已在线的市场跳过对应 publish 步骤（fail-closed：
-          # 查询失败视为未发布，交给 publish 步骤决定成败）。
-          if curl -fsS -o /dev/null "https://open-vsx.org/api/moonshot-ai/kimi-code/${version}"; then
-            echo "${version} is already on Open VSX — publish:ovsx will be skipped"
+          # 线上闸门：逐平台核验，6 个 targetPlatform 全部在线才跳过对应市场；
+          # 任一平台缺失即放行给 publish 步骤幂等补齐。
+          # fail-closed：查询失败视为未发布 → 放行，交给 publish 步骤决定成败。
+          platforms="darwin-x64 darwin-arm64 linux-x64 linux-arm64 win32-x64 win32-arm64"
+
+          ovsx_missing=""
+          for target in ${platforms}; do
+            if ! curl -fsS -o /dev/null "https://open-vsx.org/api/moonshot-ai/kimi-code/${target}/${version}"; then
+              ovsx_missing="${ovsx_missing} ${target}"
+            fi
+          done
+          if [ -z "${ovsx_missing}" ]; then
+            echo "${version} is fully on Open VSX (all 6 platforms) — publish:ovsx will be skipped"
             echo "ovsx_published=true" >> "$GITHUB_OUTPUT"
           else
+            echo "Open VSX missing platform(s):${ovsx_missing} — publish:ovsx will run to backfill"
             echo "ovsx_published=false" >> "$GITHUB_OUTPUT"
           fi
+
           if pnpm --filter kimi-code exec vsce show moonshot-ai.kimi-code --json \
-              | node -e "const v=process.argv[1];let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{const j=JSON.parse(d);process.exit((j.versions||[]).some(x=>x.version===v)?0:1)})" "${version}"; then
-            echo "${version} is already on VS Marketplace — publish:vsix will be skipped"
+              | node -e "const v=process.argv[1];const want=process.argv[2].split(' ');let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{const j=JSON.parse(d);const got=new Set((j.versions||[]).filter(x=>x.version===v).map(x=>x.targetPlatform||''));const missing=want.filter(p=>!got.has(p));if(missing.length){console.error('VS Marketplace missing platform(s): '+missing.join(' '));process.exit(1)}process.exit(0)})" "${version}" "${platforms}"; then
+            echo "${version} is fully on VS Marketplace (all 6 platforms) — publish:vsix will be skipped"
             echo "vsix_published=true" >> "$GITHUB_OUTPUT"
           else
             echo "vsix_published=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 背景

0.7.3 手动发版（VS Marketplace + Open VSX，全 6 平台）已全流程跑通。本 PR 把这套流程固化成自动 CI 流水线，只新增 `.github/workflows/vscode-publish.yml`，不动任何现有文件。

## 设计说明

**触发**
- `push` 到 `main`：仅当本次 push 改动了 `apps/vscode/package.json` 的 `version`（即 changesets 版本 PR `"ci: release packages"` 合入）才进入发布。版本号比较基于 push 的 SHA（`git show $GITHUB_SHA~1:...`），不读工作区——与 kimi-code-app 仓 desktop `release.yml` 的判定方式一致。普通 PR 合入不会改变版本号，不会发布。
- `workflow_dispatch`：手动兜底，跳过版本号变化检查，直接进入后续幂等闸门。

**闸门（发布前查线上，双保险之一）**
- VS Marketplace：`vsce show moonshot-ai.kimi-code --json`（仓内 pinned 的 @vscode/vsce），版本已在线则跳过 `publish:vsix`；
- Open VSX：`GET https://open-vsx.org/api/moonshot-ai/kimi-code/<version>`，200 则跳过 `publish:ovsx`；
- 查询失败按"未发布"处理（fail-closed），交给 publish 步骤决定成败。

**步骤链**（与 0.7.3 手动发版完全一致）
`pnpm install --frozen-lockfile` → `package:platform`（全 6 平台，自带 tsdown 打包，无需前置 build）→ `package:verify` → 上传 vsix 为 workflow artifact（retention 14 天，便于回溯审计）→ extension host 冒烟（`xvfb-run`，VS Code 1.100.0 = `engines.vscode` 下限，与手动冒烟口径一致）→ `publish:vsix`（`secrets.VSCE_PAT`）→ `publish:ovsx`（`secrets.OVSX_PAT`）。

**幂等与并发**
- 双保险之二：发布脚本自身带 `--skip-duplicate`（vsce）/ already-exists 跳过（ovsx），单包失败即中止，整体可安全重跑；
- `concurrency: ${{ github.workflow }}-${{ github.ref }}` 防并发重复发布；
- 失败即停，不自动重试 publish。

**权限**：`contents: read`；`if: github.repository_owner == 'MoonshotAI'` 避免 fork 上误跑。

## ⚠️ 管理员待办：secrets 配置

需仓库管理员预先配置 secrets：**`VSCE_PAT`**（VS Marketplace PAT）与 **`OVSX_PAT`**（Open VSX access token）。workflow 内有前置检查步骤，**未配置 secrets 时会以明确报错失败，属预期**。

## 首次启用建议

合并后先用 `workflow_dispatch` 对一个**已发布版本**（如 0.7.3）空跑一次：应观察到闸门识别双市场已在线、两个 publish 步骤被跳过，打包/校验/冒烟全绿——以此验证跳过逻辑，再等待首个真实版本 PR 触发。

## 验证方式（本 PR 已做）

- `actionlint` v1.7.7 通过，零告警；
- 全部 `run` 脚本块 `bash -n` 语法检查通过；
- 闸门逻辑在本地 git 仓库模拟四种场景实测通过：① push 改版本 → `should_publish=true`；② push 未改版本 → `should_publish=false`；③ `workflow_dispatch` → 跳过版本检查；④ 对线上 0.7.3 真实查询 → 双市场均正确识别"已发布"。
- 实际发布行为需合并后观察首次触发（语法与逻辑已静态检查 + 本地模拟）。

## 注意点

- runner 为非 root 用户（homedir `/home/runner`），`vsix-verify.mjs` 的 homedir 禁词扫描不会像 root 下那样误报；#3305（homedir 边界匹配修复）合入后更稳，但本 workflow 不依赖它。
- 冒烟固定 VS Code 1.100.0（@vscode/test-electron 按精确版本缓存）；后续可随 `engines.vscode` 下限上调。
- 冒烟步骤的 GUI 依赖（xvfb/libgtk-3-0/libgbm1/libasound2t64）在 ubuntu-latest 上显式 apt 安装，与 0.7.3 手动冒烟环境清单一致。

源自 0.7.3 手动发版实战（tkt_SqwQhnD-Ue2D / tkt_1pc7xOiv65pA）。
