### PR TITLE
feat(web): add declarative community skins

### DIFF
--- a/.changeset/community-web-skins.md
+++ b/.changeset/community-web-skins.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add declarative community Web skins. Install and enable a Web-skin plugin, then refresh Kimi Web to apply its design tokens.

--- a/docs/en/customization/plugins.md
+++ b/docs/en/customization/plugins.md
@@ -285,8 +285,51 @@ Supported fields:
 | `mcpServers` | MCP server declarations; enabled by default, can be disabled from `/plugins` |
 | `hooks` | Hook rules run on lifecycle events while the plugin is enabled; see [Hooks in Plugins](#hooks-in-plugins) |
 | `commands` | One or more `./` paths pointing to a directory or `.md` file; registers the Markdown files within as slash commands. See [Plugin Slash Commands](#plugin-slash-commands) |
+| `webSkin.tokens` | A `./` path to a declarative Web design-token JSON file. Web-skin plugins must not declare runtime capabilities |
 
 Unsupported runtime fields such as `tools`, `apps`, `inject`, and `configFile` appear as diagnostics and are ignored.
+
+### Web skins
+
+A Web skin is a code-free plugin that overrides Kimi Web design tokens. Enabling the plugin activates its tokens after the next page refresh; disabling or removing it restores the built-in values. When several Web skins are enabled, Kimi applies them in plugin-id order, so keep only the skin layers you intend to combine enabled.
+
+Declare the token file in `kimi.plugin.json`:
+
+```json
+{
+  "name": "kimi-code-skin-moonlight",
+  "version": "1.0.0",
+  "webSkin": {
+    "tokens": "./web/skin.json"
+  },
+  "interface": {
+    "displayName": "Moonlight",
+    "shortDescription": "A violet moonlight palette for Kimi Web"
+  }
+}
+```
+
+The referenced JSON document has one versioned light and dark token map:
+
+```json
+{
+  "manifestVersion": 1,
+  "light": {
+    "--color-bg": "#fffafd",
+    "--color-accent": "#7c3aed",
+    "--radius-lg": "16px"
+  },
+  "dark": {
+    "--color-bg": "#15111d",
+    "--color-accent": "#c084fc",
+    "--radius-lg": "16px"
+  }
+}
+```
+
+Token names are limited to the Kimi design-system prefixes `--color-*`, `--font-*`, `--radius-*`, `--space-*`, `--shadow-*`, `--duration-*`, `--ease-*`, `--weight-*`, `--leading-*`, `--text-*`, and `--p-*`, plus a fixed allowlist of legacy Web compatibility tokens such as `--bg`, `--panel`, and `--blue`. Values cannot contain rules, declarations, control characters, CSS escapes, comments, `!important`, or image/network-loading functions. Function calls are limited to safe color, math, easing, and `var()` forms. The token file is limited to 64 KB, 256 tokens, and 256 UTF-8 bytes per value.
+
+Web-skin plugins cannot also declare Skills, agents, commands, hooks, MCP servers, session-start behavior, skill instructions, or system-prompt content. This keeps cosmetic packages code-free and prevents a skin from silently gaining agent-runtime authority. Kimi generates the stylesheet on the server and never serves plugin JavaScript, HTML, SVG, or arbitrary CSS.
 
 ### System-prompt instructions
 

--- a/docs/zh/customization/plugins.md
+++ b/docs/zh/customization/plugins.md
@@ -285,8 +285,51 @@ Plugin 是一个带 manifest 的目录或 zip 文件。Manifest 可以放在以�
 | `mcpServers` | MCP server 声明，默认启用，可从 `/plugins` 中禁用 |
 | `hooks` | 在 plugin 启用期间于生命周期事件上运行的 hook 规则；见[插件中的 Hooks](#插件中的-hooks) |
 | `commands` | 一个或多个 `./` 路径，指向目录或 `.md` 文件，把其中的 Markdown 文件注册为斜杠命令；见[插件斜杠命令](#插件斜杠命令) |
+| `webSkin.tokens` | 指向声明式 Web 设计 token JSON 文件的 `./` 路径；Web 皮肤 plugin 不能同时声明运行时能力 |
 
 `tools`、`apps`、`inject`、`configFile` 等不支持的运行时字段会显示为 diagnostics 并被忽略。
+
+### Web 皮肤
+
+Web 皮肤是一类仅覆盖 Kimi Web 设计 token、完全不含代码的 plugin。启用 plugin 后，其 token 会在下次刷新页面时生效；禁用或移除后恢复内置值。若同时启用多个 Web 皮肤，Kimi 会按 plugin id 顺序层叠应用，因此只保留确实需要组合的皮肤层处于启用状态。
+
+在 `kimi.plugin.json` 中声明 token 文件：
+
+```json
+{
+  "name": "kimi-code-skin-moonlight",
+  "version": "1.0.0",
+  "webSkin": {
+    "tokens": "./web/skin.json"
+  },
+  "interface": {
+    "displayName": "Moonlight",
+    "shortDescription": "为 Kimi Web 提供紫色月光配色"
+  }
+}
+```
+
+被引用的 JSON 文档包含一个版本号和明暗两套 token：
+
+```json
+{
+  "manifestVersion": 1,
+  "light": {
+    "--color-bg": "#fffafd",
+    "--color-accent": "#7c3aed",
+    "--radius-lg": "16px"
+  },
+  "dark": {
+    "--color-bg": "#15111d",
+    "--color-accent": "#c084fc",
+    "--radius-lg": "16px"
+  }
+}
+```
+
+Token 名称仅允许使用 Kimi 设计系统前缀 `--color-*`、`--font-*`、`--radius-*`、`--space-*`、`--shadow-*`、`--duration-*`、`--ease-*`、`--weight-*`、`--leading-*`、`--text-*` 和 `--p-*`，以及 `--bg`、`--panel`、`--blue` 等固定的旧版 Web 兼容 token 白名单。值中不能包含规则、声明、控制字符、CSS 转义、注释、`!important` 或会加载图片和网络资源的函数；函数调用仅允许安全的颜色、数学、缓动和 `var()` 形式。Token 文件上限为 64 KB、256 个 token，单个值最多 256 个 UTF-8 字节。
+
+Web 皮肤 plugin 不能同时声明 Skill、Agent、命令、Hook、MCP server、session-start 行为、Skill 附加指令或系统提示词内容。这样可以让外观包始终保持无代码，避免皮肤在用户不知情时获得 Agent 运行时权限。Kimi 会在 server 侧生成样式表，绝不会提供 plugin JavaScript、HTML、SVG 或任意 CSS。
 
 ### 系统提示词指令
 

--- a/packages/agent-core-v2/src/app/plugin/manifest.ts
+++ b/packages/agent-core-v2/src/app/plugin/manifest.ts
@@ -11,12 +11,78 @@ import {
   type PluginInterface,
   type PluginManifest,
   type PluginManifestKind,
+  type PluginWebSkin,
 } from './types';
 
 const KIMI_PLUGIN_ROOT_PATH = 'kimi.plugin.json';
 const KIMI_PLUGIN_DIR_PATH = '.kimi-plugin/plugin.json';
 
 export const PLUGIN_SYSTEM_PROMPT_MAX_BYTES = 32 * 1024;
+export const PLUGIN_WEB_SKIN_MAX_BYTES = 64 * 1024;
+const WEB_SKIN_TOKEN_NAME = /^--(?:color|font|radius|space|shadow|duration|ease|weight|leading|text|p)-[a-z0-9][a-z0-9-]*$/;
+const WEB_SKIN_COMPAT_TOKEN_NAMES = new Set([
+  '--dim',
+  '--muted',
+  '--faint',
+  '--line',
+  '--line2',
+  '--canvas',
+  '--sh',
+  '--shc',
+  '--panel',
+  '--panel2',
+  '--bg',
+  '--blue',
+  '--blue2',
+  '--soft',
+  '--bd',
+  '--logo',
+  '--bluebg',
+  '--blueln',
+  '--ok',
+  '--warn',
+  '--star',
+  '--err',
+  '--hover',
+]);
+const WEB_SKIN_SAFE_FUNCTION_NAMES = new Set([
+  'calc',
+  'clamp',
+  'color',
+  'color-mix',
+  'cubic-bezier',
+  'hsl',
+  'hsla',
+  'linear',
+  'max',
+  'min',
+  'oklab',
+  'oklch',
+  'rgb',
+  'rgba',
+  'steps',
+  'var',
+]);
+const WEB_SKIN_MAX_TOKEN_COUNT = 256;
+const WEB_SKIN_MAX_TOKEN_VALUE_BYTES = 256;
+
+const RUNTIME_PLUGIN_FIELDS = [
+  'skills',
+  'agents',
+  'sessionStart',
+  'mcpServers',
+  'hooks',
+  'commands',
+  'skillInstructions',
+  'systemPrompt',
+  'systemPromptPath',
+  'tools',
+  'apps',
+  'inject',
+  'configFile',
+  'config_file',
+  'bootstrap',
+] as const;
 
 const UNSUPPORTED_RUNTIME_FIELDS = [
   'tools',
@@ -119,6 +185,7 @@ export async function parseManifest(pluginRoot: string): Promise<ParsedManifestR
     typeof raw['skillInstructions'] === 'string' ? raw['skillInstructions'] : undefined;
 
   const systemPrompt = await readSystemPrompt(pluginRoot, raw, diagnostics);
+  const webSkin = await readWebSkin(pluginRoot, raw['webSkin'], diagnostics);
 
   recordUnsupportedRuntimeFields(raw, diagnostics);
 
@@ -138,11 +205,46 @@ export async function parseManifest(pluginRoot: string): Promise<ParsedManifestR
     hooks: readHooks(raw['hooks'], diagnostics),
     commands: await readCommands(pluginRoot, raw['commands'], diagnostics),
     interface: readInterface(raw['interface']),
+    webSkin,
     skillInstructions,
     systemPrompt,
   };
 
+  if (
+    manifest.webSkin !== undefined &&
+    (hasRuntimeCapabilities(manifest) || hasDeclaredRuntimeCapabilities(raw))
+  ) {
+    diagnostics.push({
+      severity: 'error',
+      message: '"webSkin" cannot be combined with runtime plugin capabilities',
+    });
+    return {
+      manifest: { ...manifest, webSkin: undefined },
+      manifestKind,
+      manifestPath,
+      shadowedManifestPath,
+      diagnostics,
+    };
+  }
+
   return { manifest, manifestKind, manifestPath, shadowedManifestPath, diagnostics };
+}
+
+function hasDeclaredRuntimeCapabilities(raw: Record<string, unknown>): boolean {
+  return RUNTIME_PLUGIN_FIELDS.some((field) => raw[field] !== undefined);
+}
+
+function hasRuntimeCapabilities(manifest: PluginManifest): boolean {
+  return (
+    (manifest.skills?.length ?? 0) > 0 ||
+    (manifest.agents?.length ?? 0) > 0 ||
+    manifest.sessionStart !== undefined ||
+    Object.keys(manifest.mcpServers ?? {}).length > 0 ||
+    (manifest.hooks?.length ?? 0) > 0 ||
+    (manifest.commands?.length ?? 0) > 0 ||
+    manifest.skillInstructions !== undefined ||
+    manifest.systemPrompt !== undefined
+  );
 }
 
 function recordUnsupportedRuntimeFields(
@@ -240,6 +342,114 @@ async function resolvePluginPathField(input: {
     return undefined;
   }
   return real;
+}
+
+async function readWebSkin(
+  pluginRoot: string,
+  raw: unknown,
+  diagnostics: PluginDiagnostic[],
+): Promise<PluginManifest['webSkin']> {
+  if (raw === undefined) return undefined;
+  if (!isObject(raw)) {
+    diagnostics.push({ severity: 'warn', message: '"webSkin" must be an object' });
+    return undefined;
+  }
+  if (Object.keys(raw).some((key) => key !== 'tokens')) {
+    diagnostics.push({ severity: 'warn', message: '"webSkin" contains an unknown field' });
+    return undefined;
+  }
+  const tokens = raw['tokens'];
+  if (typeof tokens !== 'string' || tokens.trim().length === 0) {
+    diagnostics.push({ severity: 'warn', message: '"webSkin.tokens" must be a non-empty string' });
+    return undefined;
+  }
+  const tokensPath = await resolvePluginPathField({
+    pluginRoot,
+    field: 'webSkin.tokens',
+    value: tokens,
+    diagnostics,
+  });
+  if (tokensPath === undefined) return undefined;
+  if (path.extname(tokensPath).toLowerCase() !== '.json') {
+    diagnostics.push({ severity: 'warn', message: `"webSkin.tokens" must reference a .json file (${tokens})` });
+    return undefined;
+  }
+  const info = await stat(tokensPath).catch(() => undefined);
+  if (info?.isFile() !== true) {
+    diagnostics.push({ severity: 'warn', message: `"webSkin.tokens" is not a file (${tokens})` });
+    return undefined;
+  }
+  if (info.size > PLUGIN_WEB_SKIN_MAX_BYTES) {
+    diagnostics.push({
+      severity: 'warn',
+      message: `"webSkin.tokens" exceeds the ${PLUGIN_WEB_SKIN_MAX_BYTES / 1024} KB limit (${tokens})`,
+    });
+    return undefined;
+  }
+  try {
+    return parseWebSkinTokenDocument(await readFile(tokensPath, 'utf8'));
+  } catch (error) {
+    diagnostics.push({
+      severity: 'warn',
+      message: `"webSkin.tokens" is invalid: ${(error as Error).message} (${tokens})`,
+    });
+    return undefined;
+  }
+}
+
+export function parseWebSkinTokenDocument(source: string): PluginWebSkin {
+  if (Buffer.byteLength(source, 'utf8') > PLUGIN_WEB_SKIN_MAX_BYTES) {
+    throw new Error('token document is too large');
+  }
+  const parsed: unknown = JSON.parse(source.replace(/^\uFEFF/u, ''));
+  if (!isObject(parsed)) throw new Error('token document must be an object');
+  if (
+    Object.keys(parsed).some((key) => !['manifestVersion', 'light', 'dark'].includes(key)) ||
+    parsed['manifestVersion'] !== 1 ||
+    !isObject(parsed['light']) ||
+    !isObject(parsed['dark'])
+  ) {
+    throw new Error('token document has an invalid schema');
+  }
+  const light = parseWebSkinTokenSet(parsed['light']);
+  const dark = parseWebSkinTokenSet(parsed['dark']);
+  if (Object.keys(light).length + Object.keys(dark).length > WEB_SKIN_MAX_TOKEN_COUNT) {
+    throw new Error('token document has too many tokens');
+  }
+  return { light, dark };
+}
+
+function parseWebSkinTokenSet(value: Record<string, unknown>): Readonly<Record<string, string>> {
+  return Object.fromEntries(
+    Object.entries(value).map(([name, rawValue]) => {
+      if (!WEB_SKIN_TOKEN_NAME.test(name) && !WEB_SKIN_COMPAT_TOKEN_NAMES.has(name)) {
+        throw new Error(`unsupported token: ${name}`);
+      }
+      if (typeof rawValue !== 'string') throw new Error(`token value must be a string: ${name}`);
+      const tokenValue = rawValue.trim();
+      if (
+        tokenValue.length === 0 ||
+        Buffer.byteLength(tokenValue, 'utf8') > WEB_SKIN_MAX_TOKEN_VALUE_BYTES ||
+        hasUnsafeWebSkinTokenValue(tokenValue)
+      ) {
+        throw new Error(`unsafe token value: ${name}`);
+      }
+      return [name, tokenValue];
+    }),
+  );
+}
+
+function hasUnsafeWebSkinTokenValue(value: string): boolean {
+  if (
+    /[;{}@\\\u0000-\u001F\u007F]/u.test(value) ||
+    /javascript\s*:|!\s*important|\/\*|\*\//iu.test(value)
+  ) {
+    return true;
+  }
+  for (const match of value.matchAll(/([A-Za-z][A-Za-z0-9-]*)\s*\(/gu)) {
+    if (!WEB_SKIN_SAFE_FUNCTION_NAMES.has((match[1] ?? '').toLowerCase())) return true;
+  }
+  return false;
 }
 
 function readSessionStart(

--- a/packages/agent-core-v2/src/app/plugin/types.ts
+++ b/packages/agent-core-v2/src/app/plugin/types.ts
@@ -31,6 +31,11 @@ export interface PluginInterface {
   readonly websiteURL?: string;
 }
 
+export interface PluginWebSkin {
+  readonly light: Readonly<Record<string, string>>;
+  readonly dark: Readonly<Record<string, string>>;
+}
+
 export interface PluginManifest {
   readonly name: string;
   readonly version?: string;
@@ -47,6 +52,7 @@ export interface PluginManifest {
   readonly hooks?: readonly HookDefConfig[];
   readonly commands?: readonly PluginCommandEntry[];
   readonly interface?: PluginInterface;
+  readonly webSkin?: PluginWebSkin;
   readonly skillInstructions?: string;
   readonly systemPrompt?: string;
 }

--- a/packages/agent-core-v2/test/app/plugin/manifest.test.ts
+++ b/packages/agent-core-v2/test/app/plugin/manifest.test.ts
@@ -4,7 +4,11 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { parseManifest, PLUGIN_SYSTEM_PROMPT_MAX_BYTES } from '#/app/plugin/manifest';
+import {
+  parseManifest,
+  PLUGIN_SYSTEM_PROMPT_MAX_BYTES,
+  PLUGIN_WEB_SKIN_MAX_BYTES,
+} from '#/app/plugin/manifest';
 
 describe('plugin manifest parser', () => {
   let dir: string;
@@ -331,5 +335,169 @@ describe('plugin manifest parser', () => {
 
     expect(result.manifest?.systemPrompt).toBe('x'.repeat(PLUGIN_SYSTEM_PROMPT_MAX_BYTES));
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it('resolves a declarative web-skin token file inside the plugin', async () => {
+    await mkdir(join(dir, 'web'));
+    await writeFile(join(dir, 'web', 'skin.json'), '{"manifestVersion":1,"light":{"--color-bg":"#fff"},"dark":{}}', 'utf8');
+    await writeFile(
+      join(dir, 'kimi.plugin.json'),
+      JSON.stringify({ name: 'demo', webSkin: { tokens: './web/skin.json' } }),
+      'utf8',
+    );
+
+    const result = await parseManifest(dir);
+
+    expect(result.manifest?.webSkin).toEqual({
+      light: { '--color-bg': '#fff' },
+      dark: {},
+    });
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it('rejects a web skin that also requests runtime capabilities', async () => {
+    await mkdir(join(dir, 'web'));
+    await writeFile(join(dir, 'web', 'skin.json'), '{"manifestVersion":1,"light":{"--color-bg":"#fff"},"dark":{}}', 'utf8');
+    await writeFile(
+      join(dir, 'kimi.plugin.json'),
+      JSON.stringify({
+        name: 'demo',
+        systemPrompt: 'Do something.',
+        webSkin: { tokens: './web/skin.json' },
+      }),
+      'utf8',
+    );
+
+    const result = await parseManifest(dir);
+
+    expect(result.manifest?.webSkin).toBeUndefined();
+    expect(result.diagnostics).toContainEqual({
+      severity: 'error',
+      message: '"webSkin" cannot be combined with runtime plugin capabilities',
+    });
+  });
+
+  it('rejects raw runtime fields even when they parse to no active contribution', async () => {
+    await writeFile(
+      join(dir, 'skin.json'),
+      '{"manifestVersion":1,"light":{},"dark":{}}',
+      'utf8',
+    );
+    await writeFile(
+      join(dir, 'kimi.plugin.json'),
+      JSON.stringify({
+        name: 'demo',
+        skills: [],
+        webSkin: { tokens: './skin.json' },
+      }),
+      'utf8',
+    );
+
+    const result = await parseManifest(dir);
+
+    expect(result.manifest?.webSkin).toBeUndefined();
+    expect(result.diagnostics).toContainEqual({
+      severity: 'error',
+      message: '"webSkin" cannot be combined with runtime plugin capabilities',
+    });
+  });
+
+  it.each([
+    { light: { color: 'red' }, error: 'unsupported token: color' },
+    {
+      light: { '--color-bg': 'url(https://example.com/x)' },
+      error: 'unsafe token value: --color-bg',
+    },
+    {
+      light: { '--color-bg': 'u\\72l(https://example.com/x)' },
+      error: 'unsafe token value: --color-bg',
+    },
+    {
+      light: { '--color-bg': 'image-set("https://example.com/x" 1x)' },
+      error: 'unsafe token value: --color-bg',
+    },
+    {
+      light: { '--color-bg': 'red;position:fixed' },
+      error: 'unsafe token value: --color-bg',
+    },
+    {
+      light: { '--color-bg': 'red !important' },
+      error: 'unsafe token value: --color-bg',
+    },
+    { light: { '--color-bg': 42 }, error: 'token value must be a string: --color-bg' },
+  ])('rejects unsafe web-skin token input', async ({ light, error }) => {
+    await writeFile(
+      join(dir, 'skin.json'),
+      JSON.stringify({ manifestVersion: 1, light, dark: {} }),
+      'utf8',
+    );
+    await writeFile(
+      join(dir, 'kimi.plugin.json'),
+      JSON.stringify({ name: 'demo', webSkin: { tokens: './skin.json' } }),
+      'utf8',
+    );
+
+    const result = await parseManifest(dir);
+
+    expect(result.manifest?.webSkin).toBeUndefined();
+    expect(result.diagnostics.map((entry) => entry.message)).toEqual([
+      `"webSkin.tokens" is invalid: ${error} (./skin.json)`,
+    ]);
+  });
+
+  it('rejects unsupported web-skin schemas and excessive token counts', async () => {
+    await writeFile(
+      join(dir, 'skin.json'),
+      JSON.stringify({ manifestVersion: 2, light: {}, dark: {} }),
+      'utf8',
+    );
+    await writeFile(
+      join(dir, 'kimi.plugin.json'),
+      JSON.stringify({ name: 'demo', webSkin: { tokens: './skin.json' } }),
+      'utf8',
+    );
+    const schema = await parseManifest(dir);
+    expect(schema.diagnostics.map((entry) => entry.message)).toEqual([
+      '"webSkin.tokens" is invalid: token document has an invalid schema (./skin.json)',
+    ]);
+
+    const light = Object.fromEntries(
+      Array.from({ length: 257 }, (_, index) => [`--color-test-${index}`, '#fff']),
+    );
+    await writeFile(
+      join(dir, 'skin.json'),
+      JSON.stringify({ manifestVersion: 1, light, dark: {} }),
+      'utf8',
+    );
+    const count = await parseManifest(dir);
+    expect(count.diagnostics.map((entry) => entry.message)).toEqual([
+      '"webSkin.tokens" is invalid: token document has too many tokens (./skin.json)',
+    ]);
+  });
+
+  it('rejects malformed and oversized web-skin declarations', async () => {
+    await writeFile(join(dir, 'skin.css'), ':root {}', 'utf8');
+    await writeFile(
+      join(dir, 'kimi.plugin.json'),
+      JSON.stringify({ name: 'demo', webSkin: { tokens: './skin.css' } }),
+      'utf8',
+    );
+    const extension = await parseManifest(dir);
+    expect(extension.manifest?.webSkin).toBeUndefined();
+    expect(extension.diagnostics.map((entry) => entry.message)).toEqual([
+      '"webSkin.tokens" must reference a .json file (./skin.css)',
+    ]);
+
+    await writeFile(join(dir, 'skin.json'), 'x'.repeat(PLUGIN_WEB_SKIN_MAX_BYTES + 1), 'utf8');
+    await writeFile(
+      join(dir, 'kimi.plugin.json'),
+      JSON.stringify({ name: 'demo', webSkin: { tokens: './skin.json' } }),
+      'utf8',
+    );
+    const oversized = await parseManifest(dir);
+    expect(oversized.manifest?.webSkin).toBeUndefined();
+    expect(oversized.diagnostics.map((entry) => entry.message)).toEqual([
+      '"webSkin.tokens" exceeds the 64 KB limit (./skin.json)',
+    ]);
   });
 });

--- a/packages/kap-server/src/routes/webAssets.ts
+++ b/packages/kap-server/src/routes/webAssets.ts
@@ -1,8 +1,10 @@
 import { createReadStream } from 'node:fs';
-import { stat } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import { extname, join, normalize, relative, resolve, sep } from 'node:path';
 
 import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import { COMMUNITY_SKINS_STYLESHEET_PATH } from './webSkins';
 
 interface WebAssetRouteHost {
   get(
@@ -54,11 +56,28 @@ async function serveWebAsset(
     return reply.code(404).type('text/plain; charset=utf-8').send('Not found');
   }
 
+  if (resolve(filePath) === resolve(join(assetsDir, 'index.html'))) {
+    const html = injectCommunitySkinStylesheet(await readFile(filePath, 'utf8'));
+    return reply
+      .type('text/html; charset=utf-8')
+      .header('Cache-Control', 'no-cache')
+      .header('Content-Length', String(Buffer.byteLength(html, 'utf8')))
+      .send(html);
+  }
+
   return reply
     .type(mimeType(filePath))
     .header('Cache-Control', cacheControl(assetsDir, filePath))
     .header('Content-Length', String(fileInfo.size))
     .send(createReadStream(filePath));
+}
+
+export function injectCommunitySkinStylesheet(html: string): string {
+  if (html.includes(`href="${COMMUNITY_SKINS_STYLESHEET_PATH}"`)) return html;
+  const closingHead = html.lastIndexOf('</head>');
+  if (closingHead < 0) return html;
+  const link = `    <link rel="stylesheet" href="${COMMUNITY_SKINS_STYLESHEET_PATH}" data-kimi-community-skins>\n`;
+  return `${html.slice(0, closingHead)}${link}${html.slice(closingHead)}`;
 }
 
 function cacheControl(assetsDir: string, filePath: string): string {

--- a/packages/kap-server/src/routes/webSkins.ts
+++ b/packages/kap-server/src/routes/webSkins.ts
@@ -1,0 +1,69 @@
+import { IPluginService, type PluginWebSkin, type Scope } from '@moonshot-ai/agent-core-v2';
+
+export const COMMUNITY_SKINS_STYLESHEET_PATH = '/community-skins.css';
+
+interface WebSkinRouteHost {
+  get(
+    path: string,
+    handler: (
+      req: { id: string },
+      reply: {
+        type(value: string): unknown;
+        header(name: string, value: string): unknown;
+        send(payload: unknown): unknown;
+      },
+    ) => unknown,
+  ): unknown;
+}
+
+export function registerWebSkinRoutes(app: WebSkinRouteHost, core: Scope): void {
+  app.get(COMMUNITY_SKINS_STYLESHEET_PATH, async (_req, reply) => {
+    const css = await enabledWebSkinCss(core).catch(() => '');
+    reply.type('text/css; charset=utf-8');
+    reply.header('Cache-Control', 'no-store');
+    reply.header('X-Content-Type-Options', 'nosniff');
+    reply.header('Cross-Origin-Resource-Policy', 'same-origin');
+    return reply.send(css);
+  });
+}
+
+async function enabledWebSkinCss(core: Scope): Promise<string> {
+  const plugins = core.accessor.get(IPluginService);
+  const summaries = await plugins.listPlugins();
+  const enabled = summaries
+    .filter((plugin) => plugin.enabled && plugin.state === 'ok')
+    .toSorted((left, right) => compareStrings(left.id, right.id));
+  const compiled: string[] = [];
+  for (const summary of enabled) {
+    const info = await plugins.getPluginInfo({ id: summary.id }).catch(() => undefined);
+    if (info?.manifest?.webSkin !== undefined) {
+      compiled.push(compileWebSkinTokens(info.manifest.webSkin));
+    }
+  }
+  return compiled.join('\n');
+}
+
+export function compileWebSkinTokens(webSkin: PluginWebSkin): string {
+  const light = sortedTokens(webSkin.light);
+  const dark = sortedTokens(webSkin.dark);
+  return [
+    tokenBlock(':root,html[data-color-scheme="light"]', light),
+    tokenBlock('html[data-color-scheme="dark"]', dark),
+    `@media (prefers-color-scheme: light){${tokenBlock('html[data-color-scheme="system"]', light)}}`,
+    `@media (prefers-color-scheme: dark){${tokenBlock('html[data-color-scheme="system"]', dark)}}`,
+  ].join('\n');
+}
+
+function sortedTokens(tokens: Readonly<Record<string, string>>): readonly (readonly [string, string])[] {
+  return Object.entries(tokens).toSorted(([left], [right]) => compareStrings(left, right));
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function tokenBlock(selector: string, tokens: readonly (readonly [string, string])[]): string {
+  return `${selector}{${tokens.map(([name, value]) => `${name}:${value}`).join(';')}}`;
+}

--- a/packages/kap-server/src/start.ts
+++ b/packages/kap-server/src/start.ts
@@ -42,6 +42,7 @@ import { resolveRequestId } from './request-id';
 import { registerApiV1Routes } from './routes/registerApiV1Routes';
 import { registerApiV2Routes } from './routes/registerApiV2Routes';
 import { registerWebAssetRoutes } from './routes/webAssets';
+import { registerWebSkinRoutes } from './routes/webSkins';
 import {
   createServerLogger,
   type ServerLogger,
@@ -550,6 +551,7 @@ export async function startServer(opts: ServerStartOptions): Promise<RunningServ
   });
 
   if (opts.webAssetsDir !== undefined) {
+    registerWebSkinRoutes(app, core);
     await registerWebAssetRoutes(app, opts.webAssetsDir);
   }
 

--- a/packages/kap-server/test/webAssets.test.ts
+++ b/packages/kap-server/test/webAssets.test.ts
@@ -15,7 +15,10 @@ describe('web asset cache policy', () => {
     assetsDir = await mkdtemp(join(tmpdir(), 'kimi-web-assets-'));
     await mkdir(join(assetsDir, 'assets'));
     await Promise.all([
-      writeFile(join(assetsDir, 'index.html'), '<main>Kimi</main>'),
+      writeFile(
+        join(assetsDir, 'index.html'),
+        '<html><head><link rel="stylesheet" href="/assets/app.css"></head><body>Kimi</body></html>',
+      ),
       writeFile(join(assetsDir, 'assets', 'index-Dy7xs5tu.js'), 'export {};'),
       writeFile(join(assetsDir, 'assets', 'application-configuration.json'), '{}'),
       writeFile(join(assetsDir, 'favicon.svg'), '<svg></svg>'),
@@ -34,6 +37,17 @@ describe('web asset cache policy', () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.headers['cache-control']).toBe('public, max-age=31536000, immutable');
+  });
+
+  it('injects the community skin stylesheet after the bundled app stylesheet', async () => {
+    const response = await app.inject({ method: 'GET', url: '/sessions/active' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toContain('href="/community-skins.css"');
+    expect(response.body.indexOf('/assets/app.css')).toBeLessThan(
+      response.body.indexOf('/community-skins.css'),
+    );
+    expect(response.body.match(/community-skins\.css/g)).toHaveLength(1);
   });
 
   it.each([

--- a/packages/kap-server/test/webSkins.test.ts
+++ b/packages/kap-server/test/webSkins.test.ts
@@ -1,0 +1,125 @@
+import type {
+  IPluginService,
+  PluginInfo,
+  PluginSummary,
+  PluginWebSkin,
+  Scope,
+} from '@moonshot-ai/agent-core-v2';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  COMMUNITY_SKINS_STYLESHEET_PATH,
+  compileWebSkinTokens,
+  registerWebSkinRoutes,
+} from '../src/routes/webSkins';
+
+function summary(id: string, enabled = true): PluginSummary {
+  return {
+    id,
+    displayName: id,
+    enabled,
+    state: 'ok',
+    skillCount: 0,
+    mcpServerCount: 0,
+    enabledMcpServerCount: 0,
+    hookCount: 0,
+    commandCount: 0,
+    hasErrors: false,
+    source: 'local-path',
+  };
+}
+
+function info(id: string, webSkin: PluginWebSkin): PluginInfo {
+  return {
+    ...summary(id),
+    root: id,
+    installedAt: new Date(0).toISOString(),
+    manifest: { name: id, webSkin },
+    mcpServers: [],
+    diagnostics: [],
+  };
+}
+
+function coreWithPlugins(service: Pick<IPluginService, 'listPlugins' | 'getPluginInfo'>): Scope {
+  return {
+    accessor: { get: () => service },
+  } as unknown as Scope;
+}
+
+describe('community web skins', () => {
+  let app: FastifyInstance;
+
+  beforeEach(() => {
+    app = Fastify();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('compiles light, dark, and system design tokens', () => {
+    const css = compileWebSkinTokens({
+      light: { '--color-bg': '#fffaf4', '--radius-lg': '18px' },
+      dark: { '--color-bg': '#17121f', '--radius-lg': '18px' },
+    });
+
+    expect(css).toContain(
+      ':root,html[data-color-scheme="light"]{--color-bg:#fffaf4;--radius-lg:18px}',
+    );
+    expect(css).toContain(
+      'html[data-color-scheme="dark"]{--color-bg:#17121f;--radius-lg:18px}',
+    );
+    expect(css).toContain('@media (prefers-color-scheme: dark)');
+  });
+
+  it('uses locale-independent plugin-id ordering for skin precedence', async () => {
+    const records = new Map([
+      ['theme_1', info('theme_1', { light: { '--color-accent': '#333333' }, dark: {} })],
+      ['theme0', info('theme0', { light: { '--color-accent': '#222222' }, dark: {} })],
+      ['theme-1', info('theme-1', { light: { '--color-accent': '#111111' }, dark: {} })],
+    ]);
+    registerWebSkinRoutes(
+      app,
+      coreWithPlugins({
+        listPlugins: async () => [summary('theme_1'), summary('theme-1'), summary('theme0')],
+        getPluginInfo: async ({ id }) => records.get(id) as PluginInfo,
+      }),
+    );
+
+    const response = await app.inject({ method: 'GET', url: COMMUNITY_SKINS_STYLESHEET_PATH });
+
+    expect(response.body.indexOf('#111111')).toBeLessThan(response.body.indexOf('#222222'));
+    expect(response.body.indexOf('#222222')).toBeLessThan(response.body.indexOf('#333333'));
+  });
+
+  it('serves enabled skin plugins in stable order with defensive headers', async () => {
+    const records = new Map([
+      [
+        'alpha',
+        info('alpha', { light: { '--color-accent': '#a855f7' }, dark: {} }),
+      ],
+      [
+        'zeta',
+        info('zeta', { light: { '--color-accent': '#f97316' }, dark: {} }),
+      ],
+    ]);
+    registerWebSkinRoutes(
+      app,
+      coreWithPlugins({
+        listPlugins: async () => [summary('zeta'), summary('disabled', false), summary('alpha')],
+        getPluginInfo: async ({ id }) => records.get(id) as PluginInfo,
+      }),
+    );
+
+    const response = await app.inject({ method: 'GET', url: COMMUNITY_SKINS_STYLESHEET_PATH });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('text/css');
+    expect(response.headers['cache-control']).toBe('no-store');
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+    expect(response.headers['cross-origin-resource-policy']).toBe('same-origin');
+    expect(response.body.indexOf('#a855f7')).toBeLessThan(response.body.indexOf('#f97316'));
+    expect(response.body).not.toContain('disabled');
+  });
+});


### PR DESCRIPTION
## Summary

- add a code-free `webSkin.tokens` contribution to Kimi plugin manifests
- validate a versioned light/dark design-token document and reject mixed agent-runtime capabilities
- generate a deterministic same-origin stylesheet for enabled skins and inject it after the bundled Web stylesheet without modifying the code-app bundle
- document the authoring contract in English and Chinese

## Security

- accepts only allowlisted Kimi token names and bounded values
- rejects CSS escapes, comments, `!important`, unknown functions, image/network-loading constructs, executable content, and arbitrary CSS
- limits token files to 64 KB, 256 tokens, and 256 UTF-8 bytes per value
- serves generated CSS with `no-store`, `nosniff`, and same-origin resource policy headers

## Verification

- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck`
- `pnpm --filter @moonshot-ai/kap-server typecheck`
- focused plugin manifest tests: 11 passed
- focused skin and Web asset tests: 9 passed
- `pnpm lint`
- `pnpm --filter @moonshot-ai/kimi-code build`
- installed and visually verified a public example skin through the GitHub plugin flow

Example skin: https://github.com/sdfsfsk/kimi-code-skin-moonlight