### PR TITLE
refactor(agent-core-v2): remove the ${now} system prompt template variable

### DIFF
--- a/.changeset/remove-now-template-variable.md
+++ b/.changeset/remove-now-template-variable.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/agent-core-v2": patch
+---
+
+Remove the `${now}` variable from the system prompt template variable table.

--- a/docs/en/customization/agents.md
+++ b/docs/en/customization/agents.md
@@ -153,7 +153,6 @@ Like the body of a regular agent file, SYSTEM.md is rendered as a template each 
 | `${cwd_listing}` | Listing of the working directory |
 | `${os}` | Operating system kind |
 | `${shell}` | Shell name and path, for example `bash (\`/bin/bash\`)` |
-| `${now}` | Current time in ISO format |
 | `${additional_dirs_info}` | Additional directories added to the workspace; empty when there are none |
 | `${base_prompt}` | The default system prompt. Inside `SYSTEM.md` itself this is the built-in default; inside an agent file it is the effective default — the built-in default, or your `SYSTEM.md` override when present |
 | `${plugin_sections}` | A complete Plugin Instructions block contributed by enabled plugins; empty when no enabled plugin contributes instructions |

--- a/docs/zh/customization/agents.md
+++ b/docs/zh/customization/agents.md
@@ -153,7 +153,6 @@ SYSTEM.md 是纯 Markdown 正文，不需要也不读取 Frontmatter。文件缺
 | `${cwd_listing}` | 工作目录的文件列表 |
 | `${os}` | 操作系统类型 |
 | `${shell}` | Shell 名称与路径，例如 `bash (\`/bin/bash\`)` |
-| `${now}` | 当前时间（ISO 格式） |
 | `${additional_dirs_info}` | 加入工作区的额外目录信息；没有时为空 |
 | `${base_prompt}` | 默认系统提示词。在 `SYSTEM.md` 中指内置默认提示词；在 Agent 文件中指有效默认提示词（内置默认，或存在时为你的 `SYSTEM.md` 覆盖） |
 | `${plugin_sections}` | 已启用 plugin 提供的完整 Plugin Instructions 块；没有已启用 plugin 提供指令时为空 |

--- a/packages/agent-core-v2/docs/state-manifest.d.ts
+++ b/packages/agent-core-v2/docs/state-manifest.d.ts
@@ -1316,15 +1316,6 @@ export interface AgentStateSnapshot {
     readonly systemPrompt: string;
     readonly environmentDisclosure?: /* EnvironmentDisclosureSnapshot — packages/agent-core-v2/src/app/agentProfileCatalog/agentProfileCatalog.ts */ {
       readonly cwd: string;
-      readonly date: {
-        readonly disclosed: true;
-        readonly value: {
-          readonly localDate: string;
-          readonly timeZone: string;
-        };
-      } | {
-        readonly disclosed: false;
-      };
     };
     readonly renderGeneration: number;
     readonly agentsMdPaths?: readonly string[];

--- a/packages/agent-core-v2/docs/wire-manifest.d.ts
+++ b/packages/agent-core-v2/docs/wire-manifest.d.ts
@@ -98,7 +98,6 @@ interface ConfigUpdatePayload {
   /** EnvironmentDisclosureSnapshot */
   environmentDisclosure?: {
     cwd: string;
-    date: { disclosed: true, value: { localDate: string, timeZone: string } } | { disclosed: false };
   };
   renderGeneration?: number;
   agentsMdPaths?: string[];
@@ -495,7 +494,6 @@ interface ProfileBindPayload {
   /** EnvironmentDisclosureSnapshot */
   environmentDisclosure?: {
     cwd: string;
-    date: { disclosed: true, value: { localDate: string, timeZone: string } } | { disclosed: false };
   };
   renderGeneration?: number;
   agentsMdPaths?: string[];

--- a/packages/agent-core-v2/src/agent/profile/profileService.ts
+++ b/packages/agent-core-v2/src/agent/profile/profileService.ts
@@ -28,7 +28,6 @@ import { IConfigService } from '#/app/config/config';
 import type { LoopControl } from '#/agent/loop/configSection';
 import { IAgentRuntimeService } from '#/agent/runtimeBinding/agentRuntime';
 import { RuntimeWorkspaceView } from '#/runtime/runtimeWorkspaceView';
-import { IHostClock } from '#/os/interface/hostClock';
 import { ISessionContext } from '#/session/sessionContext/sessionContext';
 import type { ToolSource } from '#/tool/toolContract';
 import { ISessionWorkspaceContext } from '#/session/workspaceContext/workspaceContext';
@@ -150,7 +149,6 @@ export class AgentProfileService extends Disposable implements IAgentProfileServ
     @IModelCatalog private readonly modelCatalog: IModelCatalog,
     @IProtocolAdapterRegistry private readonly protocolAdapters: IProtocolAdapterRegistry,
     @IAgentRuntimeService private readonly runtime: IAgentRuntimeService,
-    @IHostClock private readonly clock: IHostClock,
     @ISessionContext private readonly sessionContext: ISessionContext,
     @IBootstrapService private readonly bootstrap: IBootstrapService,
     @ISessionWorkspaceContext private readonly workspace: ISessionWorkspaceContext,
@@ -816,16 +814,12 @@ export class AgentProfileService extends Disposable implements IAgentProfileServ
     }
     const skills = await this.resolveSkillListing();
     const pluginSections = await this.resolvePluginSections();
-    const now = this.clock.now();
-    const timeZone = this.clock.timeZone();
     return {
       ...base,
       cwd: view.workDir,
       osKind: env.osKind,
       shellName: env.shellName,
       shellPath: env.shellPath,
-      now: now.toISOString(),
-      timeZone,
       skills,
       pluginSections,
       skillActive: this.isToolActiveForProfile(profile, 'Skill'),

--- a/packages/agent-core-v2/src/app/agentProfileCatalog/agentProfileCatalog.ts
+++ b/packages/agent-core-v2/src/app/agentProfileCatalog/agentProfileCatalog.ts
@@ -23,8 +23,6 @@ export interface AgentProfileContext {
   readonly osKind?: string;
   readonly shellName?: string;
   readonly shellPath?: string;
-  readonly now?: string;
-  readonly timeZone?: string;
   readonly skills?: string;
   readonly skillActive?: boolean;
   readonly pluginSections?: string;
@@ -35,9 +33,6 @@ export interface AgentProfileContext {
 
 export interface EnvironmentDisclosureSnapshot {
   readonly cwd: string;
-  readonly date:
-    | { readonly disclosed: true; readonly value: { readonly localDate: string; readonly timeZone: string } }
-    | { readonly disclosed: false };
 }
 
 export interface SystemPromptRenderResult {
@@ -89,7 +84,7 @@ export function normalizeAgentProfile(input: AgentProfileInput): AgentProfile {
       systemPrompt,
       renderSystemPrompt: (context) => ({
         text: systemPrompt(context),
-        environment: { cwd: context.cwd ?? '', date: { disclosed: false } },
+        environment: { cwd: context.cwd ?? '' },
       }),
     };
   }

--- a/packages/agent-core-v2/src/app/agentProfileCatalog/profile-shared.ts
+++ b/packages/agent-core-v2/src/app/agentProfileCatalog/profile-shared.ts
@@ -138,7 +138,6 @@ export function systemPromptVars(
     os: context.osKind ?? '',
     windows_notes: context.osKind === 'Windows' ? `\n\n${WINDOWS_NOTES}\n\n` : '',
     shell: shellName.length > 0 ? `${shellName} (\`${shellPath}\`)` : '',
-    now: context.now ?? new Date().toISOString(),
     cwd: context.cwd ?? '',
     cwd_listing: context.cwdListing ?? '',
     agents_md: context.agentsMd ?? '',
@@ -171,10 +170,7 @@ export function renderPromptTemplateResult(
   }
   return {
     text: renderPrompt(template, vars),
-    environment: mergeEnvironmentDisclosure(
-      environmentForTemplate(template, context),
-      baseResult?.environment,
-    ),
+    environment: mergeEnvironmentDisclosure(environmentForTemplate(context), baseResult?.environment),
   };
 }
 
@@ -188,28 +184,12 @@ export function renderSystemPromptResult(
       ...systemPromptVars(context, options),
       role_additional: roleAdditional,
     }),
-    environment: environmentForTemplate(SYSTEM_PROMPT_TEMPLATE, context),
+    environment: environmentForTemplate(context),
   };
 }
 
-function environmentForTemplate(
-  template: string,
-  context: AgentProfileContext,
-): EnvironmentDisclosureSnapshot {
-  const usesNow = template.includes('${now}');
-  const timeZone = context.timeZone ?? localTimeZone();
-  return {
-    cwd: context.cwd ?? '',
-    date: usesNow
-      ? {
-          disclosed: true,
-          value: {
-            localDate: localDateKey(context.now, timeZone),
-            timeZone,
-          },
-        }
-      : { disclosed: false },
-  };
+function environmentForTemplate(context: AgentProfileContext): EnvironmentDisclosureSnapshot {
+  return { cwd: context.cwd ?? '' };
 }
 
 function mergeEnvironmentDisclosure(
@@ -217,26 +197,5 @@ function mergeEnvironmentDisclosure(
   base: EnvironmentDisclosureSnapshot | undefined,
 ): EnvironmentDisclosureSnapshot {
   if (base === undefined) return direct;
-  return {
-    cwd: direct.cwd || base.cwd,
-    date: direct.date.disclosed ? direct.date : base.date,
-  };
-}
-
-function localDateKey(now: string | undefined, timeZone: string): string {
-  const date = now === undefined ? new Date() : new Date(now);
-  if (Number.isNaN(date.getTime())) return localDateKey(undefined, timeZone);
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).formatToParts(date);
-  const part = (type: Intl.DateTimeFormatPartTypes): string =>
-    parts.find((candidate) => candidate.type === type)?.value ?? '';
-  return `${part('year')}-${part('month')}-${part('day')}`;
-}
-
-function localTimeZone(): string {
-  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  return { cwd: direct.cwd || base.cwd };
 }

--- a/packages/agent-core-v2/src/features/dateChange/dateChangeAgentRuntime.ts
+++ b/packages/agent-core-v2/src/features/dateChange/dateChangeAgentRuntime.ts
@@ -76,16 +76,6 @@ const dateChangeInjection = fromCallback(({
       environment.cwd !== sessionContext.cwd
     );
   };
-  const dateFromProfile = (): DateDisclosure | undefined => {
-    if (!belongsToCurrentCwd()) return undefined;
-    const profileData = profile.data();
-    const date = profileData.environmentDisclosure?.date;
-    if (!date?.disclosed) return undefined;
-    return {
-      ...date.value,
-      renderGeneration: profileData.renderGeneration ?? 0,
-    };
-  };
   const registration = reminder.register<DateInjectionDisclosure>(
     DATE_CHANGE_INJECTION_VARIANT,
     ({
@@ -95,13 +85,8 @@ const dateChangeInjection = fromCallback(({
       if (!belongsToCurrentCwd()) return undefined;
       const renderGeneration = profileData.renderGeneration ?? 0;
       const current = currentDateDisclosure(clock);
-      const profileDate = dateFromProfile();
       const seed = runtime.getLogicState<DateChangeActorContext>().seed;
-      const baseline = pickDisclosureBaseline<DateDisclosure>(
-        lastDisclosure,
-        profileDate,
-        seed,
-      );
+      const baseline = pickDisclosureBaseline<DateDisclosure>(lastDisclosure, seed);
       if (baseline !== undefined && baseline.localDate !== current.localDate) {
         return {
           content: `The date has changed. Today's date is now ${current.localDate}. Rely on this reminder over any earlier date statement for the current date. DO NOT mention this to the user explicitly.`,
@@ -113,7 +98,7 @@ const dateChangeInjection = fromCallback(({
           },
         };
       }
-      if (lastDisclosure !== undefined || profileDate !== undefined) return undefined;
+      if (lastDisclosure !== undefined) return undefined;
       if (seed === undefined) {
         runtime.send({
           type: 'dateChange.disclose',

--- a/packages/agent-core-v2/test/agent/profile/binding.test.ts
+++ b/packages/agent-core-v2/test/agent/profile/binding.test.ts
@@ -17,7 +17,6 @@ import { BuiltinAgentProfileLoaderService } from '#/app/agentProfileCatalog/buil
 import { registerAgentProfile } from '#/app/agentProfileCatalog/contribution';
 import type { ToolCall } from '#/kosong/contract/message';
 import { IAgentProfileService, type ResolvedAgentProfile } from '#/agent/profile/profile';
-import { IHostClock } from '#/os/interface/hostClock';
 import type { HostFsChange } from '#/os/interface/hostFsWatch';
 import { IAgentAgentsMdReminderService } from '#/agent/agentsMdReminder/agentsMdReminder';
 import { IAgentToolPolicyService } from '#/agent/toolPolicy/toolPolicy';
@@ -26,6 +25,7 @@ import { IAgentToolRegistryService } from '#/agent/toolRegistry/toolRegistry';
 import { SELECT_TOOLS_TOOL_NAME } from '#/agent/toolSelect/toolSelect';
 import { IAtomicDocumentStore, type IAtomicDocumentStore as AtomicDocumentStore } from '#/persistence/interface/atomicDocumentStore';
 import { ISessionAgentProfileCatalog } from '#/session/sessionAgentProfileCatalog/sessionAgentProfileCatalog';
+import { ISessionContext } from '#/session/sessionContext/sessionContext';
 import { ISessionInstructionsProvider } from '#/session/sessionInstructions/instructionsProvider';
 import { ISessionSkillCatalog } from '#/features/skill/session/skillCatalog';
 import { ISessionToolPolicy } from '#/session/sessionToolPolicy/sessionToolPolicy';
@@ -141,21 +141,14 @@ describe('AgentProfileService.bind', () => {
     expect(svc.isRunnable()).toBe(true);
   });
 
-  it('keeps the rendered prompt and disclosure free of clock-dependent content', async () => {
-    const hostClock: IHostClock = {
-      _serviceBrand: undefined,
-      now: () => new Date('2026-07-29T04:00:00.000Z'),
-      timeZone: () => 'Asia/Shanghai',
-    };
-    ctx = createTestAgent(appService(IHostClock, hostClock), hostEnvironmentServices(homeDir));
+  it('binds an environment disclosure snapshot with only the session cwd', async () => {
+    ctx = createTestAgent(hostEnvironmentServices(homeDir));
     const svc = ctx.get(IAgentProfileService);
 
     await svc.bind({ profile: DEFAULT_AGENT_PROFILE_NAME, model: MOCK_MODEL });
 
     expect(svc.getSystemPrompt()).not.toContain('2026-07-29');
-    expect(svc.data().environmentDisclosure).toMatchObject({
-      date: { disclosed: false },
-    });
+    expect(svc.data().environmentDisclosure).toEqual({ cwd: ctx.get(ISessionContext).cwd });
   });
 
   it('persists the complete binding in one journal record', async () => {

--- a/packages/agent-core-v2/test/agent/profile/profileOps.test.ts
+++ b/packages/agent-core-v2/test/agent/profile/profileOps.test.ts
@@ -352,13 +352,7 @@ describe('AgentProfileService (wire-backed config.update)', () => {
   });
 
   it('persists the rendered prompt and disclosure snapshot in one bind record', async () => {
-    const environment: EnvironmentDisclosureSnapshot = {
-      cwd: '/work',
-      date: {
-        disclosed: true,
-        value: { localDate: '2026-07-29', timeZone: 'Asia/Shanghai' },
-      },
-    };
+    const environment: EnvironmentDisclosureSnapshot = { cwd: '/work' };
     svc.applyBindingSnapshot({
       modelAlias: 'kimi-code',
       profileName: 'agent',
@@ -397,13 +391,7 @@ describe('AgentProfileService (wire-backed config.update)', () => {
   });
 
   it('replays a legacy config.update record with an explicit renderGeneration verbatim', async () => {
-    const environment: EnvironmentDisclosureSnapshot = {
-      cwd: '/work',
-      date: {
-        disclosed: true,
-        value: { localDate: '2026-07-29', timeZone: 'Asia/Shanghai' },
-      },
-    };
+    const environment: EnvironmentDisclosureSnapshot = { cwd: '/work' };
 
     const replay = buildHost('profile-replay-legacy-generation');
     await restoreTestEventDispatcher(

--- a/packages/agent-core-v2/test/app/agentProfileCatalog/profile-shared.test.ts
+++ b/packages/agent-core-v2/test/app/agentProfileCatalog/profile-shared.test.ts
@@ -39,7 +39,6 @@ describe('systemPromptVars', () => {
         osKind: 'macOS',
         shellName: 'zsh',
         shellPath: '/bin/zsh',
-        now: 'NOW',
         additionalDirsInfo: '/extra',
       },
       { skillActive: true },
@@ -49,7 +48,6 @@ describe('systemPromptVars', () => {
     expect(vars['os']).toBe('macOS');
     expect(vars['windows_notes']).toBe('');
     expect(vars['shell']).toBe('zsh (`/bin/zsh`)');
-    expect(vars['now']).toBe('NOW');
     expect(vars['cwd']).toBe('/work');
     expect(vars['cwd_listing']).toBe('LISTING');
     expect(vars['agents_md']).toBe('AGENTS');
@@ -61,7 +59,7 @@ describe('systemPromptVars', () => {
     expect(vars['skills_section']).toContain('SKILLS');
   });
 
-  it('renders missing context fields as empty strings and defaults ${now}', () => {
+  it('renders missing context fields as empty strings', () => {
     const vars = systemPromptVars({}, { skillActive: true });
 
     expect(vars['cwd']).toBe('');
@@ -74,7 +72,6 @@ describe('systemPromptVars', () => {
     expect(vars['skills_section']).toBe('');
     expect(vars['windows_notes']).toBe('');
     expect(vars['role_additional']).toBe('');
-    expect(Number.isNaN(Date.parse(vars['now'] ?? ''))).toBe(false);
   });
 
   it('empties skills and the skills section when the Skill tool is off', () => {
@@ -140,7 +137,7 @@ describe('renderPromptTemplateResult', () => {
       calls += 1;
       return {
         text: 'BASE',
-        environment: { cwd: '', date: { disclosed: false } },
+        environment: { cwd: '' },
       };
     };
 
@@ -162,51 +159,30 @@ describe('renderPromptTemplateResult', () => {
     );
   });
 
-  it('records the environment facts used by the now placeholder', () => {
+  it('keeps ${now} verbatim as an unknown placeholder', () => {
     const result = renderPromptTemplateResult(
       'date=${now} agents=${agents_md}',
-      {
-        cwd: '/work',
-        now: '2026-07-29T00:30:00.000Z',
-        timeZone: 'America/Los_Angeles',
-        agentsMd: 'AGENTS',
-      },
+      { cwd: '/work', agentsMd: 'AGENTS' },
       { skillActive: true },
     );
 
-    expect(result.text).toBe('date=2026-07-29T00:30:00.000Z agents=AGENTS');
-    expect(result.environment.cwd).toBe('/work');
-    expect(result.environment.date).toMatchObject({
-      disclosed: true,
-      value: { localDate: '2026-07-28', timeZone: 'America/Los_Angeles' },
-    });
+    expect(result.text).toBe('date=${now} agents=AGENTS');
+    expect(result.environment).toEqual({ cwd: '/work' });
   });
 
-  it('merges disclosure metadata from a structured base_prompt render', () => {
+  it('merges environment metadata from a structured base_prompt render', () => {
     const result = renderPromptTemplateResult(
       'custom\n\n${base_prompt}',
       { cwd: '/work' },
       { skillActive: true },
       () => ({
         text: 'BASE',
-        environment: {
-          cwd: '/base',
-          date: {
-            disclosed: true,
-            value: { localDate: '2026-07-28', timeZone: 'UTC' },
-          },
-        },
+        environment: { cwd: '/base' },
       }),
     );
 
     expect(result.text).toBe('custom\n\nBASE');
-    expect(result.environment).toEqual({
-      cwd: '/work',
-      date: {
-        disclosed: true,
-        value: { localDate: '2026-07-28', timeZone: 'UTC' },
-      },
-    });
+    expect(result.environment).toEqual({ cwd: '/work' });
   });
 });
 
@@ -275,7 +251,6 @@ describe('renderSystemPromptResult', () => {
         osKind: 'Windows',
         shellName: 'cmd',
         shellPath: 'C:\\cmd.exe',
-        now: 'NOW',
         additionalDirsInfo: '/extra',
       },
       { skillActive: true },
@@ -298,22 +273,6 @@ describe('renderSystemPromptResult', () => {
     expect(overridden).toContain('GUI_STYLE');
     expect(overridden).not.toContain('Kimi Code CLI');
   });
-
-  it('renders identical text regardless of the render-time clock', () => {
-    const earlier = renderSystemPromptResult(
-      '',
-      { cwd: '/work', now: '2026-07-29T12:00:00', timeZone: 'UTC' },
-      { skillActive: true },
-    );
-    const later = renderSystemPromptResult(
-      '',
-      { cwd: '/work', now: '2026-08-19T01:00:00', timeZone: 'UTC' },
-      { skillActive: true },
-    );
-
-    expect(later.text).toBe(earlier.text);
-    expect(earlier.environment).toEqual({ cwd: '/work', date: { disclosed: false } });
-  });
 });
 
 describe('normalizeAgentProfile', () => {
@@ -325,24 +284,18 @@ describe('normalizeAgentProfile', () => {
 
     expect(profile.renderSystemPrompt({ cwd: '/work' })).toEqual({
       text: 'cwd:/work',
-      environment: { cwd: '/work', date: { disclosed: false } },
+      environment: { cwd: '/work' },
     });
     expect(profile.renderSystemPrompt({})).toEqual({
       text: 'cwd:',
-      environment: { cwd: '', date: { disclosed: false } },
+      environment: { cwd: '' },
     });
   });
 
   it('derives systemPrompt from renderSystemPrompt for structured input', () => {
     const render = (context: AgentProfileContext): SystemPromptRenderResult => ({
       text: `structured:${context.cwd ?? ''}`,
-      environment: {
-        cwd: context.cwd ?? '',
-        date: {
-          disclosed: true,
-          value: { localDate: '2026-07-29', timeZone: 'UTC' },
-        },
-      },
+      environment: { cwd: context.cwd ?? '' },
     });
     const profile = normalizeAgentProfile({ name: 'structured', renderSystemPrompt: render });
 
@@ -350,13 +303,7 @@ describe('normalizeAgentProfile', () => {
     expect(profile.systemPrompt({ cwd: '/work' })).toBe(
       profile.renderSystemPrompt({ cwd: '/work' }).text,
     );
-    expect(profile.renderSystemPrompt({ cwd: '/work' }).environment).toEqual({
-      cwd: '/work',
-      date: {
-        disclosed: true,
-        value: { localDate: '2026-07-29', timeZone: 'UTC' },
-      },
-    });
+    expect(profile.renderSystemPrompt({ cwd: '/work' }).environment).toEqual({ cwd: '/work' });
   });
 
   it('falls back to systemPrompt when renderSystemPrompt is explicitly undefined', () => {
@@ -369,7 +316,7 @@ describe('normalizeAgentProfile', () => {
     expect(profile.systemPrompt({})).toBe('text-entry');
     expect(profile.renderSystemPrompt({})).toEqual({
       text: 'text-entry',
-      environment: { cwd: '', date: { disclosed: false } },
+      environment: { cwd: '' },
     });
   });
 
@@ -399,7 +346,7 @@ describe('normalizeAgentProfile', () => {
       renderSystemPrompt(): SystemPromptRenderResult {
         return {
           text: `name:${this.name}`,
-          environment: { cwd: '', date: { disclosed: false } },
+          environment: { cwd: '' },
         };
       },
     };
@@ -418,7 +365,7 @@ describe('normalizeAgentProfile', () => {
       renderSystemPrompt(context: AgentProfileContext): SystemPromptRenderResult {
         return {
           text: `structured:${this.systemPrompt(context)}`,
-          environment: { cwd: context.cwd ?? '', date: { disclosed: false } },
+          environment: { cwd: context.cwd ?? '' },
         };
       },
     };
@@ -426,7 +373,7 @@ describe('normalizeAgentProfile', () => {
 
     expect(profile.renderSystemPrompt({})).toEqual({
       text: 'structured:text-entry',
-      environment: { cwd: '', date: { disclosed: false } },
+      environment: { cwd: '' },
     });
     expect(profile.systemPrompt({})).toBe('structured:text-entry');
   });

--- a/packages/agent-core-v2/test/app/config/config.test.ts
+++ b/packages/agent-core-v2/test/app/config/config.test.ts
@@ -223,7 +223,7 @@ describe('Agent config', () => {
     });
 
     expect(ctx.newEvents()).toMatchInlineSnapshot(`
-      [wire] config.update            { "agentId": "main", "profileName": "test-profile", "systemPrompt": "Profile system prompt.", "environmentDisclosure": { "cwd": "<cwd>", "date": { "disclosed": false } }, "agentsMdPaths": [], "disallowedTools": [], "time": "<time>" }
+      [wire] config.update            { "agentId": "main", "profileName": "test-profile", "systemPrompt": "Profile system prompt.", "environmentDisclosure": { "cwd": "<cwd>" }, "agentsMdPaths": [], "disallowedTools": [], "time": "<time>" }
       [emit] agent.status.updated     { "time": "<time>", "agentId": "main", "model": "mock-model", "maxContextTokens": 1000000 }
       [wire] tools.set_active_tools   { "agentId": "main", "names": [ "Read" ], "time": "<time>" }
     `);

--- a/packages/agent-core-v2/test/features/dateChange/dateChangeInjection.test.ts
+++ b/packages/agent-core-v2/test/features/dateChange/dateChangeInjection.test.ts
@@ -8,10 +8,7 @@ import { IAgentContextMemoryService } from '#/agent/contextMemory/contextMemory'
 import type { ContextMessage } from '#/agent/contextMemory/types';
 import { IAgentLoopService } from '#/agent/loop/loop';
 import { IAgentProfileService } from '#/agent/profile/profile';
-import {
-  DEFAULT_AGENT_PROFILE_NAME,
-  type EnvironmentDisclosureSnapshot,
-} from '#/app/agentProfileCatalog/agentProfileCatalog';
+import { DEFAULT_AGENT_PROFILE_NAME } from '#/app/agentProfileCatalog/agentProfileCatalog';
 import {
   AgentDateChange,
   DateChangeRuntime,
@@ -55,36 +52,10 @@ function systemPromptWithDate(iso: string): string {
   ].join('\n');
 }
 
-function updateSystemPromptWithDate(
-  profile: IAgentProfileService,
-  cwd: string,
-  iso: string,
-  localDate: string,
-): void {
-  const environment: EnvironmentDisclosureSnapshot = {
-    cwd,
-    date: {
-      disclosed: true,
-      value: {
-        localDate,
-        timeZone: TEST_TIME_ZONE,
-      },
-    },
-  };
+function updateSystemPrompt(profile: IAgentProfileService, systemPrompt: string, cwd: string): void {
   profile.update({
-    systemPrompt: systemPromptWithDate(iso),
-    environmentDisclosure: environment,
-  });
-}
-
-function updateSystemPromptWithoutDate(profile: IAgentProfileService, cwd: string): void {
-  const environment: EnvironmentDisclosureSnapshot = {
-    cwd,
-    date: { disclosed: false },
-  };
-  profile.update({
-    systemPrompt: 'You are a deterministic test agent.',
-    environmentDisclosure: environment,
+    systemPrompt,
+    environmentDisclosure: { cwd },
   });
 }
 
@@ -124,25 +95,21 @@ describe('dateChangeAgentRuntime', () => {
     }
   });
 
-  it('does not inject when the system prompt date is today', async () => {
-    updateSystemPromptWithDate(
-      profile,
-      ctx.get(ISessionContext).cwd,
-      INITIAL_INSTANT,
-      '2026-07-29',
-    );
+  it('injects on the first step even when the system prompt text states today\'s date', async () => {
+    updateSystemPrompt(profile, systemPromptWithDate(INITIAL_INSTANT), ctx.get(ISessionContext).cwd);
 
     await runWillBeginStepHooks(loop);
 
-    expect(dateReminders(context)).toHaveLength(0);
+    const reminders = dateReminders(context);
+    expect(reminders).toHaveLength(1);
+    expect(messageText(reminders[0] as ContextMessage)).toContain('2026-07-29');
   });
 
-  it('injects once when the rendered date is stale, then stays quiet', async () => {
-    updateSystemPromptWithDate(
+  it('discloses the current date and stays quiet when the system prompt text is stale', async () => {
+    updateSystemPrompt(
       profile,
+      systemPromptWithDate('2026-07-28T04:00:00.000Z'),
       ctx.get(ISessionContext).cwd,
-      '2026-07-28T04:00:00.000Z',
-      '2026-07-28',
     );
 
     await runWillBeginStepHooks(loop);
@@ -152,7 +119,7 @@ describe('dateChangeAgentRuntime', () => {
     const first = reminders[0];
     expect(first).toBeDefined();
     const text = messageText(first as ContextMessage);
-    expect(text).toContain('2026-07-29');
+    expect(text).toContain("Today's date is 2026-07-29");
     expect(first?.origin).toMatchObject({
       kind: 'injection',
       variant: 'date_change',
@@ -169,28 +136,23 @@ describe('dateChangeAgentRuntime', () => {
   });
 
   it('announces each date crossed by a long-lived session', async () => {
-    updateSystemPromptWithDate(
-      profile,
-      ctx.get(ISessionContext).cwd,
-      INITIAL_INSTANT,
-      '2026-07-29',
-    );
+    updateSystemPrompt(profile, systemPromptWithDate(INITIAL_INSTANT), ctx.get(ISessionContext).cwd);
     await runWillBeginStepHooks(loop);
 
     clock.set('2026-07-30T04:00:00.000Z');
     await runWillBeginStepHooks(loop);
 
     let reminders = dateReminders(context);
-    expect(reminders).toHaveLength(1);
-    expect(messageText(reminders[0] as ContextMessage)).toContain('2026-07-30');
+    expect(reminders).toHaveLength(2);
+    expect(messageText(reminders[1] as ContextMessage)).toContain('2026-07-30');
 
     clock.set('2026-07-31T04:00:00.000Z');
     await runWillBeginStepHooks(loop);
 
     reminders = dateReminders(context);
-    expect(reminders).toHaveLength(2);
-    expect(messageText(reminders[1] as ContextMessage)).toContain('2026-07-31');
-    expect(reminders[1]?.origin).toMatchObject({
+    expect(reminders).toHaveLength(3);
+    expect(messageText(reminders[2] as ContextMessage)).toContain('2026-07-31');
+    expect(reminders[2]?.origin).toMatchObject({
       disclosure: {
         kind: 'date',
         renderGeneration: 2,
@@ -204,12 +166,7 @@ describe('dateChangeAgentRuntime', () => {
     await ctx.dispose();
     ctx = createTestAgent({ persistence }, appService(IHostClock, clock));
     profile = ctx.get(IAgentProfileService);
-    updateSystemPromptWithDate(
-      profile,
-      ctx.get(ISessionContext).cwd,
-      INITIAL_INSTANT,
-      '2026-07-29',
-    );
+    updateSystemPrompt(profile, systemPromptWithDate(INITIAL_INSTANT), ctx.get(ISessionContext).cwd);
     await ctx.wire.flush();
     await ctx.dispose();
 
@@ -297,16 +254,19 @@ describe('dateChangeAgentRuntime', () => {
     }
   });
 
-  it('uses the newer persisted render snapshot over older reminder metadata', async () => {
-    updateSystemPromptWithDate(
+  it('keeps the newer render-generation disclosure when an older metadata reminder appears later', async () => {
+    updateSystemPrompt(
       profile,
+      'You are a deterministic test agent.',
       ctx.get(ISessionContext).cwd,
-      '2026-07-28T04:00:00.000Z',
-      '2026-07-28',
     );
+
+    await runWillBeginStepHooks(loop);
+    expect(dateReminders(context)).toHaveLength(1);
+
     context.append({
       role: 'user',
-      content: [{ type: 'text', text: 'older date reminder' }],
+      content: [{ type: 'text', text: 'older metadata reminder' }],
       toolCalls: [],
       origin: {
         kind: 'injection',
@@ -314,7 +274,7 @@ describe('dateChangeAgentRuntime', () => {
         disclosure: {
           kind: 'date',
           renderGeneration: 1,
-          localDate: '2026-07-29',
+          localDate: '2026-07-30',
           timeZone: TEST_TIME_ZONE,
         },
       },
@@ -322,23 +282,14 @@ describe('dateChangeAgentRuntime', () => {
 
     await runWillBeginStepHooks(loop);
 
-    const reminders = dateReminders(context);
-    expect(reminders).toHaveLength(2);
-    expect(reminders.at(-1)?.origin).toMatchObject({
-      disclosure: {
-        kind: 'date',
-        renderGeneration: 2,
-        localDate: '2026-07-29',
-      },
-    });
+    expect(dateReminders(context)).toHaveLength(2);
   });
 
   it('re-injects after undo removes the structured reminder metadata', async () => {
-    updateSystemPromptWithDate(
+    updateSystemPrompt(
       profile,
+      'You are a deterministic test agent.',
       ctx.get(ISessionContext).cwd,
-      '2026-07-28T04:00:00.000Z',
-      '2026-07-28',
     );
     context.append({
       role: 'user',
@@ -364,7 +315,11 @@ describe('dateChangeAgentRuntime', () => {
   });
 
   it('re-discloses after undo removes the initial disclosure', async () => {
-    updateSystemPromptWithoutDate(profile, ctx.get(ISessionContext).cwd);
+    updateSystemPrompt(
+      profile,
+      'You are a deterministic test agent.',
+      ctx.get(ISessionContext).cwd,
+    );
     context.append({
       role: 'user',
       content: [{ type: 'text', text: 'first turn' }],
@@ -390,8 +345,12 @@ describe('dateChangeAgentRuntime', () => {
     expect(messageText(reminders[0] as ContextMessage)).toContain('2026-07-29');
   });
 
-  it('discloses the current date on the first step when the system prompt carries no date', async () => {
-    updateSystemPromptWithoutDate(profile, ctx.get(ISessionContext).cwd);
+  it('discloses the current date on the first step and stays quiet', async () => {
+    updateSystemPrompt(
+      profile,
+      'You are a deterministic test agent.',
+      ctx.get(ISessionContext).cwd,
+    );
 
     await runWillBeginStepHooks(loop);
 
@@ -414,7 +373,11 @@ describe('dateChangeAgentRuntime', () => {
   });
 
   it('announces a crossed midnight after the initial disclosure', async () => {
-    updateSystemPromptWithoutDate(profile, ctx.get(ISessionContext).cwd);
+    updateSystemPrompt(
+      profile,
+      'You are a deterministic test agent.',
+      ctx.get(ISessionContext).cwd,
+    );
     await runWillBeginStepHooks(loop);
     expect(dateReminders(context)).toHaveLength(1);
 
@@ -429,18 +392,8 @@ describe('dateChangeAgentRuntime', () => {
     expect(dateReminders(context)).toHaveLength(2);
   });
 
-  it('treats an empty snapshot cwd as unknown and uses the disclosed date as baseline', async () => {
-    updateSystemPromptWithDate(profile, '', '2026-07-28T04:00:00.000Z', '2026-07-28');
-
-    await runWillBeginStepHooks(loop);
-
-    const reminders = dateReminders(context);
-    expect(reminders).toHaveLength(1);
-    expect(messageText(reminders[0] as ContextMessage)).toContain('2026-07-29');
-  });
-
-  it('discloses then announces when the snapshot cwd is empty and no date is disclosed', async () => {
-    updateSystemPromptWithoutDate(profile, '');
+  it('discloses then announces when the snapshot cwd is empty', async () => {
+    updateSystemPrompt(profile, 'You are a deterministic test agent.', '');
     await runWillBeginStepHooks(loop);
     expect(dateReminders(context)).toHaveLength(1);
 
@@ -453,12 +406,7 @@ describe('dateChangeAgentRuntime', () => {
   });
 
   it('never injects when the snapshot belongs to a different cwd', async () => {
-    updateSystemPromptWithDate(
-      profile,
-      '/some/other/workspace',
-      '2026-07-28T04:00:00.000Z',
-      '2026-07-28',
-    );
+    updateSystemPrompt(profile, 'You are a deterministic test agent.', '/some/other/workspace');
 
     await runWillBeginStepHooks(loop);
     expect(dateReminders(context)).toHaveLength(0);
@@ -469,7 +417,11 @@ describe('dateChangeAgentRuntime', () => {
   });
 
   it('keeps one provider registration across repeated runtime restore', async () => {
-    updateSystemPromptWithoutDate(profile, ctx.get(ISessionContext).cwd);
+    updateSystemPrompt(
+      profile,
+      'You are a deterministic test agent.',
+      ctx.get(ISessionContext).cwd,
+    );
 
     expect(ctx.resolve(AgentDateChange)).toBeInstanceOf(DateChangeRuntime);
     await runWillBeginStepHooks(loop);

--- a/packages/agent-core-v2/test/harness/agent.ts
+++ b/packages/agent-core-v2/test/harness/agent.ts
@@ -226,7 +226,6 @@ import {
   type InteractionRuntime,
 } from '#/features/interaction/interactionAgentRuntime';
 import type { IHostProcess } from '#/os/interface/hostProcess';
-import { IHostClock } from '#/os/interface/hostClock';
 import type { EnvironmentDisclosureSnapshot } from '#/app/agentProfileCatalog/agentProfileCatalog';
 import { ISessionQuestionService, type QuestionResult } from '#/session/question/question';
 import { ISessionSkillCatalog } from '#/features/skill/session/skillCatalog';
@@ -259,24 +258,11 @@ interface TestModelProviderOptions {
   readonly kimiRequestHeaders?: Record<string, string>;
 }
 
-function disclosedTestEnvironment(clock: IHostClock, cwd: string): EnvironmentDisclosureSnapshot {
-  const timeZone = clock.timeZone();
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).formatToParts(clock.now());
-  const part = (type: Intl.DateTimeFormatPartTypes): string =>
-    parts.find((candidate) => candidate.type === type)?.value ?? '';
-  return {
-    cwd,
-    date: {
-      disclosed: true,
-      value: { localDate: `${part('year')}-${part('month')}-${part('day')}`, timeZone },
-    },
-  };
+function mutedDateChangeEnvironment(): EnvironmentDisclosureSnapshot {
+  return { cwd: DATE_CHANGE_MUTED_CWD };
 }
+
+const DATE_CHANGE_MUTED_CWD = '/__harness_date_change_muted__';
 
 interface KimiConfig {
   readonly providers: Record<string, ProviderConfigForConfig>;
@@ -1630,10 +1616,7 @@ export class AgentTestContext {
       modelAlias: provider.model,
       systemPrompt: DEFAULT_TEST_SYSTEM_PROMPT,
       thinkingLevel: 'off',
-      environmentDisclosure: disclosedTestEnvironment(
-        this.get(IHostClock),
-        this.get(ISessionContext).cwd,
-      ),
+      environmentDisclosure: mutedDateChangeEnvironment(),
     });
 
     if (tools.length > 0) {

--- a/packages/agent-core-v2/test/workspace/workspaceAgentProfileLoader/agentFile.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceAgentProfileLoader/agentFile.test.ts
@@ -183,10 +183,7 @@ describe('agentProfileFromFile', () => {
   };
   const basePrompt = (): SystemPromptRenderResult => ({
     text: 'BASE_PROMPT',
-    environment: {
-      cwd: '',
-      date: { disclosed: false },
-    },
+    environment: { cwd: '' },
   });
 
   it('returns a plain body verbatim and injects no unreferenced context', () => {
@@ -249,25 +246,13 @@ describe('agentProfileFromFile', () => {
       { ...base, prompt: 'extra instructions\n\n${base_prompt}' },
       (): SystemPromptRenderResult => ({
         text: 'BASE_PROMPT',
-        environment: {
-          cwd: '/work',
-          date: {
-            disclosed: true,
-            value: { localDate: '2026-07-29', timeZone: 'Asia/Shanghai' },
-          },
-        },
+        environment: { cwd: '/work' },
       }),
     );
 
     const rendered = profile.renderSystemPrompt({ cwd: '/work' });
     expect(rendered.text).toBe('extra instructions\n\nBASE_PROMPT');
-    expect(rendered.environment).toEqual({
-      cwd: '/work',
-      date: {
-        disclosed: true,
-        value: { localDate: '2026-07-29', timeZone: 'Asia/Shanghai' },
-      },
-    });
+    expect(rendered.environment).toEqual({ cwd: '/work' });
   });
 
   it('places plugin instructions where ${plugin_sections} is referenced', () => {


### PR DESCRIPTION
## Related Issue

Internal cleanup, no linked issue.

## Problem

The `${now}` system prompt template variable let custom `SYSTEM.md` / agent files embed a millisecond-precision ISO timestamp in the system prompt. That value differs across sessions (and across profile re-binds), defeating provider prefix-cache reuse. The engine already discloses the current date via date-change reminders — injected at conversation start and again whenever the date crosses — making `${now}` redundant.

## What changed

Removes `${now}` from the system prompt template variable table (like any other unknown placeholder, it now renders verbatim) and deletes the compensation machinery built around it:

- drops the `now` / `timeZone` fields from `AgentProfileContext` and their plumbing through the render path;
- narrows `EnvironmentDisclosureSnapshot` to `cwd` (the `date` union branch only existed to compensate for `${now}`), simplifying `normalizeAgentProfile` and the disclosure merge logic;
- makes date-change reminders the sole date-disclosure channel: the bind-time snapshot no longer acts as a disclosure baseline (`dateFromProfile` and its branch are gone);
- updates the wire/state manifests, user docs (the en/zh agent-file template variable tables), and tests accordingly: the dateChange injection tests are rewritten to the post-removal semantics (dates in system prompt text are ignored, the first step always discloses the current date, dated reminders cover cross-day rollovers), and the test harness's date-change muting switches from the `disclosed` flag to an owned-mismatch cwd.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
