### PR TITLE
fix(vscode): restore todo list card display

### DIFF
--- a/.changeset/clean-todos-display.md
+++ b/.changeset/clean-todos-display.md
@@ -1,0 +1,5 @@
+---
+'@moonshot-ai/kimi-code-sdk': patch
+---
+
+Restore structured TodoList display metadata for v2 sessions so SDK consumers can render todo items and statuses.

--- a/packages/agent-core-v2/src/agent/toolExecutor/toolExecutorService.ts
+++ b/packages/agent-core-v2/src/agent/toolExecutor/toolExecutorService.ts
@@ -882,6 +882,7 @@ function normalizeToolResult(result: ExecutableToolResult): ToolResult {
   }
   const base: {
     output: ToolResult['output'];
+    display?: ToolInputDisplay;
     stopTurn?: boolean;
     truncated?: true;
     note?: string;
@@ -889,6 +890,7 @@ function normalizeToolResult(result: ExecutableToolResult): ToolResult {
     spillExempt?: true;
   } = {
     output,
+    display: result.display,
     stopTurn: result.stopTurn,
     spill: result.spill,
     spillExempt: result.spillExempt,

--- a/packages/agent-core-v2/src/features/todo/tools/todo-list/todoListTool.ts
+++ b/packages/agent-core-v2/src/features/todo/tools/todo-list/todoListTool.ts
@@ -42,6 +42,10 @@ export class TodoListTool implements ITodoListTool {
           : 'Updating todo list';
     return {
       description,
+      display: {
+        kind: 'todo_list',
+        items: (args.todos ?? this.todo.get()).map((todo) => ({ ...todo })),
+      },
       approvalRule: this.name,
       execute: async () => {
         if (args.todos === undefined) {

--- a/packages/agent-core-v2/src/features/todo/tools/todo-list/todoListTool.ts
+++ b/packages/agent-core-v2/src/features/todo/tools/todo-list/todoListTool.ts
@@ -42,14 +42,22 @@ export class TodoListTool implements ITodoListTool {
           : 'Updating todo list';
     return {
       description,
-      display: {
-        kind: 'todo_list',
-        items: (args.todos ?? this.todo.get()).map((todo) => ({ ...todo })),
-      },
+      display:
+        args.todos === undefined
+          ? undefined
+          : {
+              kind: 'todo_list',
+              items: args.todos.map((todo) => ({ ...todo })),
+            },
       approvalRule: this.name,
       execute: async () => {
         if (args.todos === undefined) {
-          return { isError: false, output: renderTodoList(this.todo.get()) };
+          const current = this.todo.get().map((todo) => ({ ...todo }));
+          return {
+            isError: false,
+            output: renderTodoList(current),
+            display: { kind: 'todo_list' as const, items: current },
+          };
         }
 
         const next: readonly TodoItem[] = args.todos.map((todo) => ({

--- a/packages/agent-core-v2/src/tool/toolContract.ts
+++ b/packages/agent-core-v2/src/tool/toolContract.ts
@@ -31,6 +31,7 @@ export interface ToolDelivery {
 
 export interface ExecutableToolSuccessResult {
   readonly output: ExecutableToolOutput;
+  readonly display?: ToolInputDisplay;
   readonly isError?: false | undefined;
   readonly stopTurn?: boolean | undefined;
   readonly truncated?: boolean | undefined;
@@ -43,6 +44,7 @@ export interface ExecutableToolSuccessResult {
 export interface ExecutableToolErrorResult {
   readonly output: ExecutableToolOutput;
   readonly isError: true;
+  readonly display?: ToolInputDisplay;
   readonly stopTurn?: boolean | undefined;
   readonly truncated?: boolean | undefined;
   readonly note?: string;

--- a/packages/agent-core-v2/test/agent/toolExecutor/toolExecutor.test.ts
+++ b/packages/agent-core-v2/test/agent/toolExecutor/toolExecutor.test.ts
@@ -589,6 +589,28 @@ describe('AgentToolExecutorService', () => {
     });
   });
 
+  it('preserves a display produced at execution time in the final result', async () => {
+    const tool = new TestTool('dynamic-display', {
+      result: {
+        output: 'current state',
+        display: {
+          kind: 'generic',
+          summary: 'Resolved during execution',
+          detail: { value: 2 },
+        },
+      },
+    });
+    registry.register(tool);
+
+    const [result] = await execute([toolCall('call_dynamic_display', 'dynamic-display', {})]);
+
+    expect(result?.display).toEqual({
+      kind: 'generic',
+      summary: 'Resolved during execution',
+      detail: { value: 2 },
+    });
+  });
+
   it('captures tool execution failures as error results', async () => {
     const tool = new TestTool('fail', {
       execute: async () => {

--- a/packages/agent-core-v2/test/features/todo/tools/todo-list.test.ts
+++ b/packages/agent-core-v2/test/features/todo/tools/todo-list.test.ts
@@ -153,7 +153,7 @@ describe('TodoListTool', () => {
     expect(updateExecution.description).toBe('Updating todo list');
   });
 
-  it('exposes a defensive todo-list display for query, update, and clear modes', () => {
+  it('defers query display until execution while writes expose defensive input displays', async () => {
     const current: TodoItem[] = [{ title: 'existing', status: 'in_progress' }];
     const { tool } = makeTool(current);
     const next: TodoItem[] = [{ title: 'next', status: 'pending' }];
@@ -170,23 +170,37 @@ describe('TodoListTool', () => {
       throw new TypeError('expected runnable executions');
     }
 
-    expect(readExecution.display).toEqual({
-      kind: 'todo_list',
-      items: [{ title: 'existing', status: 'in_progress' }],
-    });
+    expect(readExecution.display).toBeUndefined();
     expect(updateExecution.display).toEqual({
       kind: 'todo_list',
       items: [{ title: 'next', status: 'pending' }],
     });
     expect(clearExecution.display).toEqual({ kind: 'todo_list', items: [] });
 
-    current[0] = { title: 'mutated current', status: 'done' };
     next[0] = { title: 'mutated next', status: 'done' };
-    expect(readExecution.display).toEqual({
-      kind: 'todo_list',
-      items: [{ title: 'existing', status: 'in_progress' }],
-    });
     expect(updateExecution.display).toEqual({
+      kind: 'todo_list',
+      items: [{ title: 'next', status: 'pending' }],
+    });
+
+    next[0] = { title: 'next', status: 'pending' };
+    await updateExecution.execute({
+      turnId: 1,
+      toolCallId: 'update',
+      signal,
+    });
+    const readResult = await readExecution.execute({
+      turnId: 1,
+      toolCallId: 'read',
+      signal,
+    });
+    expect(readResult.display).toEqual({
+      kind: 'todo_list',
+      items: [{ title: 'next', status: 'pending' }],
+    });
+
+    current[0] = { title: 'mutated current', status: 'done' };
+    expect(readResult.display).toEqual({
       kind: 'todo_list',
       items: [{ title: 'next', status: 'pending' }],
     });

--- a/packages/agent-core-v2/test/features/todo/tools/todo-list.test.ts
+++ b/packages/agent-core-v2/test/features/todo/tools/todo-list.test.ts
@@ -152,4 +152,43 @@ describe('TodoListTool', () => {
     expect(clearExecution.description).toBe('Clearing todo list');
     expect(updateExecution.description).toBe('Updating todo list');
   });
+
+  it('exposes a defensive todo-list display for query, update, and clear modes', () => {
+    const current: TodoItem[] = [{ title: 'existing', status: 'in_progress' }];
+    const { tool } = makeTool(current);
+    const next: TodoItem[] = [{ title: 'next', status: 'pending' }];
+
+    const readExecution = tool.resolveExecution({});
+    const updateExecution = tool.resolveExecution({ todos: next });
+    const clearExecution = tool.resolveExecution({ todos: [] });
+
+    if (
+      readExecution.isError === true ||
+      updateExecution.isError === true ||
+      clearExecution.isError === true
+    ) {
+      throw new TypeError('expected runnable executions');
+    }
+
+    expect(readExecution.display).toEqual({
+      kind: 'todo_list',
+      items: [{ title: 'existing', status: 'in_progress' }],
+    });
+    expect(updateExecution.display).toEqual({
+      kind: 'todo_list',
+      items: [{ title: 'next', status: 'pending' }],
+    });
+    expect(clearExecution.display).toEqual({ kind: 'todo_list', items: [] });
+
+    current[0] = { title: 'mutated current', status: 'done' };
+    next[0] = { title: 'mutated next', status: 'done' };
+    expect(readExecution.display).toEqual({
+      kind: 'todo_list',
+      items: [{ title: 'existing', status: 'in_progress' }],
+    });
+    expect(updateExecution.display).toEqual({
+      kind: 'todo_list',
+      items: [{ title: 'next', status: 'pending' }],
+    });
+  });
 });


### PR DESCRIPTION
## Related Issue

Resolve #3059

## Problem

The v2 TodoList tool did not attach its structured todo display to tool-call events, so the VS Code extension received an empty display and rendered only the fallback “Todo list updated” text. The context-usage portion of #3059 is handled separately by #3098.

## What changed

- Restore `todo_list` display metadata for v2 TodoList read, update, and clear calls.
- Defensively copy display items so later input or runtime mutations cannot change an emitted tool call.
- Add focused regression coverage for all three modes.
- Add a patch changeset for the SDK event behavior.

## Verification

- `pnpm exec vitest run packages/agent-core-v2/test/features/todo/tools/todo-list.test.ts` (7 passed)
- `pnpm exec vitest run apps/vscode/test/event-adapter.test.ts` (29 passed)
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck`
- `pnpm exec oxlint --type-aware packages/agent-core-v2/src/features/todo/tools/todo-list/todoListTool.ts packages/agent-core-v2/test/features/todo/tools/todo-list.test.ts`
- `pnpm --filter @moonshot-ai/agent-core-v2 run lint:imports`
- `git diff --check`

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue approved by a maintainer.
- [x] I have added tests that prove the fix works.
- [x] Added the required SDK patch changeset.
- [x] No documentation update is needed; this restores the existing structured display contract.