### PR TITLE
fix(transcript): drop duplicated and fragmented assistant text lines in the web transcript

### DIFF
--- a/.changeset/fix-transcript-heal-duplicate-lines.md
+++ b/.changeset/fix-transcript-heal-duplicate-lines.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix duplicated text lines in assistant messages shown in the web transcript after a turn ends.

--- a/.changeset/fix-transcript-heal-duplicate-lines.md
+++ b/.changeset/fix-transcript-heal-duplicate-lines.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix duplicated text lines in assistant messages shown in the web transcript after a turn ends.
+Fix assistant messages in the web transcript showing duplicated or fragmented text lines.

--- a/packages/kap-server/src/services/transcript/transcriptService.ts
+++ b/packages/kap-server/src/services/transcript/transcriptService.ts
@@ -744,6 +744,17 @@ export function healTurnOps(
       ) {
         continue;
       }
+      if (
+        liveStep.frames.some((entry) => {
+          if (entry.frameId === frame.frameId || entry.kind !== frame.kind) return false;
+          if (entry.text.length < frame.text.length || !entry.text.includes(frame.text)) {
+            return false;
+          }
+          return frame.kind !== 'text' || entry.kind !== 'text' || entry.role === frame.role;
+        })
+      ) {
+        continue;
+      }
       ops.push({ op: 'frame.upsert', turnId: snapshotTurn.turnId, stepId: step.stepId, frame });
     }
   }

--- a/packages/kap-server/test/services/transcript.test.ts
+++ b/packages/kap-server/test/services/transcript.test.ts
@@ -3528,6 +3528,59 @@ describe('bindSessionTranscript', () => {
     expect(frames).toContainEqual(expect.objectContaining({ kind: 'text', frameId: 't0.1.f2', text: 'Hello world' }));
   });
 
+  it('skips cold per-delta frames already covered by the live consolidated frame', () => {
+    const full =
+      "Sure, here's one:\n\nWhy do programmers prefer dark mode?\n\nBecause light attracts bugs.";
+    const snapshotTurn: TranscriptTurn = {
+      kind: 'turn',
+      turnId: 't0',
+      ordinal: 0,
+      state: 'completed',
+      origin: { kind: 'user' },
+      steps: [
+        {
+          kind: 'step',
+          stepId: 't0.1',
+          turnId: 't0',
+          ordinal: 1,
+          state: 'completed',
+          frames: [
+            { kind: 'thinking', frameId: 't0.1.f1', text: 'plan' },
+            { kind: 'text', frameId: 't0.1.f2', role: 'assistant', text: 'Sure' },
+            { kind: 'text', frameId: 't0.1.f3', role: 'assistant', text: ", here's one" },
+            { kind: 'text', frameId: 't0.1.f4', role: 'assistant', text: ':' },
+            { kind: 'text', frameId: 't0.1.f5', role: 'assistant', text: '\n\nWhy do programmers' },
+          ],
+        },
+      ],
+    };
+    const liveTurn: TranscriptTurn = {
+      kind: 'turn',
+      turnId: 't0',
+      ordinal: 0,
+      state: 'completed',
+      origin: { kind: 'user' },
+      steps: [
+        {
+          kind: 'step',
+          stepId: 't0.1',
+          turnId: 't0',
+          ordinal: 1,
+          state: 'completed',
+          frames: [
+            { kind: 'thinking', frameId: 't0.1.f1', text: 'plan' },
+            { kind: 'text', frameId: 't0.1.f2', role: 'assistant', text: full },
+          ],
+        },
+      ],
+    };
+
+    const frames = healTurnOps(snapshotTurn, liveTurn)
+      .filter((op): op is FrameUpsertOp => op.op === 'frame.upsert')
+      .map((op) => op.frame);
+    expect(frames).toHaveLength(0);
+  });
+
   it('heals missing tool frames and missed results, keeps richer live ones', () => {
     const makeTurn = (frames: TranscriptTurn['steps'][number]['frames']): TranscriptTurn => ({
       kind: 'turn',

--- a/packages/transcript/src/history/groupTurns.ts
+++ b/packages/transcript/src/history/groupTurns.ts
@@ -338,9 +338,19 @@ export function groupMessagesIntoSnapshot(
       pendingNotificationFrames = [];
       for (const part of message.content ?? []) {
         if (part.type === 'text' && 'text' in part && typeof part.text === 'string' && part.text.length > 0) {
-          step.frames.push({ kind: 'text', frameId: nextFrameId(), role: 'assistant', text: part.text });
+          const last = step.frames.at(-1);
+          if (last !== undefined && last.kind === 'text' && last.role === 'assistant') {
+            step.frames[step.frames.length - 1] = { ...last, text: last.text + part.text };
+          } else {
+            step.frames.push({ kind: 'text', frameId: nextFrameId(), role: 'assistant', text: part.text });
+          }
         } else if (part.type === 'think' && 'think' in part && typeof part.think === 'string' && part.think.length > 0) {
-          step.frames.push({ kind: 'thinking', frameId: nextFrameId(), text: part.think });
+          const last = step.frames.at(-1);
+          if (last !== undefined && last.kind === 'thinking') {
+            step.frames[step.frames.length - 1] = { ...last, text: last.text + part.think };
+          } else {
+            step.frames.push({ kind: 'thinking', frameId: nextFrameId(), text: part.think });
+          }
         }
       }
       for (const call of message.toolCalls ?? []) {

--- a/packages/transcript/test/layers.test.ts
+++ b/packages/transcript/test/layers.test.ts
@@ -471,6 +471,36 @@ describe('groupMessagesIntoSnapshot (cold path)', () => {
     expect(marker?.kind === 'marker' && marker.marker).toBe('compaction');
   });
 
+  it('coalesces assistant text fragments split by empty think parts into one frame', () => {
+    const snapshot = groupMessagesIntoSnapshot([
+      { role: 'user', content: [{ type: 'text', text: 'hi' }], toolCalls: [], origin: { kind: 'user' } },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'think', think: 'plan' },
+          { type: 'text', text: 'Why do programmers' },
+          { type: 'think', think: '' },
+          { type: 'text', text: ' prefer dark mode?' },
+          { type: 'think', think: '' },
+          { type: 'text', text: ' Because light attracts bugs.' },
+        ],
+        toolCalls: [],
+      },
+    ]);
+
+    const turn = snapshot.items[0];
+    if (turn?.kind !== 'turn') throw new Error('expected turn');
+    expect(turn.steps).toHaveLength(1);
+    expect(turn.steps[0]?.frames).toEqual([
+      expect.objectContaining({ kind: 'thinking', text: 'plan' }),
+      expect.objectContaining({
+        kind: 'text',
+        role: 'assistant',
+        text: 'Why do programmers prefer dark mode? Because light attracts bugs.',
+      }),
+    ]);
+  });
+
   it('folds task-notification user messages into the current turn instead of opening their own', () => {
     const snapshot = groupMessagesIntoSnapshot(
       [


### PR DESCRIPTION
## Related Issue

Resolve #3387

## Problem

After a turn ends, the transcript heal pass merges the cold (wire-rebuilt) snapshot into the live store. `healTurnOps` deduped text/thinking frames only by `frameId`. For steps whose stream persisted one `content.part` per delta (e.g. OpenAI-compatible reasoning streams that interleave an empty `think` part per chunk, preventing text-part merging), the cold rebuild produces one text frame per delta: `f2` collides with the live consolidated frame and is skipped, but `f3…fN` have no live counterpart and get appended on top of it. The web transcript then renders the full message followed by the leftover stream chunks as extra lines; the same merge at attach-time backfill shows it on reopened sessions too.

The same fragmentation also escapes the heal path entirely: when a session is cold (server restart, or a session reopened later), the REST transcript route serves the cold snapshot directly with no live store to heal against, so the message renders as one line per stream fragment.

## What changed

In `healTurnOps` (`packages/kap-server/src/services/transcript/transcriptService.ts`), after the existing same-`frameId` length check, skip a snapshot text/thinking frame when any other same-kind (and same-role for text) live frame in the step already contains its text (`length >=` + `includes`). Every per-delta leftover is a substring of the live consolidated frame, so they all disappear and the ended step renders exactly like an intermediate step (one thinking + one text frame).

In `groupMessagesIntoSnapshot` (`packages/transcript/src/history/groupTurns.ts`), coalesce adjacent assistant text frames (and adjacent thinking frames) within a step during the cold rebuild. Per-delta fragments merge back into a single frame, so cold renders match the live consolidated view. Genuinely separate frames are unaffected: they are never adjacent same-kind (text around a tool call has the tool frame in between; user-role notification frames differ by role).

Existing heal semantics are preserved:

- A longer cold frame that merely *extends* a shorter live one (the missing-stream-prefix case, covered by the existing 'kind-mismatch' test) is not contained in the live text, so it still heals.
- Same-`frameId` handling, tool-frame healing, and the live-attachment-id preference are untouched.

Added regression tests on both paths: live consolidated frame + cold per-delta frames → heal emits zero `frame.upsert` ops; assistant content with text parts interleaved by empty think parts → one consolidated text frame. Verified with `vitest run test/services/transcript.test.ts` (kap-server; the suite's single unrelated failure on my box is `git init -b` requiring git ≥ 2.28), the `@moonshot-ai/transcript` suite (82/82), and `tsc --noEmit` on both packages.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve` — awaiting approval on #3387).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
