### PR TITLE
fix(cli): default the workspace trust prompt to "Trust this folder"

### DIFF
--- a/.changeset/trust-prompt-default-trust.md
+++ b/.changeset/trust-prompt-default-trust.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Default the workspace trust prompt selection to "Trust this folder" instead of "Don't trust".

--- a/apps/kimi-code/src/tui/components/dialogs/trust-prompt.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/trust-prompt.ts
@@ -43,7 +43,7 @@ const OPTIONS: readonly TrustPromptOption[] = [
 
 export class TrustPromptComponent implements Component, Focusable {
   focused = false;
-  private selectedIndex = 1;
+  private selectedIndex = 0;
 
   constructor(private readonly opts: TrustPromptOptions) {}
 

--- a/apps/kimi-code/test/tui/components/dialogs/trust-prompt.test.ts
+++ b/apps/kimi-code/test/tui/components/dialogs/trust-prompt.test.ts
@@ -55,7 +55,7 @@ describe('TrustPromptComponent', () => {
     expect(text).not.toContain('\u001B]8;;https://evil.test');
   });
 
-  it("defaults to Don't trust", () => {
+  it('defaults to Trust this folder', () => {
     const onSelect = vi.fn();
     const prompt = new TrustPromptComponent({
       workDir: '/tmp/demo-workspace',
@@ -63,10 +63,10 @@ describe('TrustPromptComponent', () => {
       onSelect,
     });
     prompt.handleInput('\r');
-    expect(onSelect).toHaveBeenCalledWith('distrust');
+    expect(onSelect).toHaveBeenCalledWith('trust');
   });
 
-  it('selects trust only after moving to it explicitly', () => {
+  it('stays on trust when moving up past the top', () => {
     const onSelect = vi.fn();
     const prompt = new TrustPromptComponent({
       workDir: '/tmp/demo-workspace',

--- a/docs/en/customization/mcp.md
+++ b/docs/en/customization/mcp.md
@@ -23,7 +23,7 @@ Run `/mcp-config` in the TUI to interactively add, edit, or delete servers witho
 
 Deleting a server from the configuration does not interrupt open sessions: the server stays listed in `/mcp` as `removed`, its tools remain visible there, and calls to them fail with a removal notice, while new sessions do not register the tools at all. Conversely, a server added mid-session — by editing `mcp.json` or installing a plugin — is not registered in already-open sessions; it only joins sessions created later.
 
-When Kimi Code finds project-level MCP servers in an untrusted folder, it shows each server's transport and launch target in the workspace trust prompt. The prompt defaults to `Don't trust`; move to `Trust this folder` and confirm only after reviewing the listed command and arguments or remote URL. Trusting the folder enables the project-level MCP servers for that workspace.
+When Kimi Code finds project-level MCP servers in an untrusted folder, it shows each server's transport and launch target in the workspace trust prompt. The prompt defaults to `Trust this folder`; review the listed command and arguments or remote URL before confirming. Trusting the folder enables the project-level MCP servers for that workspace.
 
 Structure of `mcp.json`:
 

--- a/docs/zh/customization/mcp.md
+++ b/docs/zh/customization/mcp.md
@@ -23,7 +23,7 @@ MCP server 配置写在 `mcp.json` 中，分两层：
 
 从配置中删除某个 server 不会打断进行中的会话：该 server 在 `/mcp` 中仍显示为 `removed`，其工具在这些会话中保持可见，但调用会失败并返回移除提示；新会话则完全不会注册这些工具。反过来，会话进行中新增的 server——无论是编辑 `mcp.json` 还是安装 plugin——都不会注册到已打开的会话中，只会加入之后创建的会话。
 
-当 Kimi Code 在不受信任的文件夹中发现项目级 MCP server 时，工作区信任提示会显示每个 server 的传输方式和启动目标。提示默认选中 `Don't trust`；请先移动到 `Trust this folder`，核对列出的命令与参数或远程 URL 后，再确认信任。信任文件夹后，该工作区的项目级 MCP server 才会启用。
+当 Kimi Code 在不受信任的文件夹中发现项目级 MCP server 时，工作区信任提示会显示每个 server 的传输方式和启动目标。提示默认选中 `Trust this folder`；请先核对列出的命令与参数或远程 URL，再确认信任。信任文件夹后，该工作区的项目级 MCP server 才会启用。
 
 `mcp.json` 的结构：
 


### PR DESCRIPTION
## Related Issue

N/A — internal UX change, no tracking issue.

## Problem

On every launch in an untrusted folder, the workspace trust prompt highlighted `Don't trust` by default, so the common path — trusting your own project — cost an extra cursor move each time.

## What changed

- `TrustPromptComponent` now initializes its selection on `Trust this folder` instead of `Don't trust`. Esc still resolves to "don't trust", and moving the cursor down still selects `Don't trust`.
- Updated the component tests: default Enter now selects trust; moving up past the top stays on trust.
- Synced the en/zh MCP customization docs, which described the old default.
- Added a patch changeset.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.