### PR TITLE
fix(acp): make session/set_mode plan idempotent on sessions created in plan mode

### DIFF
--- a/.changeset/acp-set-mode-plan.md
+++ b/.changeset/acp-set-mode-plan.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix ACP `session/set_mode` failing with "Already in plan mode" right after creating a session when it was created in plan mode.

--- a/packages/acp-server/src/session.ts
+++ b/packages/acp-server/src/session.ts
@@ -358,6 +358,15 @@ export class AcpSession {
         error: error instanceof Error ? error.message : String(error),
       });
     }
+    // A session created while `default_plan_mode` is enabled enters plan mode
+    // at create time (`sessionLifecycleService`). Reflect that engine state in
+    // the ACP mode so `session/new` reports `plan` instead of the local
+    // `default` default — otherwise a client that sets an explicit mode right
+    // after creation re-enters plan and trips the engine's "Already in plan
+    // mode" guard.
+    if (await this.isPlanActive()) {
+      this.currentModeId = 'plan';
+    }
     // Awaited: the post-`session/new` `available_commands_update` must already
     // carry the skills (see `activateSession`).
     await this.refreshSkills();
@@ -1102,14 +1111,22 @@ export class AcpSession {
   /** Switch the ACP mode (plan mode + permission mode). */
   async setMode(id: AcpModeId): Promise<void> {
     const { plan, permission } = acpModeToToggles(id);
-    if (plan) {
-      await this.agent.enterPlan();
-    } else {
-      // KLIENT-GAP(plan): `exitPlan` (`planService.exit()`) is not on the
-      // klient surface; `cancelPlan` (`planModeCancel`) has the identical
-      // state effect (see `agent/plan/planOps.ts`) — only the persisted op
-      // name differs.
-      await this.agent.cancelPlan();
+    // Idempotent plan toggle: only enter/cancel when the engine's plan state
+    // differs from the target, so a client re-asserting the active mode (e.g.
+    // `set_mode "plan"` right after `session/new` while the engine already
+    // entered plan mode via `default_plan_mode`) does not trip the engine's
+    // "Already in plan mode" guard.
+    const planActive = await this.isPlanActive();
+    if (plan !== planActive) {
+      if (plan) {
+        await this.agent.enterPlan();
+      } else {
+        // KLIENT-GAP(plan): `exitPlan` (`planService.exit()`) is not on the
+        // klient surface; `cancelPlan` (`planModeCancel`) has the identical
+        // state effect (see `agent/plan/planOps.ts`) — only the persisted op
+        // name differs.
+        await this.agent.cancelPlan();
+      }
     }
     await this.agent.setPermission(permission);
     this.currentModeId = id;
@@ -1119,6 +1136,24 @@ export class AcpSession {
     // observable — klient exposes no permission/plan change event.)
     this.emit(currentModeUpdateNotification(this.sessionId, id));
     await this.emitConfigOptionUpdate();
+  }
+
+  /**
+   * Whether the engine's plan mode is currently active, as reported by the
+   * agent plan service's `status` (non-null while a plan is open). Best-effort:
+   * a transient read failure degrades to `false` so `setMode` falls back to the
+   * unconditional toggle rather than rejecting a call that previously worked.
+   */
+  private async isPlanActive(): Promise<boolean> {
+    try {
+      return (await this.agent.getPlan()) !== null;
+    } catch (error) {
+      log.warn('acp: could not read plan mode state', {
+        sessionId: this.sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
   }
 
   /** Push a fresh `config_option_update` to the client. */

--- a/packages/acp-server/test/config.test.ts
+++ b/packages/acp-server/test/config.test.ts
@@ -104,6 +104,31 @@ describe('acp-server config surface', () => {
   );
 
   it(
+    'session/set_mode plan succeeds when default_plan_mode already entered plan mode',
+    async () => {
+      homeDir = await mkdtemp(join(tmpdir(), 'acp-config-'));
+      await writeFile(join(homeDir, 'config.toml'), 'default_plan_mode = true\n', 'utf8');
+      client = await createTestClient({ homeDir });
+      await client.send('initialize', { protocolVersion: 1, clientCapabilities: {} });
+      const { sessionId, modes } = (await client!.send('session/new', {
+        cwd: homeDir,
+        mcpServers: [],
+      })) as NewSessionResult;
+      // The engine entered plan mode at create time, so session/new must report
+      // it — a client that then sets an explicit plan mode must not hit the
+      // "Already in plan mode" guard.
+      expect(modes?.currentModeId).toBe('plan');
+
+      const result = await client!.send('session/set_mode', {
+        sessionId,
+        modeId: 'plan',
+      });
+      expect(result).toEqual({});
+    },
+    30_000,
+  );
+
+  it(
     'session/set_mode pushes current_mode_update alongside config_option_update',
     async () => {
       await boot();
@@ -133,6 +158,7 @@ describe('acp-server config surface', () => {
       const session = Object.create(AcpSession.prototype) as AcpSession;
       const updates: unknown[] = [];
       const agent = {
+        getPlan: async () => null,
         enterPlan: async () => {
           throw new Error('plan toggle failed');
         },


### PR DESCRIPTION
## Related Issue

Resolve #3356

## Problem

Over ACP, `session/set_mode` with `modeId: "plan"` fails with `-32603 Internal error` ("Already in plan mode") right after `session/new` reports `currentModeId: "default"`. When `default_plan_mode = true`, the engine enters plan mode at session creation, but the ACP server's local mode state stays `"default"` and `setMode` re-enters plan unconditionally, tripping the engine's guard. ACP clients that apply a configured plan mode right after `session/new` abort session creation entirely.

## What changed

In `packages/acp-server/src/session.ts`:

- Seed the local `currentModeId` from the engine's actual plan state during session init, so `session/new` truthfully reports `"plan"` when the engine entered plan mode at create time.
- Make `setMode`'s plan toggle idempotent — only call `enterPlan`/`cancelPlan` when the engine's plan state differs from the requested mode — so re-asserting the active mode no longer throws "Already in plan mode".

Added an integration test in `packages/acp-server/test/config.test.ts` that boots with `default_plan_mode = true`, asserts `session/new` reports `plan`, and verifies `session/set_mode "plan"` succeeds.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.