### PR TITLE
refactor(agent-core-v2): deliver the subagent fork notice via reminder injection

### DIFF
--- a/.changeset/fork-context-notice-reminder.md
+++ b/.changeset/fork-context-notice-reminder.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Send the forked-subagent context notice as a system reminder.

--- a/packages/agent-core-v2/src/session/subagent/subagentService.ts
+++ b/packages/agent-core-v2/src/session/subagent/subagentService.ts
@@ -31,6 +31,7 @@ import { RuntimeWorkspaceView } from '#/runtime/runtimeWorkspaceView';
 import { createHooks } from '#/hooks';
 import { IAgentLifecycleService, MAIN_AGENT_ID } from '#/session/agentLifecycle/agentLifecycle';
 import { agentContextOf } from '#/agent/scopeContext/scopeContext';
+import { IAgentReminderService } from '#/features/reminder/reminderService';
 
 import {
   type AgentRunHandle,
@@ -166,6 +167,9 @@ export class SessionSubagentService extends Service implements ISessionSubagentS
             labels: opts.labels,
           });
           created = this.agentLifecycle.handleOf(forked.agentId)!;
+          created.accessor
+            .get(IAgentReminderService)
+            .notify(FORK_CONTEXT_NOTICE, { variant: 'fork_context' });
         } else {
           const createdContext = await this.agentLifecycle.create({
             binding: {
@@ -197,7 +201,7 @@ export class SessionSubagentService extends Service implements ISessionSubagentS
         createdUserTools.inheritUserTools(callerUserTools);
       }
       const promptText = plan.fork
-        ? `${FORK_CONTEXT_NOTICE}\n\n${opts.prompt}`
+        ? opts.prompt
         : await this.applyPromptPrefix(plan.profileName, opts.prompt, lease!.runtime);
       return {
         agentId: created.id,

--- a/packages/agent-core-v2/test/session/subagent/forkParity.test.ts
+++ b/packages/agent-core-v2/test/session/subagent/forkParity.test.ts
@@ -24,6 +24,7 @@ import { IAgentLifecycleService } from '#/session/agentLifecycle/agentLifecycle'
 import { IFlagService } from '#/app/flag/flag';
 import { SUBAGENT_FORK_FLAG_ID } from '#/session/subagent/flag';
 import { FORK_CONTEXT_NOTICE } from '#/session/subagent/spawn';
+import { wrapSystemReminder } from '#/features/reminder/systemReminder';
 import { AGENT_WIRE_RECORD_KEY, type WireRecord } from '#/wire/record';
 import {
   IRuntimeResolver,
@@ -189,14 +190,17 @@ describe('fork subagent first-request parity', () => {
     expect(prefix).toEqual(parentReq.history);
 
     const tail = childReq.history.slice(parentReq.history.length);
-    expect(tail.map((message) => message.role)).toEqual(['assistant', 'tool', 'user']);
+    expect(tail.map((message) => message.role)).toEqual(['assistant', 'tool', 'user', 'user']);
     expect(tail[0]?.toolCalls.map((call) => call.name)).toEqual(['Agent']);
     expect(tail[0]?.partial).toBeUndefined();
     expect(tail[1]?.toolCallId).toBe('call_fork');
     expect(tail[1]?.content).toEqual([{ type: 'text', text: INHERITED_IN_FLIGHT_TOOL_OUTPUT }]);
     const notice = tail[2]?.content[0];
     expect(notice?.type).toBe('text');
-    expect(notice?.type === 'text' && notice.text.startsWith(FORK_CONTEXT_NOTICE)).toBe(true);
+    expect(notice?.type === 'text' && notice.text).toBe(wrapSystemReminder(FORK_CONTEXT_NOTICE));
+    const prompt = tail[3]?.content[0];
+    expect(prompt?.type).toBe('text');
+    expect(prompt?.type === 'text' && prompt.text).toBe('finish the inherited task');
 
     expect(parentFollowup.history.slice(0, parentReq.history.length)).toEqual(parentReq.history);
     expect(parentFollowup.history[parentReq.history.length]).toEqual(tail[0]);

--- a/packages/agent-core-v2/test/session/subagent/spawn.test.ts
+++ b/packages/agent-core-v2/test/session/subagent/spawn.test.ts
@@ -36,6 +36,7 @@ import {
   type SubagentSpawnPlan,
   type SubagentSpawnPlanInput,
 } from '#/session/subagent/spawn';
+import { IAgentReminderService } from '#/features/reminder/reminderService';
 
 import { stubLog } from '../../_base/log/stubs';
 import { stubFlag } from '../../app/flag/stubs';
@@ -60,6 +61,7 @@ describe('SessionSubagentService planSpawn and spawn', () => {
   let createdPermissionMode: { mode: string; setMode: ReturnType<typeof vi.fn> };
   let callerUserTools: IAgentUserToolService;
   let createdUserTools: IAgentUserToolService;
+  let createdReminder: { notify: ReturnType<typeof vi.fn> };
   let lease: RuntimeLease;
 
   function userToolsStub(): IAgentUserToolService {
@@ -91,6 +93,7 @@ describe('SessionSubagentService planSpawn and spawn', () => {
           }
           if (serviceId === IAgentPermissionModeService) return createdPermissionMode;
           if (serviceId === IAgentUserToolService) return createdUserTools;
+          if (serviceId === IAgentReminderService) return createdReminder;
           return undefined;
         },
       } as IAgentScopeHandle['accessor'],
@@ -127,6 +130,7 @@ describe('SessionSubagentService planSpawn and spawn', () => {
     createdPermissionMode = { mode: 'manual', setMode: vi.fn() };
     callerUserTools = userToolsStub();
     createdUserTools = userToolsStub();
+    createdReminder = { notify: vi.fn() };
     lease = {
       runtime: new FakeRuntime({ workspaceId: 'w1', runtimeId: 'acp:s1', generation: 'g1' }),
       track: (resource) => resource,
@@ -587,7 +591,7 @@ describe('SessionSubagentService planSpawn and spawn', () => {
     ]);
   });
 
-  it('prefixes the prompt with the fork notice when the plan is a fork', async () => {
+  it('delivers the fork notice as a reminder injection when the plan is a fork', async () => {
     const svc = service();
 
     const spawned = await spawnForkChild(svc);
@@ -597,7 +601,10 @@ describe('SessionSubagentService planSpawn and spawn', () => {
       profileName: 'orchestrator',
       model: 'main-model',
       modelSource: 'inherited',
-      promptText: `${FORK_CONTEXT_NOTICE}\n\nContinue the analysis`,
+      promptText: 'Continue the analysis',
+    });
+    expect(createdReminder.notify).toHaveBeenCalledWith(FORK_CONTEXT_NOTICE, {
+      variant: 'fork_context',
     });
   });
 

--- a/packages/agent-core-v2/test/tool/tool.test.ts
+++ b/packages/agent-core-v2/test/tool/tool.test.ts
@@ -35,12 +35,12 @@ import {
   type SubagentToolInput,
 } from '#/agent/tools/agent/agent';
 import {
-  FORK_CONTEXT_NOTICE,
   FORK_EXPERIMENTAL_UNAVAILABLE,
   FORK_WITH_MODEL_UNAVAILABLE,
   FORK_WITH_RESUME_UNAVAILABLE,
   FORK_WITH_TYPE_UNAVAILABLE,
 } from '#/session/subagent/spawn';
+import { IAgentReminderService } from '#/features/reminder/reminderService';
 import { DEFAULT_SUBAGENT_TIMEOUT_MS, SECONDARY_MODEL_SECTION, SUBAGENT_SECTION } from '#/session/subagent/configSection';
 import { SUBAGENT_FORK_FLAG_ID } from '#/session/subagent/flag';
 import { Error2, ErrorCodes } from '#/errors';
@@ -308,6 +308,14 @@ function createAgentLifecycleStub(options: AgentLifecycleStubOptions = {}): Agen
             inheritUserTools: () => {},
             register: () => {},
             unregister: () => {},
+          } as never;
+        }
+        if (serviceId === IAgentReminderService) {
+          return {
+            _serviceBrand: undefined,
+            register: () => noopDisposable(),
+            notify: () => {},
+            reconcileWhenIdle: () => Promise.resolve(),
           } as never;
         }
         if (serviceId === IEventBus) {
@@ -1488,8 +1496,7 @@ describe('Agent tool execution contract', () => {
     const [runAgent, runRequest] = lifecycle.run.mock.calls[0]!;
     expect(runAgent).toMatchObject({ agentId: 'agent-child' });
     const runPrompt = runRequest.kind === 'prompt' ? runRequest.prompt : '';
-    expect(runPrompt).toContain(FORK_CONTEXT_NOTICE);
-    expect(runPrompt).toContain('Continue the analysis');
+    expect(runPrompt).toBe('Continue the analysis');
   });
 
   it('forks without requiring the caller profile in the catalog', async () => {


### PR DESCRIPTION
## Related Issue

Internal change; no linked issue.

## Problem

The experimental `subagent_fork` feature frames the inherited conversation snapshot by prepending a plain-text notice to the subagent's first prompt. Plain text carries no directive authority for the model, and hand-assembling the prompt text bypasses the engine's reminder delivery architecture (model-facing reminders are delivered through `IAgentReminderService` only).

## What changed

- `SessionSubagentService.spawn` now delivers the fork context notice via `IAgentReminderService.notify` immediately after `agentLifecycle.fork` — the same fork-then-notify pattern as the btw feature. The notice lands as a `<system-reminder>` injection (variant `fork_context`) between the inherited snapshot and the first task prompt, and the run prompt is the bare task text.
- The AgentSwarm fork path inherits the behavior since it goes through the same spawn.
- Tests: `spawn` asserts the notify call and the bare prompt; `forkParity` asserts the child first-request tail is `[assistant, tool, user(notice), user(prompt)]` with system-prompt/tools/history prefix parity intact; `tool` and swarm suites updated for the new harness surface.

Behavior notes: the notice is now a `kind: 'injection'` message — hidden from the UI, not an undo anchor, and dropped by compaction (the old prompt-embedded form was folded away by compaction just the same).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (internal change, no issue).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.