### PR TITLE
test: catch fixtures up with the model-validation removal

### DIFF
--- a/packages/agent-core-v2/test/workspace/workspaceInstance/workspaceInstanceManager.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceInstance/workspaceInstanceManager.test.ts
@@ -139,10 +139,10 @@ function manager(
     { scope: () => 'sessions' },
     workspaces,
     { ready },
-    ...Array.from({ length: 23 }, () => undefined),
+    ...Array.from({ length: 21 }, () => undefined),
     new TestRuntimeUnitHostFactory(),
   ];
-  args[20] = { entries: () => [] };
+  args[18] = { entries: () => [] };
   const value = Reflect.construct(WorkspaceInstanceManager, args) as WorkspaceInstanceManager;
   const providers = (value as unknown as { providers: Map<string, RuntimeProviderFactory> }).providers;
   providers.clear();

--- a/packages/kap-server/test/config.test.ts
+++ b/packages/kap-server/test/config.test.ts
@@ -159,16 +159,16 @@ describe('server-v2 /api/v1/config', () => {
     });
   });
 
-  it('session create with a broken subagent model pool fails with VALIDATION_FAILED', async () => {
+  it('session create with a broken subagent model pool still succeeds', async () => {
     await boot('[secondary_model.models]\n"provider/fast" = "fast and cheap"\n');
     const res = await authedFetch(server as RunningServer, base, '/api/v1/sessions', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ metadata: { cwd: home as string } }),
     });
-    const body = (await res.json()) as Envelope<null>;
-    expect(body.code).toBe(ErrorCode.VALIDATION_FAILED);
-    expect(body.msg).toContain('[secondary_model].default_model is required');
+    const body = (await res.json()) as Envelope<{ id?: string }>;
+    expect(body.code).toBe(0);
+    expect(body.data?.id).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Related Issue

N/A — CI fix. Since #3411 landed, `main`'s own push CI fails two suites (see the failing run on 82bf0a8dd).

## Problem

#3411 removed session-create model validation and two positional constructor params (`modelCatalog`, `flags`) without updating the tests that encode the old shape:

- `workspaceInstanceManager.test.ts` builds the manager via `Reflect.construct` with index-pinned stubs; the removed params shift `agentProfiles` from slot 20 to 18, so the stub lands in the wrong slot and `Program.snapshot` throws `Cannot read properties of undefined (reading 'entries')` — all 8 tests fail.
- `config.test.ts` still expects a broken `[secondary_model.models]` pool to fail session create with `VALIDATION_FAILED`, which is exactly the behavior #3411 removed.

## What changed

Test-only: the fixture pins the agent-profile stub at its new slot (and shrinks the placeholder run to the new arity), and the config test asserts the new contract — creation succeeds and returns a session id.

No changeset: test-only change, nothing user-facing.