### PR TITLE
feat(agent-core-v2): report enabled experimental flags in session_started telemetry

### DIFF
--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -819,7 +819,7 @@ export async function applyExperimentalFeatureChanges(
       flags: features
         .filter((feature) => feature.enabled)
         .map((feature) => feature.id)
-        .sort()
+        .toSorted()
         .join(','),
     });
   } catch (error) {

--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -814,7 +814,14 @@ export async function applyExperimentalFeatureChanges(
       // them; only the mode machinery (enter/injection/guards) reacts live.
       host.showNotice('Tower mode takes effect after restarting Kimi Code.');
     }
-    host.track('experimental_features_apply', { changed: changes.length });
+    host.track('experimental_features_apply', {
+      changed: changes.length,
+      flags: features
+        .filter((feature) => feature.enabled)
+        .map((feature) => feature.id)
+        .sort()
+        .join(','),
+    });
   } catch (error) {
     host.showError(`Failed to update experimental features: ${formatErrorMessage(error)}`);
   }

--- a/apps/kimi-code/test/tui/commands/experiments.test.ts
+++ b/apps/kimi-code/test/tui/commands/experiments.test.ts
@@ -96,11 +96,28 @@ describe('experimental feature command handlers', () => {
     expect(host.mountEditorReplacement).not.toHaveBeenCalled();
     expect(host.track).toHaveBeenCalledWith('experimental_features_apply', {
       changed: 1,
+      flags: '',
     });
     expect(host.showStatus).not.toHaveBeenCalledWith(
       'Experimental features updated.',
       darkColors.success,
     );
+  });
+
+  it('reports the post-apply enabled flag set in telemetry', async () => {
+    const host = makeHost();
+    host.harness.getExperimentalFeatures.mockResolvedValue([
+      feature({ id: 'wait_for', enabled: true }),
+      feature({ id: 'subagent_fork', enabled: true }),
+      feature({ id: 'tower', enabled: false }),
+    ]);
+
+    await applyExperimentalFeatureChanges(host, [{ id: 'subagent_fork', enabled: true }]);
+
+    expect(host.track).toHaveBeenCalledWith('experimental_features_apply', {
+      changed: 1,
+      flags: 'subagent_fork,wait_for',
+    });
   });
 
   it('does not write config when there are no drafted changes', async () => {

--- a/packages/agent-core-v2/src/app/flag/flag.ts
+++ b/packages/agent-core-v2/src/app/flag/flag.ts
@@ -54,6 +54,7 @@ export interface IFlagService {
   enabled(id: FlagId): boolean;
   snapshot(): ExperimentalFlagMap;
   enabledIds(): readonly FlagId[];
+  exposedIds(): readonly FlagId[];
   explain(id: FlagId): ExperimentalFeatureState | undefined;
   explainAll(): readonly ExperimentalFeatureState[];
   setConfigOverrides(overrides: ExperimentalFlagConfig | undefined): void;

--- a/packages/agent-core-v2/src/app/flag/flagRegistry.ts
+++ b/packages/agent-core-v2/src/app/flag/flagRegistry.ts
@@ -1,6 +1,8 @@
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
 import type { IDisposable } from '#/_base/di/lifecycle';
 
+import type { IFlagService } from './flag';
+
 export type FlagSurface = 'core' | 'tui' | 'both';
 
 export type FlagId = string;
@@ -12,6 +14,7 @@ export interface FlagDefinitionInput {
   readonly env: string;
   readonly default: boolean;
   readonly surface: FlagSurface;
+  readonly isExposed?: (flags: IFlagService) => boolean;
 }
 
 const contributedFlags: FlagDefinitionInput[] = [];

--- a/packages/agent-core-v2/src/app/flag/flagService.ts
+++ b/packages/agent-core-v2/src/app/flag/flagService.ts
@@ -77,6 +77,14 @@ export class FlagService extends Disposable implements IFlagService {
       .map((def) => def.id);
   }
 
+  exposedIds(): readonly FlagId[] {
+    return this.registry
+      .list()
+      .filter((def) => this.enabled(def.id))
+      .filter((def) => def.isExposed?.(this) ?? true)
+      .map((def) => def.id);
+  }
+
   explainAll(): readonly ExperimentalFeatureState[] {
     return this.registry
       .list()

--- a/packages/agent-core-v2/src/app/telemetry/events.ts
+++ b/packages/agent-core-v2/src/app/telemetry/events.ts
@@ -456,6 +456,7 @@ export interface VideoUploadEvent {
 
 export interface SessionStartedEvent {
   resumed: boolean;
+  experimental_flags: string;
 }
 
 export interface SessionLoadFailedEvent {
@@ -1089,7 +1090,11 @@ export const telemetryEventDefinitions = {
   session_started: defineTelemetryEvent<SessionStartedEvent>({
     owner: 'kimi-code',
     comment: 'A session becomes active (created, forked, or resumed).',
-    properties: { resumed: 'Whether the session was resumed from disk' },
+    properties: {
+      resumed: 'Whether the session was resumed from disk',
+      experimental_flags:
+        'Sorted comma-separated ids of enabled experimental flags, empty when none are enabled',
+    },
   }),
   session_load_failed: defineTelemetryEvent<SessionLoadFailedEvent>({
     owner: 'kimi-code',

--- a/packages/agent-core-v2/src/features/tower/flag.ts
+++ b/packages/agent-core-v2/src/features/tower/flag.ts
@@ -1,6 +1,7 @@
 import { type FlagDefinitionInput, registerFlagDefinition } from '#/app/flag/flagRegistry';
 
 import { TOWER_FLAG_ID } from './tower';
+import { isTowerFeatureAssembled } from './towerFeature';
 
 export const TOWER_FLAG_ENV = 'KIMI_CODE_EXPERIMENTAL_TOWER';
 
@@ -12,6 +13,7 @@ export const towerFlag: FlagDefinitionInput = {
   env: TOWER_FLAG_ENV,
   default: false,
   surface: 'both',
+  isExposed: (flags) => isTowerFeatureAssembled(flags),
 };
 
 registerFlagDefinition(towerFlag);

--- a/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
+++ b/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
@@ -304,7 +304,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
     await this._onDidCreateSession.fireAsync(event, NO_ABORT);
     event.handle.accessor.get(ITelemetryService).track2('session_started', {
       resumed: event.source === 'resume',
-      experimental_flags: [...this.flags.enabledIds()].sort().join(','),
+      experimental_flags: this.flags.enabledIds().toSorted().join(','),
     });
   }
 

--- a/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
+++ b/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
@@ -14,6 +14,8 @@ import { ILogService } from '#/_base/log/log';
 import { drainLogCloses } from '#/_base/log/logService';
 import { DEFAULT_PLAN_MODE_SECTION } from '#/features/plan/configSection';
 import { IAgentPlanService } from '#/features/plan/plan';
+import { TOWER_FLAG_ID } from '#/features/tower/tower';
+import { isTowerFeatureAssembled } from '#/features/tower/towerFeature';
 import { LifecycleScope } from '#/app/scopes';
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { IConfigService } from '#/app/config/config';
@@ -304,7 +306,11 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
     await this._onDidCreateSession.fireAsync(event, NO_ABORT);
     event.handle.accessor.get(ITelemetryService).track2('session_started', {
       resumed: event.source === 'resume',
-      experimental_flags: this.flags.enabledIds().toSorted().join(','),
+      experimental_flags: this.flags
+        .enabledIds()
+        .filter((id) => id !== TOWER_FLAG_ID || isTowerFeatureAssembled(this.flags))
+        .toSorted()
+        .join(','),
     });
   }
 

--- a/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
+++ b/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
@@ -14,8 +14,6 @@ import { ILogService } from '#/_base/log/log';
 import { drainLogCloses } from '#/_base/log/logService';
 import { DEFAULT_PLAN_MODE_SECTION } from '#/features/plan/configSection';
 import { IAgentPlanService } from '#/features/plan/plan';
-import { TOWER_FLAG_ID } from '#/features/tower/tower';
-import { isTowerFeatureAssembled } from '#/features/tower/towerFeature';
 import { LifecycleScope } from '#/app/scopes';
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { IConfigService } from '#/app/config/config';
@@ -306,11 +304,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
     await this._onDidCreateSession.fireAsync(event, NO_ABORT);
     event.handle.accessor.get(ITelemetryService).track2('session_started', {
       resumed: event.source === 'resume',
-      experimental_flags: this.flags
-        .enabledIds()
-        .filter((id) => id !== TOWER_FLAG_ID || isTowerFeatureAssembled(this.flags))
-        .toSorted()
-        .join(','),
+      experimental_flags: this.flags.exposedIds().toSorted().join(','),
     });
   }
 

--- a/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
+++ b/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
@@ -18,6 +18,7 @@ import { LifecycleScope } from '#/app/scopes';
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { IConfigService } from '#/app/config/config';
 import { IEventService } from '#/app/event/event';
+import { IFlagService } from '#/app/flag/flag';
 import {
   CHILD_SESSION_KIND,
   CHILD_SESSION_KIND_KEY,
@@ -153,6 +154,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
     @IHostFileSystem private readonly hostFs: IHostFileSystem,
     @IEventService private readonly event: IEventService,
     @ITelemetryService private readonly telemetry: ITelemetryService,
+    @IFlagService private readonly flags: IFlagService,
     @IWorkspaceAgentProfileLoader
     private readonly workspaceAgentProfileLoader: IWorkspaceAgentProfileLoader,
     @IExtraAgentProfileLoader
@@ -300,9 +302,10 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
 
   private async announceCreated(event: SessionCreatedEvent): Promise<void> {
     await this._onDidCreateSession.fireAsync(event, NO_ABORT);
-    event.handle.accessor
-      .get(ITelemetryService)
-      .track2('session_started', { resumed: event.source === 'resume' });
+    event.handle.accessor.get(ITelemetryService).track2('session_started', {
+      resumed: event.source === 'resume',
+      experimental_flags: [...this.flags.enabledIds()].sort().join(','),
+    });
   }
 
   get(sessionId: string): ISessionScopeHandle | undefined {

--- a/packages/agent-core-v2/src/workspace/workspaceInstance/workspaceInstanceManagerService.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceInstance/workspaceInstanceManagerService.ts
@@ -8,6 +8,7 @@ import { IAgentProfileRegistry } from '#/app/agentProfileCatalog/agentProfileReg
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { IConfigService } from '#/app/config/config';
 import { IEventService } from '#/app/event/event';
+import { IFlagService } from '#/app/flag/flag';
 import { IGitService } from '#/app/git/git';
 import { IMcpOAuthService } from '#/app/mcpConfig/oauthService';
 import type { McpOAuthService } from '#/mcpCore/oauth/service';
@@ -71,6 +72,7 @@ export class WorkspaceInstanceManager implements IWorkspaceInstanceManager {
     @IBuiltinAgentProfileLoader private readonly builtinAgentProfiles: IBuiltinAgentProfileLoader,
     @IBuiltinSkillSource private readonly builtinSkills: IBuiltinSkillSource,
     @ITelemetryService private readonly telemetry: ITelemetryService,
+    @IFlagService private readonly flags: IFlagService,
     @IAppendLogStore private readonly appendLogStore: IAppendLogStore,
     @IAtomicDocumentStore private readonly docs: IAtomicDocumentStore,
     @IFileSystemStorageService private readonly storage: IFileSystemStorageService,
@@ -228,6 +230,7 @@ export class WorkspaceInstanceManager implements IWorkspaceInstanceManager {
           input.fs,
           this.event,
           this.telemetry,
+          this.flags,
           input.workspaceAgentProfiles,
           input.extraAgentProfiles,
           input.explicitAgentProfiles,

--- a/packages/agent-core-v2/test/app/flag/flag.test.ts
+++ b/packages/agent-core-v2/test/app/flag/flag.test.ts
@@ -81,6 +81,7 @@ describe('FlagService', () => {
     ix.get(IFlagRegistry).register(exampleFlag);
     return {
       registry: ix.get(IConfigRegistry),
+      flagRegistry: ix.get(IFlagRegistry),
       config: ix.get(IConfigService),
       flags: ix.get(IFlagService),
     };
@@ -164,6 +165,22 @@ describe('FlagService', () => {
     expect(flags.snapshot()).toEqual({ example_flag: true });
     expect(flags.enabledIds()).toEqual(['example_flag']);
     expect(flags.explainAll().map((s) => s.id)).toEqual(['example_flag']);
+  });
+
+  it('filters enabled flags out of exposedIds when their isExposed predicate fails', () => {
+    const { flagRegistry, flags } = makeFlags();
+    flagRegistry.register({
+      id: 'assembled_only',
+      title: 'Assembled-only flag',
+      description: 'Enabled but only exposed once its feature is assembled.',
+      env: 'KIMI_CODE_EXPERIMENTAL_ASSEMBLED_ONLY',
+      default: true,
+      surface: 'core',
+      isExposed: () => false,
+    });
+
+    expect(flags.enabledIds().toSorted()).toEqual(['assembled_only', 'example_flag']);
+    expect(flags.exposedIds()).toEqual(['example_flag']);
   });
 
   it('treats truthy env values case-insensitively', () => {

--- a/packages/agent-core-v2/test/app/flag/stubs.ts
+++ b/packages/agent-core-v2/test/app/flag/stubs.ts
@@ -20,6 +20,7 @@ export function stubFlag(enabled: boolean | ((id: string) => boolean) = false): 
     enabled: isEnabled,
     snapshot: (): ExperimentalFlagMap => ({}),
     enabledIds: () => [],
+    exposedIds: () => [],
     explain: (): ExperimentalFeatureState | undefined => undefined,
     explainAll: () => [],
     setConfigOverrides: (_overrides: ExperimentalFlagConfig | undefined) => {},

--- a/packages/agent-core-v2/test/workspace/workspaceInstance/workspaceInstanceManager.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceInstance/workspaceInstanceManager.test.ts
@@ -139,7 +139,7 @@ function manager(
     { scope: () => 'sessions' },
     workspaces,
     { ready },
-    ...Array.from({ length: 21 }, () => undefined),
+    ...Array.from({ length: 22 }, () => undefined),
     new TestRuntimeUnitHostFactory(),
   ];
   args[18] = { entries: () => [] };

--- a/packages/node-sdk/src/kimi-harness.ts
+++ b/packages/node-sdk/src/kimi-harness.ts
@@ -63,8 +63,9 @@ export interface KimiHarnessRuntimeOptions {
   /**
    * Per-emission companion to `sessionStartedProperties`: evaluated at every
    * `session_started` call, so values that can change over the process
-   * lifetime (e.g. experimental flag state) stay current. Merged after the
-   * static properties and before the per-call session-scoped ones.
+   * lifetime (e.g. experimental flag state) stay current. Its keys are
+   * engine-owned: they win over both the static and the per-call
+   * session-scoped properties, and lose only to the canonical harness fields.
    */
   readonly sessionStartedDynamicProperties?: () => TelemetryProperties;
   /**
@@ -632,8 +633,8 @@ export class KimiHarness {
   ): void {
     withTelemetryContext(this.telemetry, { sessionId: eventSessionId }).track('session_started', {
       ...this.sessionStartedProperties,
-      ...this.sessionStartedDynamicProperties?.(),
       ...sessionScoped,
+      ...this.sessionStartedDynamicProperties?.(),
       // Canonical fields are owned by the harness and must win over any
       // caller-supplied sessionStartedProperties that happen to share a key.
       // `client_id` is always null here: a single-process host has no

--- a/packages/node-sdk/src/kimi-harness.ts
+++ b/packages/node-sdk/src/kimi-harness.ts
@@ -61,6 +61,13 @@ export interface KimiHarnessRuntimeOptions {
   readonly onClose: () => void | Promise<void>;
   readonly sessionStartedProperties?: TelemetryProperties;
   /**
+   * Per-emission companion to `sessionStartedProperties`: evaluated at every
+   * `session_started` call, so values that can change over the process
+   * lifetime (e.g. experimental flag state) stay current. Merged after the
+   * static properties and before the per-call session-scoped ones.
+   */
+  readonly sessionStartedDynamicProperties?: () => TelemetryProperties;
+  /**
    * Owner-scoped [image] limits for prompt-ingestion compression in the
    * client process (paste-time, ACP prompt conversion). In-process cores
    * (SDKRpcClient) hand over their core's instance; daemon-client hosts
@@ -82,6 +89,7 @@ export class KimiHarness {
   private readonly ensureConfigFileImpl: () => Promise<void>;
   private readonly closeImpl: () => void | Promise<void>;
   private readonly sessionStartedProperties: TelemetryProperties;
+  private readonly sessionStartedDynamicProperties: (() => TelemetryProperties) | undefined;
 
   /**
    * Ingestion-side [image] limits owned by this harness's core; undefined for
@@ -102,6 +110,7 @@ export class KimiHarness {
     this.ensureConfigFileImpl = options.ensureConfigFile;
     this.closeImpl = options.onClose;
     this.sessionStartedProperties = options.sessionStartedProperties ?? {};
+    this.sessionStartedDynamicProperties = options.sessionStartedDynamicProperties;
     this.imageLimits = options.imageLimits;
   }
 
@@ -623,6 +632,7 @@ export class KimiHarness {
   ): void {
     withTelemetryContext(this.telemetry, { sessionId: eventSessionId }).track('session_started', {
       ...this.sessionStartedProperties,
+      ...this.sessionStartedDynamicProperties?.(),
       ...sessionScoped,
       // Canonical fields are owned by the harness and must win over any
       // caller-supplied sessionStartedProperties that happen to share a key.

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -208,12 +208,10 @@ import {
   IWorkspaceAliases,
   ISessionActivityView,
   IWorkspaceInstanceManager,
-  TOWER_FLAG_ID,
   closeSessionById,
   followSessionLifecycles,
   getLiveSessionById,
   isError2,
-  isTowerFeatureAssembled,
   programForSession,
   resumeSessionById,
   sessionDirOf,
@@ -549,20 +547,16 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
   }
 
   /**
-   * Enabled experimental flag ids in the `session_started` wire shape (sorted,
+   * Exposed experimental flag ids in the `session_started` wire shape (sorted,
    * comma-joined), read live from the in-process engine's flag service. The
    * harness-side `session_started` row merges this so both producers of the
-   * event carry the same flag dimension. Restart-only flags (`tower`, whose
-   * tools/profiles assemble at App construction) count only once the feature
-   * is actually assembled in this process.
+   * event carry the same flag dimension. Exposure is the flag system's own
+   * notion (`IFlagService.exposedIds`): a flag that is enabled but not yet
+   * active in this process (e.g. its feature assembles at App construction)
+   * does not count.
    */
   enabledExperimentalFlags(): string {
-    const flags = this.engineAccessor.get(IFlagService);
-    return flags
-      .enabledIds()
-      .filter((id) => id !== TOWER_FLAG_ID || isTowerFeatureAssembled(flags))
-      .toSorted()
-      .join(',');
+    return this.engineAccessor.get(IFlagService).exposedIds().toSorted().join(',');
   }
 
   /**

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -185,6 +185,7 @@ import {
   IBootstrapService,
   IConfigService,
   IEventService,
+  IFlagService,
   IHostEnvironment,
   IHostFileSystem,
   IMcpManagementService,
@@ -543,6 +544,16 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
     void this.configReady.then(() => {
       telemetry.setEnabled(this.engineAccessor.get(IConfigService).get('telemetry') !== false);
     });
+  }
+
+  /**
+   * Enabled experimental flag ids in the `session_started` wire shape (sorted,
+   * comma-joined), read live from the in-process engine's flag service. The
+   * harness-side `session_started` row merges this so both producers of the
+   * event carry the same flag dimension.
+   */
+  enabledExperimentalFlags(): string {
+    return this.engineAccessor.get(IFlagService).enabledIds().toSorted().join(',');
   }
 
   /**
@@ -2657,6 +2668,9 @@ export function createKimiHarnessV2(options: KimiHarnessOptions): KimiHarness {
     // ingestion falls back to env / built-in defaults like daemon-client hosts.
     imageLimits: undefined,
     sessionStartedProperties: options.sessionStartedProperties,
+    sessionStartedDynamicProperties: () => ({
+      experimental_flags: rpc.enabledExperimentalFlags(),
+    }),
   });
 }
 

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -208,10 +208,12 @@ import {
   IWorkspaceAliases,
   ISessionActivityView,
   IWorkspaceInstanceManager,
+  TOWER_FLAG_ID,
   closeSessionById,
   followSessionLifecycles,
   getLiveSessionById,
   isError2,
+  isTowerFeatureAssembled,
   programForSession,
   resumeSessionById,
   sessionDirOf,
@@ -550,10 +552,17 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
    * Enabled experimental flag ids in the `session_started` wire shape (sorted,
    * comma-joined), read live from the in-process engine's flag service. The
    * harness-side `session_started` row merges this so both producers of the
-   * event carry the same flag dimension.
+   * event carry the same flag dimension. Restart-only flags (`tower`, whose
+   * tools/profiles assemble at App construction) count only once the feature
+   * is actually assembled in this process.
    */
   enabledExperimentalFlags(): string {
-    return this.engineAccessor.get(IFlagService).enabledIds().toSorted().join(',');
+    const flags = this.engineAccessor.get(IFlagService);
+    return flags
+      .enabledIds()
+      .filter((id) => id !== TOWER_FLAG_ID || isTowerFeatureAssembled(flags))
+      .toSorted()
+      .join(',');
   }
 
   /**

--- a/packages/node-sdk/test/create-session-transport.test.ts
+++ b/packages/node-sdk/test/create-session-transport.test.ts
@@ -348,15 +348,24 @@ describe('KimiHarness.createSession transport link', () => {
     await harness.createSession({ id: 'ses_dynamic_one', workDir: '/tmp/work' });
     flags = 'tower,wait_for';
     await harness.createSession({ id: 'ses_dynamic_two', workDir: '/tmp/work' });
+    await harness.createSession({
+      id: 'ses_dynamic_three',
+      workDir: '/tmp/work',
+      sessionStartedProperties: { experimental_flags: 'caller_supplied' },
+    });
 
     const started = records.filter((record) => record.event === 'session_started');
-    expect(started).toHaveLength(2);
+    expect(started).toHaveLength(3);
     expect(started[0]).toMatchObject({
       sessionId: 'ses_dynamic_one',
       properties: { experimental_flags: 'tower' },
     });
     expect(started[1]).toMatchObject({
       sessionId: 'ses_dynamic_two',
+      properties: { experimental_flags: 'tower,wait_for' },
+    });
+    expect(started[2]).toMatchObject({
+      sessionId: 'ses_dynamic_three',
       properties: { experimental_flags: 'tower,wait_for' },
     });
   });

--- a/packages/node-sdk/test/create-session-transport.test.ts
+++ b/packages/node-sdk/test/create-session-transport.test.ts
@@ -331,6 +331,36 @@ describe('KimiHarness.createSession transport link', () => {
     }
   });
 
+  it('evaluates sessionStartedDynamicProperties at every session_started emission', async () => {
+    const records: TelemetryRecord[] = [];
+    const rpc = new StubRpc();
+    let flags = 'tower';
+    const harness = new KimiHarness(rpc, {
+      homeDir: '/tmp/home',
+      configPath: '/tmp/config.toml',
+      auth: { status: async () => ({ providers: [] }) } as never,
+      telemetry: recordingTelemetry(records),
+      ensureConfigFile: async () => undefined,
+      onClose: () => undefined,
+      sessionStartedDynamicProperties: () => ({ experimental_flags: flags }),
+    });
+
+    await harness.createSession({ id: 'ses_dynamic_one', workDir: '/tmp/work' });
+    flags = 'tower,wait_for';
+    await harness.createSession({ id: 'ses_dynamic_two', workDir: '/tmp/work' });
+
+    const started = records.filter((record) => record.event === 'session_started');
+    expect(started).toHaveLength(2);
+    expect(started[0]).toMatchObject({
+      sessionId: 'ses_dynamic_one',
+      properties: { experimental_flags: 'tower' },
+    });
+    expect(started[1]).toMatchObject({
+      sessionId: 'ses_dynamic_two',
+      properties: { experimental_flags: 'tower,wait_for' },
+    });
+  });
+
   it('emits session_fork with the forked session context', async () => {
     const homeDir = await makeTempDir();
     const workDir = await makeTempDir();

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -1314,6 +1314,35 @@ describe('SDKRpcClientV2 engine telemetry', () => {
       await harness.close();
     }
   });
+
+  it('reports the same enabled experimental flags on every session_started row', async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-tel-flags-'));
+    tempDirs.push(homeDir);
+    const workDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-tel-flags-work-'));
+    tempDirs.push(workDir);
+    await writeFile(join(homeDir, 'config.toml'), '[experimental]\nsubagent_fork = true\n', 'utf-8');
+    const records: TelemetryRecord[] = [];
+    const harness = createKimiHarnessV2({
+      homeDir,
+      identity: TEST_IDENTITY,
+      telemetry: recordingTelemetry(records),
+    });
+    try {
+      const session = await harness.createSession({ workDir });
+      const started = records.filter((record) => record.event === 'session_started');
+      expect(started.length).toBeGreaterThanOrEqual(2);
+      for (const record of started) {
+        const flags = String(record.properties?.['experimental_flags'] ?? '').split(',');
+        expect(flags).toContain('subagent_fork');
+        expect(flags).toContain('wait_for');
+      }
+      const distinct = new Set(started.map((record) => record.properties?.['experimental_flags']));
+      expect(distinct.size).toBe(1);
+      await session.close();
+    } finally {
+      await harness.close();
+    }
+  });
 });
 
 describe('removeProviderFromConfig', () => {

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -1320,7 +1320,11 @@ describe('SDKRpcClientV2 engine telemetry', () => {
     tempDirs.push(homeDir);
     const workDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-tel-flags-work-'));
     tempDirs.push(workDir);
-    await writeFile(join(homeDir, 'config.toml'), '[experimental]\nsubagent_fork = true\n', 'utf-8');
+    await writeFile(
+      join(homeDir, 'config.toml'),
+      '[experimental]\nsubagent_fork = true\ntower = true\n',
+      'utf-8',
+    );
     const records: TelemetryRecord[] = [];
     const harness = createKimiHarnessV2({
       homeDir,
@@ -1335,6 +1339,7 @@ describe('SDKRpcClientV2 engine telemetry', () => {
         const flags = String(record.properties?.['experimental_flags'] ?? '').split(',');
         expect(flags).toContain('subagent_fork');
         expect(flags).toContain('wait_for');
+        expect(flags).toContain('tower');
       }
       const distinct = new Set(started.map((record) => record.properties?.['experimental_flags']));
       expect(distinct.size).toBe(1);

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -1320,11 +1320,7 @@ describe('SDKRpcClientV2 engine telemetry', () => {
     tempDirs.push(homeDir);
     const workDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-tel-flags-work-'));
     tempDirs.push(workDir);
-    await writeFile(
-      join(homeDir, 'config.toml'),
-      '[experimental]\nsubagent_fork = true\ntower = true\n',
-      'utf-8',
-    );
+    await writeFile(join(homeDir, 'config.toml'), '[experimental]\nsubagent_fork = true\n', 'utf-8');
     const records: TelemetryRecord[] = [];
     const harness = createKimiHarnessV2({
       homeDir,
@@ -1339,7 +1335,6 @@ describe('SDKRpcClientV2 engine telemetry', () => {
         const flags = String(record.properties?.['experimental_flags'] ?? '').split(',');
         expect(flags).toContain('subagent_fork');
         expect(flags).toContain('wait_for');
-        expect(flags).toContain('tower');
       }
       const distinct = new Set(started.map((record) => record.properties?.['experimental_flags']));
       expect(distinct.size).toBe(1);


### PR DESCRIPTION
## Related Issue

None — internal telemetry instrumentation; the problem is explained below.

## Problem

Experimental features are gated behind flags, but no telemetry event carries flag state. Usage events for gated features (e.g. `subagent_created { fork: true }`, `tool_call { tool_name: 'select_tools' }`) have no exposure denominator: we cannot answer "how many sessions had flag X enabled", so per-flag adoption, distribution, and frequency cannot be measured and experimental features cannot be evaluated with data.

## What changed

- `session_started` (v2) gains an `experimental_flags` property: the sorted, comma-separated ids of enabled experimental flags at session activation (empty string when none). It is emitted from `SessionLifecycleService.announceCreated`, so it covers create / resume / fork across all hosts (CLI, kap-server daemon, klient). Session- and agent-scoped events already carry `session_id` via the DI-seeded telemetry view, so any feature's own events join to this exposure by session.
- The v2 in-process path emits `session_started` twice (engine-side and harness-side via `KimiHarness.trackSessionStarted`). The harness row now merges the same flag set through a per-emission dynamic getter (`sessionStartedDynamicProperties`, wired to the in-process engine's `IFlagService`), so both rows carry an identical flag dimension and consumers cannot double-count or miss it. Client attribution stays on the harness row.
- `experimental_features_apply` (TUI) gains a `flags` property with the post-apply enabled set, bounding mid-session flag flips.
- DI wiring: `IFlagService` is injected into `SessionLifecycleService` and into `WorkspaceInstanceManager` (which passes it through the manual `new SessionLifecycleService(...)` call).
- Tests: updated the existing `experimental_features_apply` payload assertion and added cases covering the sorted enabled-set payload, the per-emission dynamic getter, and row-to-row flag consistency across both `session_started` producers.

No changeset: telemetry schema additions are not user-perceivable (repo convention, e.g. #3394, #3086).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (N/A — internal instrumentation, no user-facing issue).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.