### PR TITLE
fix(agent-core-v2): drop compaction mechanics from the AGENTS.md discovery reminder

### DIFF
--- a/packages/agent-core-v2/src/agent/agentsMdReminder/agentsMdReminderService.ts
+++ b/packages/agent-core-v2/src/agent/agentsMdReminder/agentsMdReminderService.ts
@@ -374,7 +374,7 @@ function stringArg(args: unknown, key: string): string | undefined {
 
 function reminderText(paths: readonly string[]): string {
   return (
-    'The path(s) touched by a recent tool call are covered by AGENTS.md instruction file(s) that were not part of the injected instructions:\n' +
+    'The following AGENTS.md file(s) apply to paths accessed by your recent tool call, but were not included in your system prompt:\n' +
     paths.map((path) => `- ${path}`).join('\n') +
     '\nRead them before making changes in those directories.'
   );

--- a/packages/agent-core-v2/src/agent/agentsMdReminder/agentsMdReminderService.ts
+++ b/packages/agent-core-v2/src/agent/agentsMdReminder/agentsMdReminderService.ts
@@ -376,7 +376,7 @@ function reminderText(paths: readonly string[]): string {
   return (
     'The path(s) touched by a recent tool call are covered by AGENTS.md instruction file(s) that were not part of the injected instructions:\n' +
     paths.map((path) => `- ${path}`).join('\n') +
-    '\nRead them before making changes in those directories. Files may be suggested again after context compaction unless you have read them.'
+    '\nRead them before making changes in those directories.'
   );
 }
 

--- a/packages/agent-core-v2/test/agent/agentsMdReminder/agentsMdReminder.test.ts
+++ b/packages/agent-core-v2/test/agent/agentsMdReminder/agentsMdReminder.test.ts
@@ -401,7 +401,7 @@ describe('agentsMdReminder path-carrying tools', () => {
       variant: 'agents_md',
     });
     expect(messageText(agentsMdMessages(h)[0]!)).toContain(
-      'The path(s) touched by a recent tool call',
+      'The following AGENTS.md file(s) apply to paths accessed by your recent tool call',
     );
     const text = reminderText(h);
     expect(text).toContain(subAgentsMd);


### PR DESCRIPTION
## Related Issue

None — follow-up to #3409 (wording review of the reminder it introduced).

## Problem

The discovery reminder added in #3409 ends with "Files may be suggested again after context compaction unless you have read them." The compaction trigger is harness mechanics the model cannot act on, and the "unless you have read them" branch never fires from the model's perspective — re-injection only targets unread paths, so a model seeing the reminder has always not read the file. Model-facing text should carry only the actionable instruction, not a description of the delivery machinery. (The false "at most once per agent" claim this sentence replaced did have to go; it just did not need a mechanism explanation in its place.)

## What changed

- `reminderText()` now ends at "Read them before making changes in those directories." — no behavior, state, or delivery-timing change.
- Existing tests already assert the reminder prefix and the listed paths; none assert the dropped sentence. Full agentsMdReminder suite passes (65/65).
- No changeset: the reminder is an `injection` message hidden from the UI, and #3409 shipped without one — this is a wording tweak to that same surface.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] Related issue linked or N/A (internal follow-up — no issue required).
- [x] I have added tests that prove my feature works. (No new behavior — existing suite covers the reminder content.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset: model-facing injection text, not user-perceivable.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Internal model-facing string; no user docs affected.)