### PR TITLE
feat(kimi-code): allow overriding the remote control relay origin via env

### DIFF
--- a/apps/kimi-code/src/cli/sub/web/remote-control.ts
+++ b/apps/kimi-code/src/cli/sub/web/remote-control.ts
@@ -19,6 +19,8 @@ import { acquireRemoteControlLock } from './remote-control-lock';
 
 export const REMOTE_CONTROL_RELAY_ORIGIN = 'https://code-rc.kimi.com';
 
+export const REMOTE_CONTROL_RELAY_URL_ENV = 'KIMI_CODE_REMOTE_CONTROL_RELAY_URL';
+
 export const REMOTE_CONTROL_FLAG_ENV = 'KIMI_CODE_EXPERIMENTAL_REMOTE_CONTROL';
 
 const TRUTHY_ENV_VALUES = new Set(['1', 'true', 'yes', 'on']);
@@ -29,6 +31,13 @@ export function isRemoteControlEnabled(
   const truthy = (key: string): boolean =>
     TRUTHY_ENV_VALUES.has((env[key] ?? '').trim().toLowerCase());
   return truthy('KIMI_CODE_EXPERIMENTAL_FLAG') || truthy(REMOTE_CONTROL_FLAG_ENV);
+}
+
+export function resolveRemoteControlRelayOrigin(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): string {
+  const value = env[REMOTE_CONTROL_RELAY_URL_ENV]?.trim();
+  return value === undefined || value.length === 0 ? REMOTE_CONTROL_RELAY_ORIGIN : value;
 }
 
 const MAX_HTTP_HEADER_BYTES = 64 * 1024;
@@ -174,7 +183,7 @@ export function formatRemoteControlStatus(status: RemoteControlStatus): string {
 export function buildRemoteControlUrl(
   deviceId: string,
   sessionId?: string,
-  relayOrigin = REMOTE_CONTROL_RELAY_ORIGIN,
+  relayOrigin = resolveRemoteControlRelayOrigin(),
 ): string {
   const url = new URL(relayOrigin);
   const relayPath = url.pathname.replace(/\/+$/, '');
@@ -291,7 +300,7 @@ export async function startRemoteControl(
   if (token?.refreshToken === undefined || token.refreshToken.length === 0) {
     throw new Error('Remote Control requires a Kimi login. Run `kimi login` first.');
   }
-  const relayOrigin = options.relayOrigin ?? REMOTE_CONTROL_RELAY_ORIGIN;
+  const relayOrigin = options.relayOrigin ?? resolveRemoteControlRelayOrigin();
   const deviceId = createKimiDeviceId(options.homeDir);
   const deviceName = hostname();
   const url = buildRemoteControlUrl(deviceId, undefined, relayOrigin);

--- a/apps/kimi-code/test/cli/web/remote-control.test.ts
+++ b/apps/kimi-code/test/cli/web/remote-control.test.ts
@@ -21,6 +21,7 @@ import {
   formatRemoteControlStatus,
   isRemoteControlEnabled,
   parseRawHttpRequest,
+  resolveRemoteControlRelayOrigin,
   rewriteRemoteControlResponse,
   startRemoteControl,
   type RemoteControlHandle,
@@ -70,6 +71,21 @@ describe('Remote Control URLs', () => {
   it('builds an encoded session deep link before the query', () => {
     expect(buildRemoteControlUrl('device-1', 'session/a b')).toBe(
       'https://code-rc.kimi.com/devices/device-1/sessions/session%2Fa%20b?rc=1&from=kimi_code_cli',
+    );
+  });
+
+  it('falls back to the default relay origin when the env is unset or blank', () => {
+    expect(resolveRemoteControlRelayOrigin({})).toBe('https://code-rc.kimi.com');
+    expect(
+      resolveRemoteControlRelayOrigin({ KIMI_CODE_REMOTE_CONTROL_RELAY_URL: '  ' }),
+    ).toBe('https://code-rc.kimi.com');
+  });
+
+  it('builds device URLs from the relay origin env override', () => {
+    vi.stubEnv('KIMI_CODE_REMOTE_CONTROL_RELAY_URL', 'https://rc.example.test/coding-relay/');
+    expect(resolveRemoteControlRelayOrigin()).toBe('https://rc.example.test/coding-relay/');
+    expect(buildRemoteControlUrl('device-1')).toBe(
+      'https://rc.example.test/coding-relay/devices/device-1/?rc=1&from=kimi_code_cli',
     );
   });
 });


### PR DESCRIPTION
## Related Issue

N/A — internal change, no linked issue.

## Problem

The Remote Control relay origin is hardcoded to `https://code-rc.kimi.com`. Pointing the CLI at a staging or self-hosted relay requires editing source code.

## What changed

- Added the `KIMI_CODE_REMOTE_CONTROL_RELAY_URL` environment variable to override the relay origin; unset or blank values fall back to the default `https://code-rc.kimi.com`.
- The override applies to both entry paths — `kimi web --remote-control` and the TUI `/web` command — including the printed link, QR code, session deep links, and the actual relay WebSocket connections. Explicitly passed `relayOrigin` options (tests) keep precedence.
- Added tests for the default fallback and for building device URLs from an env-provided origin with a path and trailing slash.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
