### PR TITLE
feat(cli): add the kimi session list subcommand

### DIFF
--- a/.changeset/session-list-command.md
+++ b/.changeset/session-list-command.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Add the `kimi session list` command to list sessions from the command line. Run `kimi session list` to see sessions for the current directory, or `kimi session list --all` for every workspace.
+Add the `kimi session list` command to list sessions from the command line.

--- a/.changeset/session-list-command.md
+++ b/.changeset/session-list-command.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add the `kimi session list` command to list sessions from the command line. Run `kimi session list` to see sessions for the current directory, or `kimi session list --all` for every workspace.

--- a/apps/kimi-code/src/cli/commands.ts
+++ b/apps/kimi-code/src/cli/commands.ts
@@ -9,6 +9,7 @@ import { registerExportCommand } from './sub/export';
 import { registerForkCommand } from './sub/fork';
 import { registerLoginCommand } from './sub/login';
 import { registerProviderCommand } from './sub/provider';
+import { registerSessionCommand } from './sub/session';
 import { registerVisCommand } from './sub/vis';
 import { registerWebCommand } from './sub/web';
 
@@ -119,6 +120,7 @@ export function createProgram(
   registerExportCommand(program);
   registerForkCommand(program);
   registerProviderCommand(program);
+  registerSessionCommand(program);
   registerAcpCommand(program);
   registerWebCommand(program);
   registerLoginCommand(program);

--- a/apps/kimi-code/src/cli/sub/session.ts
+++ b/apps/kimi-code/src/cli/sub/session.ts
@@ -37,8 +37,8 @@ export interface SessionListDeps {
 export interface SessionListOptions {
   readonly all: boolean;
   readonly archived: boolean;
-  readonly cwd?: string | undefined;
-  readonly limit?: number | undefined;
+  readonly cwd?: string;
+  readonly limit?: number;
   readonly json: boolean;
 }
 
@@ -129,9 +129,13 @@ function createDefaultSessionListDeps(
 
 function formatRow(summary: SessionSummary, showWorkDir: boolean): string {
   const archived = summary.archived === true ? ' [archived]' : '';
-  const title = summary.title ?? summary.lastPrompt ?? '';
+  const title = sanitizeField(summary.title ?? summary.lastPrompt ?? '');
   const base = `${formatTimestamp(summary.updatedAt)}  ${summary.id}  ${title}${archived}`;
-  return showWorkDir ? `${base}  ${summary.workDir}` : base;
+  return showWorkDir ? `${base}  ${sanitizeField(summary.workDir)}` : base;
+}
+
+function sanitizeField(value: string): string {
+  return value.replaceAll(/[\x00-\x1f\x7f]+/g, ' ').trim();
 }
 
 function formatTimestamp(epochMs: number): string {

--- a/apps/kimi-code/src/cli/sub/session.ts
+++ b/apps/kimi-code/src/cli/sub/session.ts
@@ -1,0 +1,153 @@
+/**
+ * `kimi session` sub-command group.
+ *
+ * CLI glue only: listing semantics (workspace scoping, recency order,
+ * archived filtering) are owned by the SDK/engine; this file parses options
+ * and formats rows.
+ */
+
+import { setTelemetryContext, track, withTelemetryContext } from '@moonshot-ai/kimi-telemetry';
+import {
+  createKimiHarness,
+  createKimiHarnessV2,
+  type KimiHarness,
+  type ListSessionsOptions,
+  type SessionSummary,
+  type TelemetryClient,
+} from '@moonshot-ai/kimi-code-sdk';
+import type { Command } from 'commander';
+
+import { createCliTelemetryBootstrap } from '#/cli/telemetry';
+import { createKimiCodeHostIdentity } from '#/cli/version';
+
+import { isKimiV2Enabled } from '../experimental-v2';
+
+interface WritableLike {
+  write(chunk: string): boolean;
+}
+
+export interface SessionListDeps {
+  readonly listSessions: (options: ListSessionsOptions) => Promise<readonly SessionSummary[]>;
+  readonly cwd: () => string;
+  readonly stdout: WritableLike;
+  readonly stderr: WritableLike;
+  readonly exit: (code: number) => never;
+}
+
+export interface SessionListOptions {
+  readonly all: boolean;
+  readonly archived: boolean;
+  readonly cwd?: string | undefined;
+  readonly limit?: number | undefined;
+  readonly json: boolean;
+}
+
+export async function handleSessionList(
+  deps: SessionListDeps,
+  opts: SessionListOptions,
+): Promise<void> {
+  const workDir = opts.all ? undefined : (opts.cwd ?? deps.cwd());
+  const sessions = await deps.listSessions({
+    workDir,
+    includeArchived: opts.archived ? true : undefined,
+  });
+  const limited = opts.limit === undefined ? sessions : sessions.slice(0, opts.limit);
+  if (opts.json) {
+    deps.stdout.write(`${JSON.stringify(limited, null, 2)}\n`);
+    return;
+  }
+  if (limited.length === 0) {
+    deps.stdout.write('No sessions found.\n');
+    return;
+  }
+  for (const summary of limited) {
+    deps.stdout.write(`${formatRow(summary, opts.all)}\n`);
+  }
+}
+
+export function registerSessionCommand(parent: Command, deps?: Partial<SessionListDeps>): void {
+  const session = parent.command('session').description('Manage sessions non-interactively.');
+
+  session
+    .command('list')
+    .description('List sessions, most recently updated first.')
+    .option('--cwd <path>', 'List sessions of this working directory. Defaults to the current directory.')
+    .option('--all', 'List sessions across every workspace.', false)
+    .option('--archived', 'Include archived sessions.', false)
+    .option('--limit <n>', 'Print at most n sessions.', parseLimitOption)
+    .option('--json', 'Emit the session summaries as JSON.', false)
+    .action(async (options: { cwd?: string; all?: boolean; archived?: boolean; limit?: number; json?: boolean }) => {
+      const resolved = createDefaultSessionListDeps(deps);
+      try {
+        await handleSessionList(resolved, {
+          all: options.all === true,
+          archived: options.archived === true,
+          cwd: options.cwd,
+          limit: options.limit,
+          json: options.json === true,
+        });
+      } catch (error) {
+        resolved.stderr.write(`${errorMessage(error)}\n`);
+        resolved.exit(1);
+      } finally {
+        await resolved.close();
+      }
+    });
+}
+
+function createDefaultSessionListDeps(
+  overrides: Partial<SessionListDeps> = {},
+): SessionListDeps & { readonly close: () => Promise<void> } {
+  let harness: KimiHarness | undefined;
+  const identity = createKimiCodeHostIdentity();
+  const telemetryClient: TelemetryClient = {
+    track,
+    withContext: withTelemetryContext,
+    setContext: setTelemetryContext,
+  };
+  const getHarness = (): KimiHarness => {
+    harness ??= (isKimiV2Enabled() ? createKimiHarnessV2 : createKimiHarness)({
+      homeDir: createCliTelemetryBootstrap().homeDir,
+      identity,
+      telemetry: telemetryClient,
+    });
+    return harness;
+  };
+  return {
+    listSessions:
+      overrides.listSessions ??
+      ((options: ListSessionsOptions) => getHarness().listSessions(options)),
+    cwd: overrides.cwd ?? (() => process.cwd()),
+    stdout: overrides.stdout ?? process.stdout,
+    stderr: overrides.stderr ?? process.stderr,
+    exit: overrides.exit ?? ((code: number) => process.exit(code)),
+    close: async () => {
+      await harness?.close();
+    },
+  };
+}
+
+function formatRow(summary: SessionSummary, showWorkDir: boolean): string {
+  const archived = summary.archived === true ? ' [archived]' : '';
+  const title = summary.title ?? summary.lastPrompt ?? '';
+  const base = `${formatTimestamp(summary.updatedAt)}  ${summary.id}  ${title}${archived}`;
+  return showWorkDir ? `${base}  ${summary.workDir}` : base;
+}
+
+function formatTimestamp(epochMs: number): string {
+  const date = new Date(epochMs);
+  const pad = (value: number): string => String(value).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function parseLimitOption(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`--limit must be a positive integer, got "${value}"`);
+  }
+  return parsed;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/kimi-code/test/cli/options.test.ts
+++ b/apps/kimi-code/test/cli/options.test.ts
@@ -587,6 +587,7 @@ describe('CLI options parsing', () => {
         'export',
         'fork',
         'provider',
+        'session',
         'acp',
         'web',
         'server',

--- a/apps/kimi-code/test/cli/session.test.ts
+++ b/apps/kimi-code/test/cli/session.test.ts
@@ -1,0 +1,166 @@
+/**
+ * `kimi session list`
+ *
+ * Verifies the CLI layer: scope option handling (--cwd/--all), archived
+ * pass-through, --limit, --json, and the empty state.
+ */
+
+import { Command } from 'commander';
+import { describe, expect, it } from 'vitest';
+
+import {
+  handleSessionList,
+  registerSessionCommand,
+  type SessionListDeps,
+} from '#/cli/sub/session';
+import type { ListSessionsOptions, SessionSummary } from '@moonshot-ai/kimi-code-sdk';
+
+function summary(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: 'ses_1',
+    workDir: '/repo',
+    sessionDir: '/home/.kimi-code/sessions/wd_repo/ses_1',
+    createdAt: 1,
+    updatedAt: new Date('2026-09-01T10:00:00').getTime(),
+    ...overrides,
+  };
+}
+
+interface Captured {
+  options?: ListSessionsOptions;
+  out: string;
+  err: string;
+  exitCode?: number;
+}
+
+function stubDeps(sessions: readonly SessionSummary[]): {
+  deps: SessionListDeps;
+  captured: Captured;
+} {
+  const captured: Captured = { out: '', err: '' };
+  const deps: SessionListDeps = {
+    listSessions: async (options) => {
+      captured.options = options;
+      return sessions;
+    },
+    cwd: () => '/repo',
+    stdout: {
+      write: (chunk) => {
+        captured.out += chunk;
+        return true;
+      },
+    },
+    stderr: {
+      write: (chunk) => {
+        captured.err += chunk;
+        return true;
+      },
+    },
+    exit: (code) => {
+      captured.exitCode = code;
+      throw new Error(`exit ${code}`);
+    },
+  };
+  return { deps, captured };
+}
+
+describe('handleSessionList', () => {
+  it('lists sessions of the current working directory by default', async () => {
+    const { deps, captured } = stubDeps([
+      summary({ id: 'ses_1', title: 'first' }),
+      summary({ id: 'ses_2', title: 'second' }),
+    ]);
+
+    await handleSessionList(deps, { all: false, archived: false, json: false });
+
+    expect(captured.options).toEqual({ workDir: '/repo', includeArchived: undefined });
+    expect(captured.out).toContain('ses_1');
+    expect(captured.out).toContain('first');
+    expect(captured.out).toContain('ses_2');
+    expect(captured.out).toMatch(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}/);
+    expect(captured.out).not.toContain('/repo\n');
+  });
+
+  it('lists every workspace with --all and shows workDir per row', async () => {
+    const { deps, captured } = stubDeps([summary({ id: 'ses_1', workDir: '/repo' })]);
+
+    await handleSessionList(deps, { all: true, archived: false, json: false });
+
+    expect(captured.options).toEqual({ workDir: undefined, includeArchived: undefined });
+    expect(captured.out).toContain('/repo');
+  });
+
+  it('uses an explicit --cwd over the current directory', async () => {
+    const { deps, captured } = stubDeps([summary()]);
+
+    await handleSessionList(deps, { all: false, archived: false, cwd: '/other', json: false });
+
+    expect(captured.options).toEqual({ workDir: '/other', includeArchived: undefined });
+  });
+
+  it('passes includeArchived through with --archived', async () => {
+    const { deps, captured } = stubDeps([summary({ archived: true })]);
+
+    await handleSessionList(deps, { all: false, archived: true, json: false });
+
+    expect(captured.options).toEqual({ workDir: '/repo', includeArchived: true });
+    expect(captured.out).toContain('[archived]');
+  });
+
+  it('truncates with --limit', async () => {
+    const { deps, captured } = stubDeps([
+      summary({ id: 'ses_1' }),
+      summary({ id: 'ses_2' }),
+      summary({ id: 'ses_3' }),
+    ]);
+
+    await handleSessionList(deps, { all: false, archived: false, limit: 2, json: false });
+
+    expect(captured.out).toContain('ses_1');
+    expect(captured.out).toContain('ses_2');
+    expect(captured.out).not.toContain('ses_3');
+  });
+
+  it('emits the summaries as JSON with --json', async () => {
+    const sessions = [summary({ id: 'ses_1', title: 'first' })];
+    const { deps, captured } = stubDeps(sessions);
+
+    await handleSessionList(deps, { all: false, archived: false, json: true });
+
+    expect(JSON.parse(captured.out)).toEqual(JSON.parse(JSON.stringify(sessions)));
+  });
+
+  it('prints a friendly empty state', async () => {
+    const { deps, captured } = stubDeps([]);
+
+    await handleSessionList(deps, { all: false, archived: false, json: false });
+
+    expect(captured.out).toBe('No sessions found.\n');
+  });
+});
+
+describe('registerSessionCommand', () => {
+  it('parses session list options and runs the handler', async () => {
+    const sessions = [summary({ id: 'ses_1', title: 'first' })];
+    const { deps, captured } = stubDeps(sessions);
+    const program = new Command('kimi');
+    registerSessionCommand(program, deps);
+
+    await program.parseAsync(['node', 'kimi', 'session', 'list', '--all', '--json']);
+
+    expect(captured.options).toEqual({ workDir: undefined, includeArchived: undefined });
+    expect(JSON.parse(captured.out)).toEqual(JSON.parse(JSON.stringify(sessions)));
+    expect(captured.exitCode).toBeUndefined();
+  });
+
+  it('rejects a non-numeric --limit', async () => {
+    const { deps } = stubDeps([]);
+    const program = new Command('kimi');
+    program.exitOverride();
+    registerSessionCommand(program, deps);
+
+    await expect(
+      program.parseAsync(['node', 'kimi', 'session', 'list', '--limit', 'abc']),
+    ).rejects.toThrow(/positive integer/);
+  });
+});

--- a/apps/kimi-code/test/cli/session.test.ts
+++ b/apps/kimi-code/test/cli/session.test.ts
@@ -137,6 +137,24 @@ describe('handleSessionList', () => {
 
     expect(captured.out).toBe('No sessions found.\n');
   });
+
+  it('strips control characters and line breaks from user-controlled fields', async () => {
+    const { deps, captured } = stubDeps([
+      summary({
+        id: 'ses_1',
+        title: 'line one\nline two \u001b[31mred\u001b[0m',
+        workDir: '/repo\nevil',
+      }),
+    ]);
+
+    await handleSessionList(deps, { all: true, archived: false, json: false });
+
+    const rows = captured.out.trimEnd().split('\n');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).not.toContain('\u001b');
+    expect(rows[0]).toContain('line one line two  [31mred [0m');
+    expect(rows[0]).toContain('/repo evil');
+  });
 });
 
 describe('registerSessionCommand', () => {

--- a/packages/node-sdk/src/rpc.ts
+++ b/packages/node-sdk/src/rpc.ts
@@ -257,7 +257,11 @@ export abstract class SDKRpcClientBase {
 
   async listSessions(input: ListSessionsOptions = {}): Promise<readonly SessionSummary[]> {
     const rpc = await this.getRpc();
-    return rpc.listSessions(input);
+    return rpc.listSessions({
+      workDir: input.workDir,
+      sessionId: input.sessionId,
+      includeArchive: input.includeArchived,
+    });
   }
 
   /**

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -1153,6 +1153,7 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
       const page = await this.listSessionsPage({
         workDir: input.workDir,
         sessionId: input.sessionId,
+        includeArchived: input.includeArchived,
         before,
       });
       all.push(...page.items);
@@ -1182,6 +1183,7 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
       const page = await this.klient.global.sessions.list({
         workspaceIds,
         sessionId: input.sessionId,
+        includeArchived: input.includeArchived,
         limit: remaining,
         before,
       });

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -264,6 +264,10 @@ export interface ListSessionsOptions {
   readonly workDir?: string;
   readonly sessionId?: string;
   /**
+   * Include archived sessions in the listing. Defaults to non-archived only.
+   */
+  readonly includeArchived?: boolean;
+  /**
    * Maximum number of summaries in one page. Only consulted by
    * `listSessionsPage`; plain `listSessions` always returns the whole
    * filtered set.


### PR DESCRIPTION
## Related Issue

No linked issue — came up during kimi-cli migration verification: after migrating sessions, the only ways to confirm they landed were the TUI `/session` picker or reading `~/.kimi-code/session_index.jsonl` by hand. There is no command-line way to list sessions.

## Problem

Users who want to check their sessions non-interactively (scripts, migration checks, quick terminal lookups) currently must enter the TUI. The session-listing data path (`harness.listSessions` over `ISessionIndex`) already exists and powers the TUI picker — it is only missing a CLI surface.

## What changed

- New `kimi session` command group with `kimi session list`:
  - defaults to the current working directory (same scope as the TUI picker); `--all` lists every workspace, `--cwd <path>` picks another directory
  - human-readable rows (updatedAt, session id, title), most recently updated first; `--json` emits the full `SessionSummary` array for scripting
  - `--archived` includes archived sessions (excluded by default, matching the index default); `--limit <n>` truncates
  - empty listing prints `No sessions found.` with exit code 0
- Plumbing: `ListSessionsOptions` gains `includeArchived`, passed through to the v2 klient `sessionIndex.listRecent` query (contract field already existed); the v1 base client maps it to its `includeArchive` payload field.
- Implementation follows the existing sub-command patterns (`fork.ts`/`provider.ts`): `handleSessionList(deps, opts)` + `registerSessionCommand` + lazily created harness, tests with mocked deps (`test/cli/session.test.ts`).

Note: on the legacy v1 engine (`KIMI_CODE_LEGACY_FLAG`), `--all` surfaces the engine's "workDir required" error — v1 has no all-workspace listing and is being removed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
