### PR TITLE
fix(kap-server): report the real event watermark as last_seq in getSession

### DIFF
--- a/.changeset/tidy-session-event-watermark.md
+++ b/.changeset/tidy-session-event-watermark.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix idle sessions briefly showing a "Working" state when opened in desktop and web clients.

--- a/packages/kap-server/src/routes/registerApiV1Routes.ts
+++ b/packages/kap-server/src/routes/registerApiV1Routes.ts
@@ -118,6 +118,7 @@ export async function registerApiV1Routes(
       registerSessionsRoutes(
         apiV1 as unknown as Parameters<typeof registerSessionsRoutes>[0],
         core,
+        { sessionEventCursor: (sessionId) => opts.broadcaster.getCursor(sessionId) },
       );
       registerRuntimeRoutes(apiV1 as unknown as Parameters<typeof registerRuntimeRoutes>[0], core);
       registerSessionExportRoute(

--- a/packages/kap-server/src/routes/sessions.ts
+++ b/packages/kap-server/src/routes/sessions.ts
@@ -411,6 +411,7 @@ export function registerSessionsRoutes(
     },
     async (req, reply) => {
       const { session_id } = req.params;
+      const cursor = await deps.sessionEventCursor(session_id);
       const summary = await core.accessor.get(ISessionIndex).get(session_id);
       if (summary === undefined) {
         reply.send(
@@ -430,7 +431,6 @@ export function registerSessionsRoutes(
         );
         return;
       }
-      const cursor = await deps.sessionEventCursor(session_id);
       reply.send(
         okEnvelope(
           toWireSession(summary, cwd, resolveSessionFacts(core, session_id), cursor.seq),

--- a/packages/kap-server/src/routes/sessions.ts
+++ b/packages/kap-server/src/routes/sessions.ts
@@ -166,7 +166,15 @@ const sessionActionRequestSchema = z.preprocess(
 
 const detailsSchema = z.array(z.object({ path: z.string(), message: z.string() }));
 
-export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void {
+export interface SessionsRoutesDeps {
+  readonly sessionEventCursor: (sessionId: string) => Promise<{ seq: number; epoch: string }>;
+}
+
+export function registerSessionsRoutes(
+  app: SessionRouteHost,
+  core: Scope,
+  deps: SessionsRoutesDeps,
+): void {
   const createRoute = defineRoute(
     {
       method: 'POST',
@@ -422,8 +430,12 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
         );
         return;
       }
+      const cursor = await deps.sessionEventCursor(session_id);
       reply.send(
-        okEnvelope(toWireSession(summary, cwd, resolveSessionFacts(core, session_id)), req.id),
+        okEnvelope(
+          toWireSession(summary, cwd, resolveSessionFacts(core, session_id), cursor.seq),
+          req.id,
+        ),
       );
     },
   );
@@ -995,6 +1007,7 @@ export function toWireSession(
   fields: SessionWireFields,
   cwd: string,
   facts: SessionFacts,
+  lastSeq?: number,
 ): Session {
   return {
     id: fields.id,
@@ -1016,7 +1029,7 @@ export function toWireSession(
     usage: emptySessionUsage(),
     permission_rules: [],
     message_count: 0,
-    last_seq: 0,
+    last_seq: lastSeq ?? 0,
   };
 }
 

--- a/packages/kap-server/test/sessions.test.ts
+++ b/packages/kap-server/test/sessions.test.ts
@@ -467,15 +467,8 @@ describe('server-v2 /api/v1/sessions', () => {
     });
     expect(renamed.body.code).toBe(0);
 
-    const deadline = Date.now() + 5000;
-    let observed = baseline;
-    while (Date.now() < deadline) {
-      const got = await getJson<SessionWire>(`/api/v1/sessions/${id}`);
-      observed = got.body.data.last_seq;
-      if (observed > baseline) break;
-      await new Promise((r) => setTimeout(r, 25));
-    }
-    expect(observed).toBeGreaterThan(baseline);
+    const got = await getJson<SessionWire>(`/api/v1/sessions/${id}`);
+    expect(got.body.data.last_seq).toBeGreaterThan(baseline);
   });
 
   it('supports exclude_empty when listing sessions', async () => {

--- a/packages/kap-server/test/sessions.test.ts
+++ b/packages/kap-server/test/sessions.test.ts
@@ -454,6 +454,30 @@ describe('server-v2 /api/v1/sessions', () => {
     expect(got.body.data.agent_config).toEqual({ model: 'stub' });
   });
 
+  it('reports the journaled event watermark as last_seq', async () => {
+    const cwd = home as string;
+    const created = await postJson<SessionWire>('/api/v1/sessions', { metadata: { cwd } });
+    const id = created.body.data.id;
+
+    const initial = await getJson<SessionWire>(`/api/v1/sessions/${id}`);
+    const baseline = initial.body.data.last_seq;
+
+    const renamed = await postJson<SessionWire>(`/api/v1/sessions/${id}/profile`, {
+      title: 'watermark probe',
+    });
+    expect(renamed.body.code).toBe(0);
+
+    const deadline = Date.now() + 5000;
+    let observed = baseline;
+    while (Date.now() < deadline) {
+      const got = await getJson<SessionWire>(`/api/v1/sessions/${id}`);
+      observed = got.body.data.last_seq;
+      if (observed > baseline) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(observed).toBeGreaterThan(baseline);
+  });
+
   it('supports exclude_empty when listing sessions', async () => {
     const cwd = home as string;
     const created = await postJson<SessionWire>('/api/v1/sessions', { metadata: { cwd } });


### PR DESCRIPTION
## Related Issue

Related client PR: https://github.com/MoonshotAI/kimi-code-app/pull/494 (no tracker issue — reported and root-caused against the desktop client).

## Problem

Opening the desktop app / web UI or switching to any session reliably shows a spurious "Working…" indicator for a few seconds on idle sessions.

Both event-watermark sources the client uses are hardcoded to 0: v2 session rows and the v1 `GET /sessions/{id}` response (`last_seq: 0`). Every first event subscription of a session therefore replays the entire journaled event history from seq 0, and historical `event.session.work_changed busy=true` frames are folded into the client's live state, lighting the "Working" lamp until the replay drains. The server already tracks the real per-session journal watermark (live in memory, on disk for cold sessions); it just never reported it.

## What changed

- `GET /api/v1/sessions/{session_id}` now returns the real `last_seq` via the event broadcaster's `getCursor` (live journal seq, or the persisted journal watermark for cold sessions). No wire-schema change — the field already existed and was always 0.
- `registerSessionsRoutes` takes a narrow `sessionEventCursor` dependency, wired to the broadcaster in `registerApiV1Routes`.
- Clients that subscribe at the fetched `last_seq` now land exactly on the journal tail (`cursor.seq === currentSeq` → empty replay), eliminating the full-history replay on first subscribe. The code-app client already consumes `last_seq` this way, so no client change is needed once the submodule pointer advances; the client-side guard in kimi-code-app#494 remains as the safety net for the subscribe window.

Scope note: v2 list rows intentionally keep `lastSeq: 0` — the client's first subscribe always goes through the single-session watermark fetch, so per-row watermarks (and their disk-read cost on list pages) are unnecessary.

## Tests

- New `sessions.test.ts` case: `last_seq` reflects the journaled watermark and advances after a session event.
- Full `@moonshot-ai/kap-server` suite passes; workspace lint and typecheck clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
