### PR TITLE
docs(transcript): rewrite SDK document against the current contract

### DIFF
--- a/packages/transcript/AGENTS.md
+++ b/packages/transcript/AGENTS.md
@@ -8,7 +8,7 @@ No comments — no file headers, no section banners, no statement-level narratio
 
 ## Contract documentation
 
-`docs/sdk.md` is the readable form of the package's external contract (data model, ops, WS/REST surface, derived selectors, event sources) plus the versioning rule: any contract change (entity fields, op types, frame shapes, REST responses, grade semantics) must ship with a numbered migration doc under `docs/migrations/NNNN-<title>.md`; pure additions need only a changeset. The doc currently describes the target contract of the state-model unification — until that refactor lands, `src/contract/` remains the authority.
+`docs/sdk.md` is the readable form of the package's external contract as currently implemented (data model, ops, WS/REST surface, event sources) plus the versioning rule: any contract change (entity fields, op types, frame shapes, REST responses, grade semantics) must ship with a numbered migration doc under `docs/migrations/NNNN-<title>.md`; pure additions need only a changeset. `src/contract/` remains the authority — when the two diverge, fix the doc.
 
 ## Cold rebuild
 

--- a/packages/transcript/docs/sdk.md
+++ b/packages/transcript/docs/sdk.md
@@ -1,147 +1,116 @@
 # Transcript SDK
 
-状态：**目标契约**。本文档描述状态模型统一重构（migration 0001，规划于 `docs/migrations/`）落地后的 transcript 对外契约。落地前以代码为准，落地后以本文档为准；此后任何契约变更必须附带一份 migration 文档（见第八节）。
-
-读者：transcript 通道的消费方（kimi-code-app、kimi-inspect、外部 REST/WS 客户端）与 transcript 包的维护者。
+本文档描述 transcript 对外契约的**当前实现**，读者为 transcript 通道的消费方（kimi-code-app、kimi-inspect、外部 REST/WS 客户端）与 transcript 包的维护者。契约的权威定义是 `src/contract/schema.ts` 的 zod schema；本文档是其可读形式，两者冲突时以 schema 为准并修正本文档。契约变更必须附带 migration 文档（见第八节）。
 
 ## 一、定位与分层
 
-transcript 是 session 对话时间线的**唯一读取通道**。所有持久事实以 wire.jsonl 的 durable 记录为唯一真相源；live 与 cold 是同一 fold 逻辑对同一记录流的两种喂法，同一 session 任一时刻两种读法结果一致。
+transcript 是 session 对话时间线的读取通道，同一份数据有两种喂法：
+
+- **live**：kap-server 订阅 core 的 observable 事件（IEventBus），由 projector 翻译成 ops 写入内存 store；
+- **cold**：从 `wire.jsonl` 的 durable 记录两层 fold 重建（`history/groupTurns.ts` 负责 context 消息 → turn 树，`history/foldFacts.ts` 负责非 context 记录 → 实体与 meta）。
+
+wire.jsonl 是历史的唯一真相源；live store 是纯内存态，随 session 消亡。cold 重建存在已声明的字段缺口（见 2.8 已知限制）。
 
 ```text
-wire.jsonl（durable 记录，真相源）
-   └─ fold（transcript 包，live 增量 / cold 批量共用）
-       └─ TranscriptStore（per session）
-           └─ AgentTranscript（per agent，不可变 AgentState）
-               ├─ WS 订阅通道（transcript.ops / transcript.reset，按 grade 过滤）
-               └─ REST 只读接口（分页、ops 补差）
+TranscriptStore（per session）
+└── agents: Map<AgentId, AgentTranscript> + roster: AgentDescriptor[]
+    └── AgentState
+        ├── items: (Turn | Marker | TaskRef)[]     时间线；Turn 内嵌 steps[]，Step 内嵌 frames[]
+        ├── tasks / interactions / attachments / todos / prompts   全局实体
+        ├── meta（goal / modes / activity / agent）
+        └── hasMoreOlder
 ```
 
-非 durable 事件（`assistant.delta` / `thinking.delta` / `tool.call.delta` / `tool.progress`）只用于流式渲染，其写入 store 的内容会被 durable 记录 fold 出的全量帧幂等覆盖校准。消费方永远可以只依据 durable 来源的内容重建一致视图。
+ID 规范：turn `t{N}`（ordinal 从 0 起，与引擎一致）、step `t{N}.{M}`、文本/thinking frame `t{N}.{M}.f{K}`、tool frame `t{N}.{M}.{toolCallId}`。marker id 在 live 路径为 `live-m{N}`，cold 路径为 `m{N}`。
 
 ## 二、数据模型
 
-### 2.1 容器
+### 2.1 AgentDescriptor
 
 ```ts
-interface TranscriptStore {
-  agents: Map<AgentId, AgentTranscript>;
-  roster: AgentDescriptor[];
-}
-
-type AgentCreatedBy = 'session' | 'btw' | 'agent' | 'agent_swarm' | 'tower_spawn';
-
 interface AgentDescriptor {
   agentId: AgentId;
-  createdBy: AgentCreatedBy;
+  type?: 'main' | 'sub' | 'independent';
   parentAgentId?: AgentId;
-  forkedFrom?: AgentId;
   label?: string;
+  createdAt?: string;
   disposedAt?: string;
 }
 ```
 
-agent 分类由 `createdBy` 派生：`'session'` → main；`'btw'` → btw 侧栏；其余 → subagent。`createdBy` 是封闭枚举，新增能创建 agent 的工具时扩充。
+当前写入逻辑只按 `agentId === 'main'` 区分：main 写 `'main'`，其余写 `'sub'`（`agentLifecycleService.ts:184`）；`'independent'` 无写入方。btw 侧栏 agent 与 subagent 在元数据上无法区分（都注册为 `'sub'`、`parentAgentId: 'main'`，区别仅在有无 labels）。
 
-### 2.2 AgentState
-
-```ts
-interface AgentState {
-  items: TranscriptItem[];                       // Turn | Marker | TaskRef 时间线
-  tasks: Map<TaskId, Task>;
-  interactions: Map<InteractionId, Interaction>;
-  attachments: Map<AttachmentId, Attachment>;
-  todos: Map<TodoId, Todo>;
-  prompts: PromptQueueState;
-  meta: TranscriptMeta;
-  hasMoreOlder: boolean;                         // 仅 reset/快照截断置真
-}
-```
-
-### 2.3 Turn / Step
+### 2.2 Turn / Step
 
 ```ts
 interface Turn {
   kind: 'turn';
-  turnId: TurnId;                                // 't{N}'，ordinal 从 0 起
+  turnId: TurnId;
+  triggerPromptId?: string;
   ordinal: number;
-  state: 'running' | 'completed' | 'failed' | 'cancelled';
-  origin: TurnOrigin;
-  promptId?: PromptId;
+  state: 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+  origin: TurnOrigin;                 // { kind: 'user'|'cron'|'task'|'hook'|'compaction'|'side'|'other', taskId?, payload? }
   prompt?: string;
   attachmentIds?: AttachmentId[];
-  startedAt: string;
-  endedAt?: string;
-  durationMs?: number;
-  endReason?: 'blocked' | 'max_steps' | 'lost' | 'error';
-  error?: string;
   steps: Step[];
-  usage?: Usage;
+  startedAt?: string;
+  endedAt?: string;
+  usage?: Usage;                      // { inputTokens?, outputTokens?, cachedTokens?, cost? }
+  durationMs?: number;
+  error?: string;
 }
 
-type TurnOrigin =
-  | { kind: 'user'; payload?: unknown }
-  | { kind: 'cron'; taskId?: TaskId; payload?: unknown }
-  | { kind: 'task'; taskId: TaskId; payload?: unknown }
-  | { kind: 'hook'; payload?: unknown }
-  | { kind: 'compaction'; payload?: unknown }
-  | { kind: 'other'; payload?: unknown };
-
 interface Step {
-  stepId: StepId;                                // 't{N}.{M}'
+  kind: 'step';
+  stepId: StepId;
   turnId: TurnId;
   ordinal: number;
-  state: 'running' | 'completed' | 'interrupted';
+  state: 'running' | 'completed' | 'interrupted' | 'failed';
   frames: Frame[];
   startedAt?: string;
   endedAt?: string;
-  usage?: StepUsage;
-  timing?: StepTiming;
-  retry?: StepRetry;
+  usage?: StepUsage;                  // { inputOther, output, inputCacheRead, inputCacheCreation }
   finishReason?: string;
+  timing?: StepTiming;                // llmFirstTokenLatencyMs / llmStreamDurationMs / llmRequestBuildMs / llmServerFirstTokenMs / llmServerDecodeMs / llmClientConsumeMs
+  retry?: StepRetry;                  // { failedAttempt, nextAttempt, maxAttempts, delayMs, errorName, errorMessage, statusCode? }
+  endReason?: string;
+  endMessage?: string;
 }
 ```
 
-状态机（终态不可变；每个 prompt 启动执行即创建新 turn）：
+实际状态机比枚举声明小：Turn 实际只有 `running → completed | failed | cancelled`（`'queued'` 无写入方）；Step 实际只有 `running → completed | interrupted`（`'failed'` 无写入方）。core 的 `TurnEndReason` 有 4 值（含 `'blocked'`），投影到 transcript 时 `'blocked'` 折叠为 `'failed'`。
 
-```text
-Turn:  running ──→ completed | failed | cancelled
-Step:  running ──→ completed | interrupted
-```
-
-- `endReason` 是终态细节：`'blocked'`（hook 拦截）、`'max_steps'`、`'lost'`（进程崩溃导致无 `turn.ended` 记录）、`'error'`。
-- turn 历史是只读事实：后续 prompt 不会改写已有 turn 的 state；undo 是整个删除 turn（`items.remove`），不是状态变更。
-
-### 2.4 Frame
+### 2.3 Frame
 
 ```ts
-type Frame = TextFrame | ThinkingFrame | ToolFrame | NoticeFrame;
+type Frame = TextFrame | ThinkingFrame | ToolCallFrame | NoticeFrame;
 ```
 
-- `TextFrame`：`{ kind: 'text', frameId, role: 'assistant'|'user', text, attachmentIds?, taskId?, promptIds?, origin? }`
+- `TextFrame`：`{ kind: 'text', frameId, role: 'assistant'|'user', text, attachmentIds?, taskId?, promptIds?, origin? }`（user 帧的 origin 可带 skillActivations）
 - `ThinkingFrame`：`{ kind: 'thinking', frameId, text }`
-- `ToolFrame`：`{ kind: 'tool', frameId, toolCallId, name, state: 'running'|'done'|'error', view?, input?, output?, display?, error?, inputText?, progress?, taskId?, approvalId?, todoId?, agentRefs? }`
-- `NoticeFrame`：`{ kind: 'notice', frameId, level: 'info'|'warning'|'error', source?, message, detail? }`
+- `ToolCallFrame`：`{ kind: 'tool', frameId, toolCallId, name, state: 'running'|'done'|'error', view?, input?, output?, display?, error?, inputText?, progress?, taskId?, approvalId?, todoId?, agentRefs? }`
+- `NoticeFrame`：`{ kind: 'notice', frameId, level: 'error'|'warning'|'info', source?, message, detail? }`
 
-### 2.5 Marker / TaskRef / Task / Interaction / Todo / Attachment
+### 2.4 Marker / TaskRef / Task / Interaction / Todo / Attachment
 
 ```ts
 interface Marker {
   kind: 'marker';
-  markerId: string;                              // 'm{N}'，live/cold 同一命名
-  marker: 'compaction' | 'undo' | 'clear' | 'goal'
-    | 'plan.enter' | 'plan.exit' | 'plan.revision'
-    | 'swarm.enter' | 'swarm.exit'
-    | 'skill' | 'cron.fired' | 'notice';
+  markerId: string;
+  marker: string;                     // KNOWN_MARKERS 见下
   payload?: unknown;
   at?: string;
 }
+```
 
+`KNOWN_MARKERS`：`'compaction' | 'undo' | 'clear' | 'goal' | 'plan.enter' | 'plan.exit' | 'plan.revision' | 'swarm.enter' | 'swarm.exit' | 'skill' | 'cron.fired' | 'notice' | 'hook'`（`marker` 字段类型为自由 string，KNOWN_MARKERS 是已知键清单）。
+
+```ts
 interface TaskRef { kind: 'taskref'; refId: string; taskId: TaskId; at?: string }
 
 interface Task {
   taskId: TaskId;
-  kind: 'shell' | 'subagent' | 'other';
+  kind: 'shell' | 'subagent' | 'tool' | 'other';   // 'tool' 无写入方
   state: 'running' | 'completed' | 'failed' | 'timed_out' | 'killed' | 'lost';
   detached: boolean;
   description?: string;
@@ -167,50 +136,76 @@ interface Interaction {
 }
 ```
 
-### 2.6 Prompt（队列实体，无状态机）
+### 2.5 Prompt
 
 ```ts
 interface Prompt {
   promptId: PromptId;
-  userMessageId: string;
-  content: MessageContent[];
+  status: 'running' | 'queued' | 'blocked' | 'completed' | 'failed' | 'aborted';
+  userMessageId?: string;
+  content?: unknown;
   createdAt: string;
-  blocked?: true;                                // hook 拦截，终态，不产生 turn
-  steeredInto?: TurnId;                          // 被 steer 吸收的 turn
-}
-
-interface PromptQueueState {
-  records: Map<PromptId, Prompt>;
-  active: PromptId | null;
-  queued: PromptId[];
+  finishedAt?: string;
+  steeredAt?: string;
 }
 ```
 
-读取方式：排队中 = 在 `queued`；执行中 = 是 `active`；执行结果 = 沿 `promptId` 读 `turn.state`；被拦截 = `blocked`；被吸收 = `steeredInto`。prompt 实体描述"当前队列"，session 冷启动后队列为空。
+prompt 实体只在 live 路径写入（cold 重建不构建 prompts 列表）。`'blocked'` 表示被外部 hook 拦截（turn 未启动）；steer 吸收的子 prompt 记为 `'completed'` 并带 `steeredAt`。
 
-### 2.7 Meta
+### 2.6 Meta
 
 ```ts
 interface TranscriptMeta {
-  goal?: { objective: string; status: 'active'|'paused'|'blocked'|'complete';
-           completionCriterion?: string; budgetUsed?: number; budgetLimit?: number };
-  modes?: { plan?: { reviewPath?: string; version?: number };
-            swarm?: { trigger?: string };
-            tower?: Record<string, never> };
-  agent?: { model?: string; thinkingEffort?: string; usage?: AgentUsageMeta;
-            contextTokens?: number; maxContextTokens?: number; contextUsage?: number;
-            permission?: 'manual' | 'yolo' | 'auto' };
+  goal?: { objective: string; status: 'active'|'paused'|'blocked'|'complete'; completionCriterion?; budgetUsed?; budgetLimit? };
+  modes?: { plan?: { reviewPath?, version? }; swarm?: { trigger? }; tower?: {} };
+  activity?: 'idle' | 'turn' | 'disposing' | 'unknown';   // 实际只写 'idle'/'turn'
+  agent?: AgentStatusMeta;
+}
+
+interface AgentStatusMeta {
+  model?: string;
+  thinkingEffort?: string;
+  usage?: { byModel?: Record<string, StepUsage>; currentTurn?: StepUsage; total?: StepUsage };
+  contextTokens?: number;
+  maxContextTokens?: number;
+  contextUsage?: number;
+  permission?: 'manual' | 'yolo' | 'auto';
+  phase?: AgentPhaseMeta;
 }
 ```
 
-`meta` 不含 activity 与 agent.phase——两者是派生量，见第六节。
+`AgentPhaseMeta` 8 种 kind：`idle | running | streaming | tool_call | retrying | awaiting_approval | interrupted | ended`，由 kap-server 的 `toLegacyPhase` 从 core 的 `AgentActivityState` 映射，经 `meta.merge` 下发；cold 路径不回填。`AgentStatusMeta` 的 `permission` 与 `contextUsage` 当前无写入方（schema 声明保留）。
+
+### 2.7 Snapshot
+
+```ts
+interface AgentTranscriptSnapshot {
+  items: TranscriptItem[];
+  tasks: Task[];
+  interactions: Interaction[];
+  attachments: Attachment[];
+  todos: Todo[];
+  prompts: Prompt[];
+  meta: TranscriptMeta;
+  hasMoreOlder?: boolean;
+}
+```
+
+### 2.8 已知限制（cold 重建缺口）
+
+- `step.retry` 不回填（retry 事件自 #3428 起已写入 wire，但 fold 尚未消费，transient by design）。
+- `step.usage / timing / finishReason`、`turn.usage`、`meta.agent.*`、`agent.phase`、prompts 列表不回填。
+- step 中断信息（`state: 'interrupted'` + `endReason` / `endMessage` / `endedAt`）自 #3428 起由 durable `turn.step.interrupted` 记录回填（context 树缺少对应 step 时会合成）。
+- 缺少 `turn.ended` 记录的 turn（进程崩溃中断）在 cold 路径一律标 `'completed'`。
+- live/cold 对同一逻辑 marker 使用不同 id 命名空间（`live-m{N}` vs `m{N}`）。
 
 ## 三、Operations（ops）
 
-所有 store 变更以 op batch 应用。op 联合：
+所有 store 变更以 op batch 应用。op 联合（14 个成员）：
 
 | op | payload | 语义 |
 |---|---|---|
+| `reset` | `{ agentId, snapshot }` | 整体替换 AgentState；server 不产生，仅客户端 store/测试使用（server 侧 reset 以专用帧存在） |
 | `turn.upsert` | `{ turn: TurnHeader }` | upsert turn 头，保留已有 steps |
 | `step.upsert` | `{ turnId, step: StepHeader }` | upsert step 头，保留已有 frames |
 | `frame.upsert` | `{ turnId, stepId, frame }` | 整帧替换 |
@@ -221,16 +216,14 @@ interface TranscriptMeta {
 | `interaction.upsert` | `{ interaction }` | interaction 实体，同步维护 pendingInteractions |
 | `attachment.upsert` | `{ attachment }` | attachment 实体 |
 | `todo.upsert` | `{ todo }` | todo 实体 |
-| `prompt.upsert` | `{ prompt }` | prompt 记录 |
-| `prompt.queue` | `{ active, queued }` | prompt 队列拓扑 |
+| `prompt.upsert` | `{ prompt }` | prompt 实体（live-only） |
 | `meta.merge` | `{ meta }` | 深合并 meta，`null` 表示删除该键 |
 | `items.remove` | `{ ids }` | 删除时间线条目，级联删除锚定的 interaction |
 
 规则：
 
 1. **幂等**：upsert 做字段级相等判断，无变化的 op 被丢弃、不通知订阅者；整批重放是 no-op。
-2. **序号**：server 给每批分配 per-(session, agent) 连续 `seq`，watermark = 最新已分配 seq；journal 容量 2000 批，随 live store 消亡。
-3. **原子结算**：一次 turn 结束结算（step 终态 + turn 终态 + prompt 队列变更）在同一个 op batch 提交；batch 边界 = dispatcher 同步执行序列边界。消费方永远看不到"turn 已结束、prompt 未结算"的中间态。
+2. **序号**：server 给每批分配 per-(session, agent) 连续 `seq`，watermark = 最新已分配 seq；journal 容量 2000 批（`TRANSCRIPT_OPS_JOURNAL_CAPACITY`），随 live store 消亡。
 
 ## 四、WebSocket 协议
 
@@ -244,30 +237,29 @@ interface TranscriptMeta {
 ```
 
 - `transcript`：`{ <agentId|'*'>: grade }`，grade ∈ `off | turn | block | delta`。
-- `transcript_since`：可选，按 agent 携带已见 seq。journal 覆盖则回放 op 批；覆盖不到（或 session 冷）回退 `transcript.reset`，`complete: false` 时调用方应全量刷新。
+- `transcript_since`：可选，按 agent 携带已见 seq。journal 覆盖则回放 op 批；覆盖不到（或 session 冷）回退 `transcript.reset`。
 - `unsubscribe_v2`：`{ agent_ids? }`，缺省摘除整个 session 的 transcript 订阅；被摘除的 agent 恢复接收 legacy session_event。
 - grade 升级触发重发 reset；降级/同级不重发。
 
 ### 4.2 下发帧
 
-```json
-{ "type": "transcript.ops",
-  "session_id": "<sid>",
-  "payload": { "agent_id": "main", "seq": 43, "ops": [ /* TranscriptOp[] */ ] } }
+transcript 帧包裹在 session 事件 envelope 中（外层 `seq` 是 session 事件 journal 序号，与 `payload.seq` 的 transcript op-batch 序号无关）：
 
-{ "type": "transcript.reset",
-  "session_id": "<sid>",
-  "payload": { "agent_id": "main",
+```json
+{ "type": "transcript.ops", "seq": 137, "epoch": "...", "volatile": true,
+  "session_id": "<sid>", "timestamp": "<ISO>",
+  "payload": { "type": "transcript.ops", "agent_id": "main",
+               "ops": [ /* TranscriptOp[] */ ], "seq": 43 } }
+
+{ "type": "transcript.reset", "seq": 136, "volatile": true, "session_id": "<sid>",
+  "payload": { "type": "transcript.reset", "agent_id": "main",
                "snapshot": { "items": [], "tasks": [], "interactions": [],
-                             "attachments": [], "todos": [],
-                             "prompts": { "records": [], "active": null, "queued": [] },
-                             "meta": {} },
-               "has_more_older": true,
-               "seq": 43 } }
+                             "attachments": [], "todos": [], "prompts": [], "meta": {} },
+               "has_more_older": true, "seq": 43 } }
 ```
 
 - baseline reset 恒为 `items: []`（`TRANSCRIPT_RESET_TAIL_TURNS = 0`），历史一律走 REST 分页。
-- 外层不携带 session-event journal seq；`payload.seq` 是 transcript op-batch 序号。
+- 发送时机：首次订阅（history backfill 完成后）、grade 升级、roster 出现新 agent。
 
 ### 4.3 粒度过滤
 
@@ -275,16 +267,16 @@ interface TranscriptMeta {
 
 | op 类型 | off | turn | block | delta |
 |---|---|---|---|---|
-| turn.upsert / meta.merge / task / interaction / marker / todo / prompt.* / attachment / items.remove | — | ✓ | ✓ | ✓ |
+| turn.upsert / meta.merge / task / interaction / marker / todo / prompt / attachment / items.remove | — | ✓ | ✓ | ✓ |
 | step.upsert / frame.upsert | — | — | ✓（全量帧） | ✓ |
 | append | — | — | — | ✓ |
-| reset 快照 | — | turn 的 steps 掏空 | 完整 | 完整 |
+| reset 快照 | — | turn 的 steps 掏空为 `[]` | 完整 | 完整 |
 
-block 订阅者在流式期间只收 `frame.upsert` 空帧；step 完成时 fold 会补发一次全量帧（flush），因此 block 级也能拿到完整文本。
+block 订阅者在流式期间只收 `frame.upsert` 空帧；step 完成时 projector 的 flushOpenFrames 会补发一次全量帧，因此 block 级也能拿到完整文本。
 
 ### 4.4 legacy 事件抑制
 
-连接对某 agent 订阅了 transcript（grade ≠ off）后，该连接 × agent 的 transcript 投影类 legacy session_event 不再下发；journal 仍记录，未订阅连接不受影响。`prompt.queued` 是唯一例外（双通道都发）。
+连接对某 agent 订阅了 transcript（grade ≠ off）后，该连接 × agent 的 transcript 投影类 legacy session_event（`TRANSCRIPT_PROJECTED_EVENT_TYPES`，49 种）不再下发；journal 仍记录，未订阅连接不受影响。`prompt.queued` 是唯一例外（不在抑制集，双通道都发）。
 
 ## 五、REST API
 
@@ -292,18 +284,18 @@ block 订阅者在流式期间只收 `frame.upsert` 空帧；step 完成时 fold
 
 ### 5.1 `GET /sessions/{id}/transcript`
 
-query：`agent_id`、`before_turn | after_turn`、`page_size`（默认尾页 20 turn，上限 100）。
+query：`agent_id`（必填）、`before_turn | after_turn`（互斥）、`page_size`（1-100，默认尾页 20 turn）。
 
 ```json
 { "agent_id": "main", "items": [ /* Turn | Marker | TaskRef */ ],
   "has_more": true,
   "tasks": [], "interactions": [], "attachments": [], "todos": [],
-  "prompts": { "records": [], "active": null, "queued": [] },
-  "meta": {}, "agents": [ /* AgentDescriptor */ ],
+  "prompts": [], "meta": {},
+  "agents": [ /* AgentDescriptor */ ],
   "pending_interactions": [], "seq": 43 }
 ```
 
-`seq` 是该 agent 当前 watermark。live 读内存 store，cold 从 wire.jsonl fold 重建，结果一致。
+`seq` 是该 agent 当前 watermark。live 读内存 store，cold 从 wire.jsonl 重建。
 
 ### 5.2 `GET /sessions/{id}/transcript/ops`
 
@@ -316,39 +308,52 @@ query：`agent_id`、`since_seq`。
   "complete": true }
 ```
 
-`complete: false` = journal 覆盖不到或 session 冷 → 调用方全量刷新（重新拿 reset/分页）。
+`complete: false` = journal 覆盖不到或 session 冷 → 调用方全量刷新。
 
-### 5.3 其他
+### 5.3 `GET /sessions/{id}/transcript/user-messages`
 
-- `GET /sessions/{id}/transcript/user-messages`：用户消息列表。
-- `GET /sessions/{id}/transcript/plan?agent_id=[&tool_call_id=]`：ExitPlanMode 计划信息。
+按 agent 返回用户消息列表：
 
-## 六、派生 selector
-
-以下量不存储，由消费方（或 L4 view 层）从 AgentState 派生：
-
-```ts
-function deriveActivity(state: AgentState): 'idle' | 'turn';
-function deriveAgentPhase(state: AgentState): AgentPhase;
+```json
+{ "agents": [ { "agent_id": "main",
+                "messages": [ { "turn_id": "t1", "ordinal": 1, "state": "completed",
+                                "origin": { "kind": "user" }, "prompt": "...",
+                                "attachment_ids": [], "started_at": "..." } ],
+                "attachments": [] } ] }
 ```
 
-- `deriveActivity`：存在 running 的 turn **或** running 的 task → `'turn'`，否则 `'idle'`。
-- `deriveAgentPhase`：`pendingInteractions` 非空 → `awaiting_approval`；最新 turn 非 running → `idle`；当前 step 有 `retry` → `retrying`；有 running 的 tool frame → `tool_call`；有未关闭的 text/thinking frame → `streaming`；否则 `running`。kind ∈ `idle | running | streaming | tool_call | retrying | awaiting_approval`。
+### 5.4 `GET /sessions/{id}/transcript/plan`
 
-## 七、事件来源（fold 输入）
+query：`agent_id`（必填）、`tool_call_id`（可选，窄化到单个调用）。
 
-transcript 只 fold durable 记录。消费方无需直接读 wire.jsonl，但理解字段来源有助于排查：
+```json
+{ "agent_id": "main",
+  "plans": [ { "tool_call_id": "call_1", "turn_id": "t1",
+               "source": "interaction", "plan": "...", "path": "...",
+               "options": [ { "label": "...", "description": "..." } ],
+               "review": { "state": "approved", "selected_option": "...", "feedback": "..." } } ] }
+```
 
-- **骨架**：`turn.prompt`（turn 开始，fire 于 `startTurn`）、`turn.ended`、`turn.cancel`、`turn.steer`、`context.append_message`、`context.append_loop_event`（step.begin / content.part / tool.call / tool.result / step.end）、`context.undo/clear/apply_compaction`。
-- **实体**：`task.started/terminated`、`interaction.request/resolved`、`goal.*`、`plan_mode.*/swarm_mode.*/tower_mode.*/plan.revision`、`tools.update_store`。
-- **数值与诊断**：`step.end` 内嵌（usage/timing/finishReason）、`profile.bind`、`config.update`、`token_counting.*`、`permission.set_mode`、`usage.record`、`turn.step.retrying`、`prompt.*`、`subagent.*`、`error`、`warning`、`cron.fired`。
-- **派生规则**：有 `turn.prompt` 无 `turn.ended` → `failed + endReason:'lost'`；`turn.ended.reason='blocked'` → `failed + endReason:'blocked'`。
+## 六、Session 级 work 状态
 
-session 级忙闲（会话列表）走另一通道：`event.session.work_changed`（`busy / main_turn_active / pending_interaction / last_turn_id / last_turn_reason`），只用于整体忙闲显示与恢复旁证，不参与 prompt 精确结算。
+session 粒度的忙闲由 core 的 `ISessionActivityView` 聚合，经 `event.session.work_changed` 下发：
+
+```json
+{ "busy": false, "main_turn_active": false,
+  "pending_interaction": "none", "last_turn_reason": "completed" }
+```
+
+`pending_interaction` ∈ `none | approval | question`；`last_turn_reason` ∈ `completed | cancelled | failed`。同一 view 也服务 REST 的 session facts 与 v2 `activity.status`（`approval > question > running > failed > idle`）。
+
+## 七、事件来源
+
+live projector 消费的 core observable 事件（主要）：`turn.started`、`turn.ended`、`turn.step.started/completed/interrupted/retrying`、`assistant.delta`、`thinking.delta`、`tool.call.started/delta`、`tool.result`、`tool.progress`、`task.started/terminated/notified`、`shell.started/output/completed`、`subagent.spawned/started/completed/failed/suspended`、`prompt.accepted/queued/submitted/started/completed/aborted/steered`、`goal.updated`、`agent.status.updated`、`agent.activity.updated`、`interaction.request/resolved`（经 session 交互状态订阅）、`error`、`warning`、`hook.result`、`cron.fired`、`skill.activated`、`plugin_command.activated`、`compaction.*`、`context.spliced/undone`。
+
+cold fold 消费的 durable record type：`turn.prompt`、`turn.ended`、`turn.cancel`、`turn.steer`、`turn.step.interrupted`、`context.append_message`、`context.append_loop_event`（内嵌 `step.begin` / `step.end` / `content.part` / `tool.call` / `tool.result`）、`context.undo/clear/apply_compaction`、`interaction.request/resolved`、`task.started/terminated`、`goal.create/update/clear`、`plan_mode.enter/exit/cancel`、`plan.revision`、`swarm_mode.enter/exit`、`tower_mode.enter/exit`、`tools.update_store`。
 
 ## 八、版本与迁移约定
 
-1. **契约载体**：`packages/transcript/src/contract/schema.ts` 的 zod schema 是 wire 契约的唯一权威定义；本文档是其可读形式。两者冲突时以 schema 为准并修正本文档。
+1. **契约载体**：`src/contract/schema.ts` 的 zod schema 是 wire 契约的唯一权威定义；本文档是其可读形式。两者冲突时以 schema 为准并修正本文档。
 2. **wire.jsonl 只增不改**：允许新增 record type、给既有 record 新增 optional 字段；禁止删除/改名/改语义。旧文件必须永远可回放（zod optional 保证 safeParse 通过）。
 3. **transcript 契约变更必须附带 migration 文档**：任何对实体字段、op 类型、帧结构、REST 响应、grade 语义的增删改，都需要在 `docs/migrations/` 下新增 `NNNN-<kebab-title>.md`，编号递增。migration 文档必含五节：
    - **变更摘要**：一句话说明改了什么、为什么。
@@ -357,4 +362,4 @@ session 级忙闲（会话列表）走另一通道：`event.session.work_changed
    - **wire 兼容性**：新增记录类型清单；旧 wire.jsonl 的回放行为。
    - **回滚**：如何回退，回退后旧客户端看到什么。
 4. **纯新增（新 op、新 optional 字段、新枚举值且有默认处理）只需 changeset**，不需要 migration 文档；migration 文档针对删除、改名、语义变更。
-5. 首份 migration：`docs/migrations/0001-state-model-unification.md`（本次状态模型统一，随重构落地）。
+5. 规划中的首份 migration：`docs/migrations/0001-state-model-unification.md`（状态模型统一重构，设计稿在工作区，落地时随代码一并进入仓库）。


### PR DESCRIPTION
## Related Issue

Internal docs task, no linked issue. Follow-up to #3432.

## Problem

#3432 landed `packages/transcript/docs/sdk.md` describing the *target* contract of the not-yet-implemented state-model unification. An SDK document on main must describe the contract as it exists today; describing an unimplemented design risks misleading every consumer who reads it as the current surface.

## What changed

Rewrite `packages/transcript/docs/sdk.md` against the current implementation, verified against `src/contract/schema.ts`, the model layer, and the kap-server WS/REST surface:

- Documents the contract as implemented today: entities with their current enums (Turn 5-state, Prompt 6-status, meta.activity / agent.phase, hook marker, etc.), the 14-member op union, subscribe_v2 / transcript.ops / transcript.reset frames with the session-event envelope, grade filtering, legacy event suppression, and all four REST endpoints with their response shapes.
- Marks declared-but-unwritten values explicitly (Turn `'queued'`, Step `'failed'`, TaskKind `'tool'`, TurnOrigin `'side'`, AgentMeta `'independent'`, activity `'disposing'/'unknown'`, `permission`/`contextUsage`), and documents the cold-rebuild known limitations (retry/usage/timing/phase/prompts not backfilled; crash-interrupted turns fold to `'completed'`; interrupt reason backfilled since #3428).
- Keeps the versioning/migration convention (contract changes require a numbered migration doc under `docs/migrations/`); the state-model unification is referenced only as a planned migration, not as the documented reality.
- Updates the "Contract documentation" section of `packages/transcript/AGENTS.md` accordingly.

Docs-only change; no changeset per the gen-changesets rules.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
