### PR TITLE
refactor(vis): migrate vis from agent-core v1 to agent-core-v2

### DIFF
--- a/apps/vis/package.json
+++ b/apps/vis/package.json
@@ -6,10 +6,8 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build:deps": "pnpm --filter @moonshot-ai/agent-core... build",
-    "predev": "pnpm run build:deps",
     "dev": "node scripts/dev.mjs",
-    "build": "pnpm run build:deps && pnpm --filter @moonshot-ai/vis-server build && pnpm --filter @moonshot-ai/vis-web build && node scripts/copy-web-dist.mjs",
+    "build": "pnpm --filter @moonshot-ai/vis-server build && pnpm --filter @moonshot-ai/vis-web build && node scripts/copy-web-dist.mjs",
     "prestart": "pnpm run build",
     "start": "node server/dist/server.mjs"
   },

--- a/apps/vis/server/package.json
+++ b/apps/vis/server/package.json
@@ -22,15 +22,14 @@
     }
   },
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch --import ../../../build/register-raw-text-loader.mjs src/index.ts",
     "build": "tsdown",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",
-    "@moonshot-ai/agent-core": "workspace:^",
-    "@moonshot-ai/kosong": "workspace:^",
+    "@moonshot-ai/agent-core-v2": "workspace:^",
     "hono": "^4.7.7",
     "yauzl": "^3.3.0"
   },

--- a/apps/vis/server/src/lib/agent-record-types.ts
+++ b/apps/vis/server/src/lib/agent-record-types.ts
@@ -1,78 +1,213 @@
 // apps/vis/server/src/lib/agent-record-types.ts
-// Single source of truth: everything below comes from agent-core directly.
-// Do NOT add local interfaces that duplicate upstream shapes.
+// Single source of truth: engine shapes come from agent-core-v2 directly.
+// Do NOT add local interfaces that duplicate upstream shapes — the only
+// exceptions are the legacy records below, which v2 never writes but old
+// (v1-written / pre-migration) wires still contain on disk.
 
 export type {
-  AgentRecordEvents,
-  AgentConfigUpdateData,
-  CompactionBeginData,
-  CompactionResult,
-  PermissionApprovalResultRecord,
-  PermissionMode,
-  UsageRecordScope,
-  ToolStoreUpdate,
-  LoopRecordedEvent,
   ContextMessage,
+  LoopRecordedEvent,
+  Message,
+  ContentPart,
+  ToolCall,
+  TokenUsage,
+  PermissionMode,
   PromptOrigin,
-  // Background-task shapes are part of agent-core's public surface, so the
-  // visualizer tracks them directly instead of duplicating the union.
-  BackgroundTaskInfo,
-  BackgroundTaskStatus,
-  ProcessBackgroundTaskInfo,
-  AgentBackgroundTaskInfo,
-  QuestionBackgroundTaskInfo,
-} from '@moonshot-ai/agent-core';
-export { AGENT_WIRE_PROTOCOL_VERSION } from '@moonshot-ai/agent-core';
-export type { Message, ContentPart, ToolCall, TokenUsage } from '@moonshot-ai/kosong';
+  CronTask,
+} from '@moonshot-ai/agent-core-v2';
+export { WIRE_PROTOCOL_VERSION } from '@moonshot-ai/agent-core-v2/wire/migration/migration';
+export type {
+  AgentTaskInfo as BackgroundTaskInfo,
+  AgentTaskStatus as BackgroundTaskStatus,
+} from '@moonshot-ai/agent-core-v2';
+export type { SubagentTaskInfo as AgentBackgroundTaskInfo } from '@moonshot-ai/agent-core-v2';
+export type { ProcessTaskInfo as ProcessBackgroundTaskInfo } from '@moonshot-ai/agent-core-v2/agent/tools/os/bash/process-task';
+export type { QuestionTaskInfo as QuestionBackgroundTaskInfo } from '@moonshot-ai/agent-core-v2/agent/tools/ask-user-question/question-background-task';
 
-// Local bindings for the upstream types referenced by the vis-only DTOs
-// below. The `export type { … }` re-export above forwards the names to
-// consumers but does NOT bring them into this module's scope.
 import type {
-  AgentRecord as UpstreamAgentRecord,
-  BackgroundTaskInfo,
-} from '@moonshot-ai/agent-core';
+  AgentTaskInfo as BackgroundTaskInfo,
+  CronAddPayload,
+  CronCursorPayload,
+  CronDeletePayload,
+  CronTask,
+  FullCompactionBegin,
+  FullCompactionCancel,
+  FullCompactionComplete,
+  GoalClear,
+  GoalCreate,
+  GoalForked,
+  GoalUpdate,
+  InteractionRequestEvent,
+  InteractionResolvedEvent,
+  InterruptionReminderRecorded,
+  LlmRequest,
+  LlmToolsSnapshot,
+  McpToolsDiscovered,
+  PlanModeCancel,
+  PlanModeEnter,
+  PlanModeExit,
+  PlanRevision,
+  PluginSessionStartEvent,
+  PromptAborted,
+  PromptAccepted,
+  PromptCompleted,
+  PromptSteered,
+  TaskStarted,
+  TaskTerminated,
+  TaskWaitDelivered,
+  TokenCountingMeasured,
+  TokenCountingRebased,
+  TokenCountingTruncated,
+  TokenCountingTurnRecorded,
+  ToolsRegisterUserTool,
+  ToolsUnregisterUserTool,
+} from '@moonshot-ai/agent-core-v2';
+import type {
+  ContextAppendLoopEvent,
+  ContextAppendMessage,
+  ContextApplyCompactionPayload,
+  ContextClear,
+  ContextUndo,
+} from '@moonshot-ai/agent-core-v2/agent/contextMemory/contextEvents';
+import type { TurnCancel, TurnEnded, TurnPrompt, TurnSteer } from '@moonshot-ai/agent-core-v2/agent/loop/turnOps';
+import type { TurnStepInterrupted } from '@moonshot-ai/agent-core-v2/agent/loop/turnEvents';
+import type { TurnStepRetrying } from '@moonshot-ai/agent-core-v2/agent/stepRetry/stepRetryService';
+import type { UsageRecord } from '@moonshot-ai/agent-core-v2/agent/usage/usageOps';
+import type {
+  ConfigUpdate,
+  ProfileBind,
+  ToolsResetActiveTools,
+  ToolsSetActiveTools,
+} from '@moonshot-ai/agent-core-v2/agent/profile/profileOps';
+import type { PermissionSetMode } from '@moonshot-ai/agent-core-v2/agent/permissionMode/permissionModeOps';
+import type { PermissionRecordApprovalResult } from '@moonshot-ai/agent-core-v2/agent/permissionRules/permissionRulesOps';
+import type { RuntimeSetBinding } from '@moonshot-ai/agent-core-v2/agent/runtimeBinding/runtimeBindingOps';
+import type { SwarmModeEnter, SwarmModeExit } from '@moonshot-ai/agent-core-v2/features/swarm/swarmOps';
+import type { TowerModeEnter, TowerModeExit } from '@moonshot-ai/agent-core-v2/features/tower/towerOps';
+import type {
+  StaleGuardCleared,
+  StaleGuardRecorded,
+} from '@moonshot-ai/agent-core-v2/features/staleGuard/staleGuardOps';
+import type { ToolsUpdateStore } from '@moonshot-ai/agent-core-v2/features/todo/todoOps';
+
+/** A wire record with v2's literal `type` discriminant restored. v2 declares
+ *  records as Event2 class + payload interface mergings whose `type` field is
+ *  the widened `string`; intersecting with the literal keeps the union below
+ *  discriminated. `time` stays optional because pre-1.5 wires may lack it. */
+type WireRecordOf<T extends string, E> = E extends unknown
+  ? Omit<E, 'type' | 'time' | 'serialize'> & { readonly type: T; readonly time?: number }
+  : never;
+
+/** v1-only durable record: dropped from v2 (`token_counting.*` carries the
+ *  context-window fill now), but old wires still contain it. */
+export interface ContextUpdateTokenCountRecord {
+  readonly type: 'context.update_token_count';
+  readonly tokenCount: number;
+  readonly time?: number;
+}
+
+/** v1-only durable record: v2 has no micro-compaction, but old wires still
+ *  contain it. */
+export interface MicroCompactionApplyRecord {
+  readonly type: 'micro_compaction.apply';
+  readonly cutoff: number;
+  readonly time?: number;
+}
+
+/** The wire file header record. Declared locally (rather than via v2's
+ *  `WireMetadataRecord`) so the union member keeps concrete field types —
+ *  the upstream interface carries an index signature that would widen
+ *  `protocol_version` / `created_at` to `unknown`. */
+export interface WireMetadataHeader {
+  readonly type: 'metadata';
+  readonly protocol_version: string;
+  readonly created_at: number;
+  readonly time?: number;
+}
 
 /**
- * The wire record union vis projects, widened with the v2-engine tower-mode
- * records (`tower_mode.enter` / `tower_mode.exit`, empty payloads). The
- * upstream v1 union is frozen ahead of its deprecation and does not carry
- * them; the local widening keeps the context projector's exhaustiveness
- * check covering tower session wires.
+ * The wire record union vis projects: every durable record kind v2 can write
+ * (the wire-manifest inventory) plus the v1-only legacy kinds above, which
+ * survive in old wires unchanged (the migration chain never drops records).
+ * The union keeps the context projector's exhaustiveness check covering every
+ * record a wire file can hold.
  */
 export type AgentRecord =
-  | UpstreamAgentRecord
-  | { readonly type: 'tower_mode.enter'; readonly time?: number }
-  | { readonly type: 'tower_mode.exit'; readonly time?: number };
+  | WireMetadataHeader
+  | WireRecordOf<'config.update', ConfigUpdate>
+  | WireRecordOf<'context.append_loop_event', ContextAppendLoopEvent>
+  | WireRecordOf<'context.append_message', ContextAppendMessage>
+  | WireRecordOf<'context.apply_compaction', ContextApplyCompactionPayload>
+  | WireRecordOf<'context.clear', ContextClear>
+  | WireRecordOf<'context.undo', ContextUndo>
+  | WireRecordOf<'cron.add', CronAddPayload>
+  | WireRecordOf<'cron.cursor', CronCursorPayload>
+  | WireRecordOf<'cron.delete', CronDeletePayload>
+  | WireRecordOf<'forked', GoalForked>
+  | WireRecordOf<'full_compaction.begin', FullCompactionBegin>
+  | WireRecordOf<'full_compaction.cancel', FullCompactionCancel>
+  | WireRecordOf<'full_compaction.complete', FullCompactionComplete>
+  | WireRecordOf<'goal.clear', GoalClear>
+  | WireRecordOf<'goal.create', GoalCreate>
+  | WireRecordOf<'goal.update', GoalUpdate>
+  | WireRecordOf<'interaction.request', InteractionRequestEvent>
+  | WireRecordOf<'interaction.resolved', InteractionResolvedEvent>
+  | WireRecordOf<'interruptionReminder.recorded', InterruptionReminderRecorded>
+  | WireRecordOf<'llm.request', LlmRequest>
+  | WireRecordOf<'llm.tools_snapshot', LlmToolsSnapshot>
+  | WireRecordOf<'mcp.tools_discovered', McpToolsDiscovered>
+  | WireRecordOf<'permission.record_approval_result', PermissionRecordApprovalResult>
+  | WireRecordOf<'permission.set_mode', PermissionSetMode>
+  | WireRecordOf<'plan_mode.cancel', PlanModeCancel>
+  | WireRecordOf<'plan_mode.enter', PlanModeEnter>
+  | WireRecordOf<'plan_mode.exit', PlanModeExit>
+  | WireRecordOf<'plan.revision', PlanRevision>
+  | WireRecordOf<'plugin.session_start', PluginSessionStartEvent>
+  | WireRecordOf<'profile.bind', ProfileBind>
+  | WireRecordOf<'prompt.aborted', PromptAborted>
+  | WireRecordOf<'prompt.accepted', PromptAccepted>
+  | WireRecordOf<'prompt.completed', PromptCompleted>
+  | WireRecordOf<'prompt.steered', PromptSteered>
+  | WireRecordOf<'runtime.set_binding', RuntimeSetBinding>
+  | WireRecordOf<'staleGuard.cleared', StaleGuardCleared>
+  | WireRecordOf<'staleGuard.recorded', StaleGuardRecorded>
+  | WireRecordOf<'swarm_mode.enter', SwarmModeEnter>
+  | WireRecordOf<'swarm_mode.exit', SwarmModeExit>
+  | WireRecordOf<'task.started', TaskStarted>
+  | WireRecordOf<'task.terminated', TaskTerminated>
+  | WireRecordOf<'task.waitDelivered', TaskWaitDelivered>
+  | WireRecordOf<'token_counting.measured', TokenCountingMeasured>
+  | WireRecordOf<'token_counting.rebased', TokenCountingRebased>
+  | WireRecordOf<'token_counting.truncated', TokenCountingTruncated>
+  | WireRecordOf<'token_counting.turn_recorded', TokenCountingTurnRecorded>
+  | WireRecordOf<'tools.register_user_tool', ToolsRegisterUserTool>
+  | WireRecordOf<'tools.reset_active_tools', ToolsResetActiveTools>
+  | WireRecordOf<'tools.set_active_tools', ToolsSetActiveTools>
+  | WireRecordOf<'tools.unregister_user_tool', ToolsUnregisterUserTool>
+  | WireRecordOf<'tools.update_store', ToolsUpdateStore>
+  | WireRecordOf<'tower_mode.enter', TowerModeEnter>
+  | WireRecordOf<'tower_mode.exit', TowerModeExit>
+  | WireRecordOf<'turn.cancel', TurnCancel>
+  | WireRecordOf<'turn.ended', TurnEnded>
+  | WireRecordOf<'turn.prompt', TurnPrompt>
+  | WireRecordOf<'turn.steer', TurnSteer>
+  | WireRecordOf<'turn.step.interrupted', TurnStepInterrupted>
+  | WireRecordOf<'turn.step.retrying', TurnStepRetrying>
+  | WireRecordOf<'usage.record', UsageRecord>
+  | ContextUpdateTokenCountRecord
+  | MicroCompactionApplyRecord;
 
-/** Extract one record kind from the (locally widened) union. */
+/** Extract one record kind from the union. */
 export type AgentRecordOf<K extends AgentRecord['type']> = Extract<
   AgentRecord,
   { readonly type: K }
 >;
 
 /**
- * Persistent representation of a cron task.
- *
- * Structural mirror of agent-core's `CronTask` (`tools/cron/types.ts`),
- * which is NOT re-exported from the package entry point. The shape is
- * tiny and frozen; `cron-store.test.ts` reads a fixture written in the
- * real on-disk format so the mirror cannot silently drift from disk.
- */
-export interface CronTask {
-  readonly id: string;
-  readonly cron: string;
-  readonly prompt: string;
-  readonly createdAt: number;
-  readonly recurring?: boolean;
-  readonly lastFiredAt?: number;
-}
-
-/**
  * `manifest.json` shape inside a `/export-debug-zip` bundle. Structural
- * mirror of agent-core's `ExportSessionManifest` (`rpc/core-api.ts`), which
- * is not re-exported from the package entry. All fields optional-tolerant
- * because the manifest comes from another machine / kimi-code version.
+ * mirror of the engine's `ExportSessionManifest`, which is not re-exported
+ * from the package entry. All fields optional-tolerant because the manifest
+ * comes from another machine / kimi-code version.
  */
 export interface ImportManifest {
   sessionId?: string;
@@ -151,10 +286,11 @@ export interface AgentInfo {
   wireExists: boolean;
   wireRecordCount: number;
   wireProtocolVersion: string | null;
-  /** Per-item swarm work label persisted by agent-core for swarm-spawned
-   *  sub-agents (`AgentMeta.swarmItem`). `null` when the agent is not a
-   *  swarm item or when the value cannot be recovered (e.g. disk-only
-   *  inventory of a session with a corrupt `state.json`). */
+  /** Per-item swarm work label persisted by the engine for swarm-spawned
+   *  sub-agents (`AgentMeta.swarmItem`, or `AgentMeta.labels.swarmItem` on
+   *  v2-written sessions). `null` when the agent is not a swarm item or when
+   *  the value cannot be recovered (e.g. disk-only inventory of a session
+   *  with a corrupt `state.json`). */
   swarmItem: string | null;
 }
 
@@ -213,7 +349,7 @@ export interface AgentTreeResponse {
 // ── background tasks & cron ─────────────────────────────────────────────────
 
 /** A persisted background task plus vis-derived `output.log` metadata.
- *  `task` is the normalized agent-core shape; the size/exists fields let the
+ *  `task` is the normalized engine shape; the size/exists fields let the
  *  UI badge how much output a task produced and offer a "view log" affordance
  *  without first fetching the (potentially large) log body. */
 export interface BackgroundTaskEntry {

--- a/apps/vis/server/src/lib/agent-tree.ts
+++ b/apps/vis/server/src/lib/agent-tree.ts
@@ -40,7 +40,7 @@ function sortAgents(a: AgentNode, b: AgentNode): number {
  * numeric suffix (so `agent-2` precedes `agent-10`), with a lexicographic
  * fallback for any id that does not match the `agent-N` shape.
  *
- * In practice a sibling set is `main` plus `agent-N` ids (agent-core's id
+ * In practice a sibling set is `main` plus `agent-N` ids (the engine's id
  * generator only emits those). The `na`/`nb`-only branches below exist solely
  * to keep a stable TOTAL order when foreign/hand-edited ids (reachable via
  * `state.json` keys or `discoverAgentsFromDisk` directory names) are mixed in:

--- a/apps/vis/server/src/lib/context-projector.ts
+++ b/apps/vis/server/src/lib/context-projector.ts
@@ -4,15 +4,14 @@ import {
   buildCompactionElisionText,
   collectCompactableUserMessages,
   isRealUserInput,
-  renderToolResultForModel,
   selectCompactionUserMessages,
   selectRecentUserMessages,
-} from '@moonshot-ai/agent-core';
+} from '@moonshot-ai/agent-core-v2/agent/contextMemory/compactionHandoff';
+import { renderToolResultForModel } from '@moonshot-ai/agent-core-v2/agent/contextMemory/toolResultRender';
 import type {
   ContentPart,
   ContextMessage,
   PermissionMode,
-  AgentConfigUpdateData,
   TokenUsage,
   ToolCall,
   WireEntry,
@@ -26,8 +25,9 @@ export interface ProjectedMessage {
   toolStepUuids: string[];
   /** Set only when source === 'undo'. */
   undo?: { count: number; removedMessageCount: number };
-  /** Set only on the summary bubble of source === 'compaction_summary'. */
-  compaction?: { compactedCount: number; tokensBefore: number; tokensAfter: number };
+  /** Set only on the summary bubble of source === 'compaction_summary'.
+   *  `tokensBefore`/`tokensAfter` are absent on legacy payload variants. */
+  compaction?: { compactedCount: number; tokensBefore?: number; tokensAfter?: number };
 }
 
 export interface UsageTotals {
@@ -58,11 +58,11 @@ export interface GoalSnapshot {
 export interface ContextProjection {
   messages: ProjectedMessage[];
   usage: UsageTotals;
-  /** Absolute current context-window fill, mirroring agent-core
-   *  ContextMemory._tokenCount. Updated from the latest step.end.usage, and
-   *  also reset on the lifecycle events agent-core touches: context.clear → 0,
-   *  context.apply_compaction → tokensAfter. Distinct from the cumulative
-   *  `usage` totals. */
+  /** Absolute current context-window fill, mirroring the engine's token
+   *  counting state. Updated from the latest step.end.usage and the
+   *  token_counting.* records, and also reset on the lifecycle events the
+   *  engine touches: context.clear → 0, context.apply_compaction →
+   *  tokensAfter. Distinct from the cumulative `usage` totals. */
   contextTokens: number;
   config: ConfigSnapshot;
   permission: { mode: PermissionMode | null };
@@ -74,8 +74,8 @@ export interface ContextProjection {
 const ZERO: TokenUsage = { inputOther: 0, output: 0, inputCacheRead: 0, inputCacheCreation: 0 };
 
 /** Build a conversation timeline + derived state from a sequence of
- *  wire entries. The reconstruction mirrors agent-core's own
- *  `appendLoopEvent` logic, so:
+ *  wire entries. The reconstruction mirrors the engine's own loop-event
+ *  fold logic, so:
  *
  *  - `context.append_message` records become messages as-is (the
  *    user / tool messages and any explicit assistant injections).
@@ -84,10 +84,10 @@ const ZERO: TokenUsage = { inputOther: 0, output: 0, inputCacheRead: 0, inputCac
  *    that same message** to grow its content / toolCalls. `step.end`
  *    just closes the step.
  *  - `tool.result` events emit an independent `role: 'tool'` message,
- *    matching how agent-core surfaces tool exchanges to the model.
+ *    matching how the engine surfaces tool exchanges to the model.
  *
  *  Without this loop-event reconstruction the timeline would only
- *  show user prompts — agent-core does not emit a synthetic
+ *  show user prompts — the engine does not emit a synthetic
  *  `context.append_message` for assistant turns.
  *
  *  `mode` selects between two views of the four destructive lifecycle
@@ -135,7 +135,7 @@ export function projectContext(
           lineNo: entry.lineNo,
           time: rec.time,
           source: 'append_message',
-          message: rec.message,
+          message: normalizeLegacyOrigin(rec.message),
           toolStepUuids: [],
         });
         break;
@@ -178,11 +178,11 @@ export function projectContext(
             });
           }
         } else if (ev.type === 'step.end') {
-          // Absolute context-window fill, mirroring agent-core
-          // ContextMemory._tokenCount: the latest step.end usage REPLACES the
+          // Absolute context-window fill, mirroring the engine's token
+          // counting state: the latest step.end usage REPLACES the
           // snapshot (it is not cumulative — see Task P1.7 note on byScope).
           // A zero-usage step.end (e.g. a content-filtered response) is the one
-          // exception agent-core makes — it keeps the prior count instead of
+          // exception the engine makes — it keeps the prior count instead of
           // resetting to 0 — so guard against a false drop here too.
           if ('usage' in ev && ev.usage !== undefined) {
             const fill =
@@ -195,7 +195,7 @@ export function projectContext(
           openSteps.delete(ev.uuid);
         } else if (ev.type === 'tool.result') {
           // Mirror what the MODEL saw, not the raw output. This calls the
-          // SAME `renderToolResultForModel` agent-core applies at its LLM
+          // SAME `renderToolResultForModel` the engine applies at its LLM
           // projection boundary (error status prefix, empty-output
           // placeholder, trailing note), so vis's model view is the real
           // projection rather than a hand-kept copy.
@@ -224,7 +224,8 @@ export function projectContext(
         if (mode === 'model') {
           messages = [];
           openSteps = new Map();
-          // Mirror agent-core clear() → microCompaction.reset() (cutoff → 0):
+          // Mirror the engine's clear() → legacy micro-compaction cutoff
+          // reset (→ 0):
           // the message indices are wiped, so any prior cutoff is meaningless.
           microCutoff = 0;
         } else {
@@ -243,48 +244,65 @@ export function projectContext(
             toolStepUuids: [],
           });
         }
-        // Mirror agent-core clear() → _tokenCount = 0: the context-window fill is
-        // wiped. Derived state, so it is mode-INDEPENDENT (applied for both modes).
+        // Mirror the engine's clear() → token count = 0: the context-window
+        // fill is wiped. Derived state, so it is mode-INDEPENDENT (applied for
+        // both modes).
         contextTokens = 0;
         break;
       case 'context.apply_compaction': {
         openSteps = new Map();
-        // Mirror agent-core's `applyCompaction`
-        // (`packages/agent-core/src/agent/context/index.ts`): the live history
+        // Mirror the engine's applyCompaction
+        // (`packages/agent-core-v2/src/agent/contextMemory/`): the live history
         // becomes the kept real user messages (verbatim, within a token budget
         // — the oldest head plus the most recent tail, separated by an elision
         // marker when the pool overflowed) followed by a single user-role
         // summary tagged `origin.kind = 'compaction_summary'`. Assistant
         // messages, tool calls, and tool results are dropped. The selection
         // rules (`selectCompactionUserMessages` / `selectRecentUserMessages` /
-        // `collectCompactableUserMessages`) are the same helpers agent-core's
-        // `ContextMemory` and the web transcript reducer apply, so all three
+        // `collectCompactableUserMessages`) are the same helpers the engine's
+        // context memory and the web transcript reducer apply, so all three
         // views stay in sync.
+        //
+        // The v2 payload is a union of three variants: current records carry
+        // `summary` as a string (with `contextSummary` holding the
+        // model-facing variant when media degraded); a legacy variant carries
+        // the summary as a ContextMessage plus `count` instead of
+        // `compactedCount`. `tokensBefore`/`tokensAfter` are optional in all
+        // variants. Normalize before projecting.
+        const rawSummary = rec.summary;
+        const contextSummary = 'contextSummary' in rec ? rec.contextSummary : undefined;
+        const summaryText =
+          typeof rawSummary === 'string'
+            ? rawSummary
+            : rawSummary !== undefined
+              ? contextMessageText(rawSummary)
+              : (contextSummary ?? '');
+        const compactedCount = rec.compactedCount ?? ('count' in rec ? rec.count : 0);
         const summaryBubble: ProjectedMessage = {
           lineNo: entry.lineNo,
           time: rec.time,
           source: 'compaction_summary',
           message: {
             role: 'user',
-            content: [{ type: 'text', text: rec.summary }],
+            content: [{ type: 'text', text: summaryText }],
             toolCalls: [],
             origin: { kind: 'compaction_summary' },
           } as ContextMessage,
           toolStepUuids: [],
           compaction: {
-            compactedCount: rec.compactedCount,
+            compactedCount,
             tokensBefore: rec.tokensBefore,
             tokensAfter: rec.tokensAfter,
           },
         };
         const modelSummaryBubble: ProjectedMessage =
-          rec.contextSummary === undefined
+          contextSummary === undefined
             ? summaryBubble
             : {
                 ...summaryBubble,
                 message: {
                   ...summaryBubble.message,
-                  content: [{ type: 'text', text: rec.contextSummary }],
+                  content: [{ type: 'text', text: contextSummary }],
                 } as ContextMessage,
               };
         if (mode === 'model') {
@@ -292,15 +310,15 @@ export function projectContext(
           // and use the kept-user selection below; legacy records fall back to the
           // old verbatim-tail shape (handled first).
           const historyEntries = messages.filter(isHistoryEntry);
-          if (rec.keptUserMessageCount === undefined && rec.compactedCount < historyEntries.length) {
+          if (rec.keptUserMessageCount === undefined && compactedCount < historyEntries.length) {
             // Legacy (pre-rework) record: it has no `keptUserMessageCount`, so
-            // agent-core's ContextMemory restore reproduces the old
+            // the engine's context-memory restore reproduces the old
             // `[summary, ...history.slice(compactedCount)]` semantics — a verbatim
             // recent tail (assistant/tool included), not the new kept-user
             // selection. Mirror that exact shape so opening an older compacted
             // session in model mode shows the same tail the resumed agent still
             // holds, instead of hiding it behind the new selection.
-            messages = [modelSummaryBubble, ...historyEntries.slice(rec.compactedCount)];
+            messages = [modelSummaryBubble, ...historyEntries.slice(compactedCount)];
           } else if (rec.keptHeadUserMessageCount === undefined) {
             // Tail-only record: written before the head/tail split, or by new
             // code whose user pool fit the budget (the two selections agree in
@@ -374,15 +392,16 @@ export function projectContext(
           // marker inline so the compacted prefix stays visible.
           messages.push(summaryBubble);
         }
-        // Mirror agent-core applyCompaction() → microCompaction.reset() (cutoff
-        // → 0): the message list is rebuilt, so the old index-based cutoff no
-        // longer points at the same messages. (In full mode the blanking pass
-        // does not run, so this is a no-op there.)
+        // Mirror the engine's applyCompaction() → legacy micro-compaction
+        // cutoff reset (→ 0): the message list is rebuilt, so the old
+        // index-based cutoff no longer points at the same messages. (In full
+        // mode the blanking pass does not run, so this is a no-op there.)
         microCutoff = 0;
-        // Mirror agent-core applyCompaction() → _tokenCount = result.tokensAfter:
+        // Mirror applyCompaction() → _tokenCount = result.tokensAfter:
         // the live context-window fill is now the post-compaction count. Derived
-        // state, so it is mode-INDEPENDENT.
-        contextTokens = rec.tokensAfter;
+        // state, so it is mode-INDEPENDENT. `tokensAfter` is optional in the v2
+        // payload (absent on legacy variants) — keep the prior count then.
+        if (rec.tokensAfter !== undefined) contextTokens = rec.tokensAfter;
         break;
       }
       case 'usage.record': {
@@ -396,12 +415,27 @@ export function projectContext(
         break;
       }
       case 'config.update': {
-        const upd = rec as AgentConfigUpdateData & { type: 'config.update' };
-        if (upd.cwd !== undefined) config.cwd = upd.cwd;
-        if (upd.modelAlias !== undefined) config.modelAlias = upd.modelAlias;
-        if (upd.profileName !== undefined) config.profileName = upd.profileName;
-        if (upd.thinkingEffort !== undefined) config.thinkingEffort = upd.thinkingEffort;
-        if (upd.systemPrompt !== undefined) config.systemPrompt = upd.systemPrompt;
+        // v2 dropped top-level `cwd` (it lives in `environmentDisclosure`)
+        // and persists `thinkingLevel` on some records instead of
+        // `thinkingEffort`; accept both spellings.
+        if (rec.environmentDisclosure !== undefined)
+          config.cwd = rec.environmentDisclosure.cwd;
+        if (rec.modelAlias !== undefined) config.modelAlias = rec.modelAlias;
+        if (rec.profileName !== undefined) config.profileName = rec.profileName;
+        const effort = rec.thinkingEffort ?? rec.thinkingLevel;
+        if (effort !== undefined) config.thinkingEffort = effort;
+        if (rec.systemPrompt !== undefined) config.systemPrompt = rec.systemPrompt;
+        break;
+      }
+      case 'profile.bind': {
+        // v2 writes most initial config state on `profile.bind` rather than
+        // `config.update` (which now carries only later updates).
+        if (rec.environmentDisclosure !== undefined)
+          config.cwd = rec.environmentDisclosure.cwd;
+        if (rec.modelAlias !== undefined) config.modelAlias = rec.modelAlias;
+        if (rec.profileName !== undefined) config.profileName = rec.profileName;
+        config.thinkingEffort = rec.thinkingEffort;
+        config.systemPrompt = rec.systemPrompt;
         break;
       }
       case 'permission.set_mode':
@@ -413,7 +447,8 @@ export function projectContext(
       case 'plan_mode.exit':
         planActive = false; planId = undefined; break;
       case 'context.undo': {
-        // Mirror agent-core `undo` (`agent/context/index.ts`): walk from the
+        // Mirror the engine's `undo`
+        // (`packages/agent-core-v2/src/agent/contextMemory/`): walk from the
         // end, skip `origin.kind === 'injection'`, stop at
         // `origin.kind === 'compaction_summary'`, remove others, counting real
         // user prompts via `isRealUserInput` until `count` is reached. Then
@@ -432,11 +467,12 @@ export function projectContext(
             (pm, i) => i < cutoff || pm.message.origin?.kind === 'injection',
           );
           openSteps = new Map();
-          // Mirror agent-core undo() → microCompaction.reset(this._history.length):
+          // Mirror the engine's undo() → legacy micro-compaction cutoff reset
+          // (to the post-undo history length):
           // clamp the cutoff to the post-undo HISTORY-entry count so a later append
           // does not get blanked by a now-too-large stale cutoff. Count only history
           // entries (`isHistoryEntry`) — `messages.length` would include any surviving
-          // synthetic undo/clear marker, which agent-core's `_history.length` does
+          // synthetic undo/clear marker, which the engine's `_history.length` does
           // NOT, so an array-length clamp could be too high by the marker count.
           // (Clamp before pushing the undo marker, which is a non-tool pseudo-message
           // and unaffected by blanking regardless.) With no markers, historyCount ===
@@ -464,8 +500,8 @@ export function projectContext(
       }
       case 'micro_compaction.apply':
         // Track the latest cutoff; the actual content blanking is applied
-        // after the loop (mirrors agent-core MicroCompaction.compact, which
-        // runs over the full history at projection time).
+        // after the loop (mirrors the engine's legacy MicroCompaction.compact,
+        // which runs over the full history at projection time).
         microCutoff = rec.cutoff;
         break;
       case 'goal.create':
@@ -501,14 +537,46 @@ export function projectContext(
       case 'tower_mode.enter':
       case 'tower_mode.exit':
         break;
+      case 'token_counting.measured':
+      case 'token_counting.truncated':
+      case 'token_counting.rebased':
+      case 'token_counting.turn_recorded':
+        // v2's replacement for `context.update_token_count`: every
+        // token_counting record carries the agent's current context-window
+        // fill (`tokens`) — the tokenCounting model sets its running count
+        // from each of them, and so do we.
+        contextTokens = rec.tokens;
+        break;
       // Kinds that don't affect the projected timeline / derived state,
       // including the observability records (request trace — `llm.*`,
-      // `mcp.tools_discovered`), which are never part of context state:
+      // `mcp.tools_discovered`) and v2's lifecycle/task bookkeeping, which
+      // are never part of context state:
       case 'metadata':
       case 'forked':
       case 'turn.prompt':
       case 'turn.steer':
       case 'turn.cancel':
+      case 'turn.ended':
+      case 'turn.step.interrupted':
+      case 'turn.step.retrying':
+      case 'prompt.accepted':
+      case 'prompt.aborted':
+      case 'prompt.completed':
+      case 'prompt.steered':
+      case 'interaction.request':
+      case 'interaction.resolved':
+      case 'task.started':
+      case 'task.terminated':
+      case 'task.waitDelivered':
+      case 'cron.add':
+      case 'cron.cursor':
+      case 'cron.delete':
+      case 'plan.revision':
+      case 'plugin.session_start':
+      case 'runtime.set_binding':
+      case 'staleGuard.recorded':
+      case 'staleGuard.cleared':
+      case 'interruptionReminder.recorded':
       case 'permission.record_approval_result':
       case 'full_compaction.begin':
       case 'full_compaction.cancel':
@@ -517,7 +585,6 @@ export function projectContext(
       case 'tools.unregister_user_tool':
       case 'tools.set_active_tools':
       case 'tools.update_store':
-      case 'profile.bind':
       case 'tools.reset_active_tools':
       case 'llm.tools_snapshot':
       case 'llm.request':
@@ -531,12 +598,13 @@ export function projectContext(
     }
   }
 
-  // Micro-compaction blanking (mirrors agent-core MicroCompaction.compact):
-  // blank any message whose HISTORY index < cutoff that is a `role: 'tool'`
-  // result with a defined toolCallId and content large enough (≥ the
-  // min-content gate), replacing its content with the truncation marker. The
-  // cutoff is an agent-core `_history` index, which never includes our synthetic
-  // 'undo'/'clear' markers, so we count only history entries (`isHistoryEntry`)
+  // Micro-compaction blanking (mirrors the engine's legacy
+  // MicroCompaction.compact): blank any message whose HISTORY index < cutoff
+  // that is a `role: 'tool'` result with a defined toolCallId and content
+  // large enough (≥ the min-content gate), replacing its content with the
+  // truncation marker. The cutoff is an engine `_history` index, which never
+  // includes our synthetic 'undo'/'clear' markers, so we count only history
+  // entries (`isHistoryEntry`)
   // — array indices would be offset by any preceding marker. This rewrite is the
   // model's-eye view, so it runs ONLY in 'model' mode — in 'full' mode the
   // original tool results are shown un-blanked.
@@ -579,9 +647,10 @@ function addUsage(into: TokenUsage, src: TokenUsage): void {
 const MICRO_TRUNCATED_MARKER = '[Old tool result content cleared]';
 const MICRO_MIN_CONTENT_TOKENS = 100;
 
-/** Replicates agent-core's per-char token weighting exactly, over the same
- *  `text` + `think` parts its gate counts. agent-core
- *  (`packages/agent-core/src/utils/tokens.ts`) sums per-part estimates, each
+/** Replicates the engine's per-char token weighting exactly, over the same
+ *  `text` + `think` parts its gate counts. The engine
+ *  (`packages/agent-core-v2/src/kosong/contract/tokens.ts`) sums per-part
+ *  estimates, each
  *  `estimateTokens(s) = Math.ceil(asciiCount / 4) + nonAsciiCount` (ASCII ~4
  *  chars/token, every non-ASCII/CJK code point a full token); other part types
  *  contribute 0. Matching it ensures Chinese-heavy tool results blank at the
@@ -608,17 +677,36 @@ function estimateContentTokens(content: readonly ContentPart[]): number {
   return total;
 }
 
-/** True for messages that correspond to a real agent-core `_history` entry —
+/** True for messages that correspond to a real `_history` entry —
  *  i.e. `append_message` and `compaction_summary` (the summary IS in `_history`).
  *  The synthetic UI-only markers (`undo` / `clear`) are NOT in `_history`, so
- *  index-based operations that mirror agent-core (compaction slice, micro-
- *  compaction cutoff) must skip them to stay aligned with agent-core indices. */
+ *  index-based operations that mirror the engine (compaction slice, micro-
+ *  compaction cutoff) must skip them to stay aligned with engine indices. */
 function isHistoryEntry(pm: ProjectedMessage): boolean {
   return pm.source !== 'undo' && pm.source !== 'clear';
 }
 
+/** v1 wires tag background-task prompts `origin.kind === 'background_task'`;
+ *  v2 renamed the kind to 'task' (same status literals). Normalize on ingest
+ *  so the undo walk (`isRealUserInput`) and the web see one vocabulary. */
+function normalizeLegacyOrigin(message: ContextMessage): ContextMessage {
+  const origin = message.origin as { readonly kind: string } | undefined;
+  if (origin?.kind !== 'background_task') return message;
+  return { ...message, origin: { ...origin, kind: 'task' } as ContextMessage['origin'] };
+}
+
+/** Text rendering of a ContextMessage's content parts, used to surface the
+ *  legacy `context.apply_compaction` variant whose summary is a message. */
+function contextMessageText(message: ContextMessage): string {
+  return message.content
+    .filter((part) => part.type === 'text')
+    .map((part) => part.text)
+    .join('\n');
+}
+
 /** Single source of truth for the `context.undo` backward walk, shared by both
- *  projection modes. Mirrors agent-core `undo` (`agent/context/index.ts`): walk
+ *  projection modes. Mirrors the engine's `undo`
+ *  (`packages/agent-core-v2/src/agent/contextMemory/`): walk
  *  from the end, skip `origin.kind === 'injection'` (those are KEPT even when
  *  they sit inside the undo window), stop at `origin.kind === 'compaction_summary'`,
  *  and count real user prompts via `isRealUserInput` until `count` is reached.

--- a/apps/vis/server/src/lib/context-projector.ts
+++ b/apps/vis/server/src/lib/context-projector.ts
@@ -7,6 +7,7 @@ import {
   selectCompactionUserMessages,
   selectRecentUserMessages,
 } from '@moonshot-ai/agent-core-v2/agent/contextMemory/compactionHandoff';
+import { estimateTokensForMessages } from '@moonshot-ai/agent-core-v2/kosong/contract/tokens';
 import { renderToolResultForModel } from '@moonshot-ai/agent-core-v2/agent/contextMemory/toolResultRender';
 import type {
   ContentPart,
@@ -307,12 +308,15 @@ export function projectContext(
               };
         if (mode === 'model') {
           // Rebuild the model's-eye view. New records carry `keptUserMessageCount`
-          // and use the kept-user selection below; legacy records fall back to the
-          // old verbatim-tail shape (handled first).
+          // and use the kept-user selection below; legacy-tail records fall back
+          // to the old verbatim-tail shape. The legacy rule is the same one the
+          // engine's `readContextCompactionShapeInput` applies — an explicit
+          // `legacyTail: true`, or any record without `keptUserMessageCount` —
+          // unconditionally on how `compactedCount` compares to the current
+          // history length.
           const historyEntries = messages.filter(isHistoryEntry);
-          if (rec.keptUserMessageCount === undefined && compactedCount < historyEntries.length) {
-            // Legacy (pre-rework) record: it has no `keptUserMessageCount`, so
-            // the engine's context-memory restore reproduces the old
+          if (rec.legacyTail === true || rec.keptUserMessageCount === undefined) {
+            // Legacy-tail record: the engine's restore reproduces the old
             // `[summary, ...history.slice(compactedCount)]` semantics — a verbatim
             // recent tail (assistant/tool included), not the new kept-user
             // selection. Mirror that exact shape so opening an older compacted
@@ -397,11 +401,22 @@ export function projectContext(
         // index-based cutoff no longer points at the same messages. (In full
         // mode the blanking pass does not run, so this is a no-op there.)
         microCutoff = 0;
-        // Mirror applyCompaction() → _tokenCount = result.tokensAfter:
-        // the live context-window fill is now the post-compaction count. Derived
-        // state, so it is mode-INDEPENDENT. `tokensAfter` is optional in the v2
-        // payload (absent on legacy variants) — keep the prior count then.
-        if (rec.tokensAfter !== undefined) contextTokens = rec.tokensAfter;
+        // Mirror the engine's `buildContextCompactionShape`: when the record
+        // omits `tokensAfter` (legacy variants), derive the post-compaction
+        // fill as an estimate over the RECONSTRUCTED shape instead of keeping
+        // the stale pre-compaction count — and reflect the derived value on
+        // the summary bubble, like the engine does. (In full mode the
+        // projected list is vis's own debug view, not the model's shape, so
+        // the fallback keeps the prior count instead of estimating over the
+        // wrong message set.)
+        if (rec.tokensAfter !== undefined) {
+          contextTokens = rec.tokensAfter;
+        } else if (mode === 'model') {
+          contextTokens = estimateTokensForMessages(messages.map((pm) => pm.message));
+          if (modelSummaryBubble.compaction !== undefined) {
+            modelSummaryBubble.compaction.tokensAfter = contextTokens;
+          }
+        }
         break;
       }
       case 'usage.record': {

--- a/apps/vis/server/src/lib/cron-store.ts
+++ b/apps/vis/server/src/lib/cron-store.ts
@@ -1,19 +1,23 @@
 // apps/vis/server/src/lib/cron-store.ts
 //
-// Read-only reader for cron tasks, persisted by agent-core under each (non-sub)
-// agent's homedir at `<agentDir>/cron/<id>.json` (callers pass the agent
-// homedir, `<session>/agents/<id>`). The visualizer never writes these files;
-// it mirrors agent-core's on-disk layout (tools/cron/persist.ts) for reading.
+// Read-only reader for cron tasks. v2 persists cron state as durable wire
+// records (`cron.add` / `cron.delete` / `cron.cursor`) inside each agent's
+// `wire.jsonl` (`packages/agent-core-v2/src/features/cron/`); v1 wrote
+// `<agentDir>/cron/<id>.json` files instead. vis reads both: legacy files
+// first, then the wire fold on top, so a session written by either engine
+// (or carried across both) lists its cron tasks. The visualizer never
+// writes anything.
 
 import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import type { CronTask } from './agent-record-types';
+import { readAgentWire } from './wire-reader';
 
-/** Cron id format: 8 lowercase hex chars (mirror of agent-core's cron-id
- *  shape). Enforced before joining a path so a stray / hand-edited filename
- *  cannot escape the cron directory. */
-const VALID_CRON_ID = /^[0-9a-f]{8}$/;
+/** Cron id format: 8 lowercase hex chars (legacy v1 ids) or a 26-char ULID
+ *  (v2 ids) — mirror of the engine's `CRON_ID_REGEX`
+ *  (`features/cron/cronService.ts`). */
+const VALID_CRON_ID = /^(?:[0-9a-f]{8}|[0-9A-HJKMNP-TV-Z]{26})$/i;
 
 export function isSafeCronId(id: string): boolean {
   return VALID_CRON_ID.test(id);
@@ -24,13 +28,24 @@ function cronDirOf(agentDir: string): string {
 }
 
 /**
- * Enumerate all persisted cron tasks for a session, sorted by creation time
+ * Enumerate all cron tasks for one agent homedir, sorted by creation time
  * (oldest first, matching how a user scheduled them).
  *
- * Silently skips filenames that don't match `VALID_CRON_ID`, files that fail
- * to read/parse, and records missing the required cron fields.
+ * Legacy `<agentDir>/cron/*.json` files whose names don't match
+ * `VALID_CRON_ID`, fail to parse, or miss required fields are skipped;
+ * a missing/unreadable `wire.jsonl` contributes no records.
  */
 export async function listCronTasks(agentDir: string): Promise<CronTask[]> {
+  const byId = new Map<string, CronTask>();
+  for (const task of await listCronTaskFiles(agentDir)) {
+    byId.set(task.id, task);
+  }
+  await foldCronWireInto(agentDir, byId);
+  return [...byId.values()].sort((a, b) => a.createdAt - b.createdAt);
+}
+
+/** Legacy v1 layout: one JSON file per task under `<agentDir>/cron/`. */
+async function listCronTaskFiles(agentDir: string): Promise<CronTask[]> {
   const dir = cronDirOf(agentDir);
   let entries: import('node:fs').Dirent[];
   try {
@@ -51,8 +66,38 @@ export async function listCronTasks(agentDir: string): Promise<CronTask[]> {
     }
     if (isCronTask(parsed)) out.push(parsed);
   }
-  out.sort((a, b) => a.createdAt - b.createdAt);
   return out;
+}
+
+/** v2 layout: fold the agent's wire records — `cron.add` upserts,
+ *  `cron.delete` removes, `cron.cursor` advances `lastFiredAt`. The fold
+ *  applies on top of the legacy-file state, so the wire (the engine's
+ *  authoritative journal) wins for tasks present in both. */
+async function foldCronWireInto(agentDir: string, byId: Map<string, CronTask>): Promise<void> {
+  let records;
+  try {
+    ({ records } = await readAgentWire(join(agentDir, 'wire.jsonl')));
+  } catch {
+    return;
+  }
+  for (const entry of records) {
+    const rec = entry.data;
+    switch (rec.type) {
+      case 'cron.add':
+        if (isCronTask(rec.task)) byId.set(rec.task.id, rec.task);
+        break;
+      case 'cron.delete':
+        for (const id of rec.ids) byId.delete(id);
+        break;
+      case 'cron.cursor': {
+        const task = byId.get(rec.id);
+        if (task !== undefined) byId.set(rec.id, { ...task, lastFiredAt: rec.lastFiredAt });
+        break;
+      }
+      default:
+        break;
+    }
+  }
 }
 
 function isCronTask(value: unknown): value is CronTask {

--- a/apps/vis/server/src/lib/cron-store.ts
+++ b/apps/vis/server/src/lib/cron-store.ts
@@ -86,12 +86,22 @@ async function foldCronWireInto(agentDir: string, byId: Map<string, CronTask>): 
       case 'cron.add':
         if (isCronTask(rec.task)) byId.set(rec.task.id, rec.task);
         break;
-      case 'cron.delete':
-        for (const id of rec.ids) byId.delete(id);
+      case 'cron.delete': {
+        // Tolerate hand-edited / partially corrupted wires: the reader only
+        // validates the record's `type`, so guard the payload shape before
+        // iterating, the same way `cron.add` goes through `isCronTask`.
+        const ids: unknown = rec.ids;
+        if (Array.isArray(ids)) {
+          for (const id of ids) if (typeof id === 'string') byId.delete(id);
+        }
         break;
+      }
       case 'cron.cursor': {
-        const task = byId.get(rec.id);
-        if (task !== undefined) byId.set(rec.id, { ...task, lastFiredAt: rec.lastFiredAt });
+        const id: unknown = rec.id;
+        const lastFiredAt: unknown = rec.lastFiredAt;
+        if (typeof id !== 'string' || typeof lastFiredAt !== 'number') break;
+        const task = byId.get(id);
+        if (task !== undefined) byId.set(id, { ...task, lastFiredAt });
         break;
       }
       default:

--- a/apps/vis/server/src/lib/log-reader.ts
+++ b/apps/vis/server/src/lib/log-reader.ts
@@ -30,10 +30,11 @@ export interface LogReadResult {
  * Discover a base log file plus its rotated siblings (`<base>`, `<base>.1`,
  * `<base>.2`, …) in chronological order, oldest first.
  *
- * agent-core rotates by renaming the active file to `.1` and bumping older
- * archives to higher numbers (`sinks.ts` rotate()), so the un-suffixed file is
- * newest and `.N` is oldest. A bundle whose active log has already rotated
- * away may contain only `<base>.1`, etc. — which the Logs tab must still find.
+ * The engine rotates by renaming the active file to `.1` and bumping older
+ * archives to higher numbers (`_base/log/fileLog.ts` rotate()), so the
+ * un-suffixed file is newest and `.N` is oldest. A bundle whose active log
+ * has already rotated away may contain only `<base>.1`, etc. — which the
+ * Logs tab must still find.
  */
 export async function discoverLogFiles(baseLogPath: string): Promise<string[]> {
   const dir = dirname(baseLogPath);

--- a/apps/vis/server/src/lib/session-store.ts
+++ b/apps/vis/server/src/lib/session-store.ts
@@ -12,7 +12,7 @@ const AGENT_ID_RE = /^[A-Za-z0-9._-]+$/;
 
 /** Reject agent ids that could escape the session directory via path
  *  joins. Defence-in-depth: the on-disk source of these ids is
- *  agent-core (which only generates main / agent-N), but a corrupted
+ *  the engine (which only generates main / agent-N), but a corrupted
  *  or hand-edited `state.json.agents` key could otherwise turn vis
  *  into a local-file-read primitive when exposed beyond loopback. */
 export function isSafeAgentId(id: string): boolean {
@@ -28,7 +28,17 @@ interface StateJson {
   // Agent metadata comes from an untrusted state.json (a corrupt or imported
   // bundle may hold non-object entries like `{ "main": null }`), so the value
   // type allows null and inventoryAgents skips anything that isn't an object.
-  agents?: Record<string, { type: 'main' | 'sub' | 'independent'; parentAgentId?: string | null; swarmItem?: string } | null>;
+  //
+  // v2 writes the REAL parent / swarm-item label under `labels` (its
+  // top-level `parentAgentId` is a fixed 'main' placeholder for sub agents);
+  // v1 wrote them top-level. Read labels first, top-level as fallback —
+  // the same order the engine itself uses.
+  agents?: Record<string, {
+    type: 'main' | 'sub' | 'independent';
+    parentAgentId?: string | null;
+    swarmItem?: string;
+    labels?: { parentAgentId?: string; swarmItem?: string };
+  } | null>;
   custom?: Record<string, unknown>;
 }
 
@@ -280,21 +290,31 @@ async function inventoryAgents(sessionDir: string, state: StateJson): Promise<Ag
     result.push({
       agentId: id,
       type: meta.type,
-      parentAgentId: meta.parentAgentId ?? null,
+      parentAgentId: meta.labels?.parentAgentId ?? meta.parentAgentId ?? null,
       homedir: join(sessionDir, 'agents', id),
       wireExists: readable,
       wireRecordCount: info.count,
       wireProtocolVersion: info.protocolVersion,
-      swarmItem: meta.swarmItem ?? null,
+      swarmItem: meta.labels?.swarmItem ?? meta.swarmItem ?? null,
     });
   }
   return result.sort((a, b) => compareAgentIds(a.agentId, b.agentId));
 }
 
 async function readState(sessionDir: string): Promise<StateJson | null> {
-  try {
-    return JSON.parse(await readFile(join(sessionDir, 'state.json'), 'utf8')) as StateJson;
-  } catch { return null; }
+  // `<sessionDir>/state.json` is the canonical path; older v2 sessions may
+  // only carry the legacy `<sessionDir>/session-meta/state.json` layout (the
+  // engine itself reads with this fallback), so try both before declaring
+  // the state broken.
+  for (const candidate of [
+    join(sessionDir, 'state.json'),
+    join(sessionDir, 'session-meta', 'state.json'),
+  ]) {
+    try {
+      return JSON.parse(await readFile(candidate, 'utf8')) as StateJson;
+    } catch { /* try the next candidate */ }
+  }
+  return null;
 }
 
 async function findSessionDir(home: string, sessionId: string): Promise<string | null> {

--- a/apps/vis/server/src/lib/task-store.ts
+++ b/apps/vis/server/src/lib/task-store.ts
@@ -1,12 +1,12 @@
 // apps/vis/server/src/lib/task-store.ts
 //
-// Read-only reader for background tasks, persisted by agent-core under each
+// Read-only reader for background tasks, persisted by the engine under each
 // spawning agent's homedir at `<agentDir>/tasks/<taskId>.json`
 // (+ `tasks/<taskId>/output.log`) — NOT the session root. Callers pass the
 // agent homedir (`<session>/agents/<id>`).
 //
-// The visualizer never writes these files; it mirrors agent-core's on-disk
-// layout (background/persist.ts) for reading only:
+// The visualizer never writes these files; it mirrors the engine's on-disk
+// layout (`packages/agent-core-v2/src/agent/task/persist.ts`) for reading only:
 //   - the same `VALID_TASK_ID` guard, so a corrupt / hand-edited filename
 //     cannot turn a log path into a traversal primitive;
 //   - the same legacy snake_case → current camelCase normalization, so old
@@ -20,8 +20,8 @@ import type {
   BackgroundTaskStatus,
 } from './agent-record-types';
 
-/** Task id format: `{prefix}-{8 chars of [0-9a-z]}`. Mirror of agent-core's
- *  `VALID_TASK_ID` (background/persist.ts). Enforced before deriving any
+/** Task id format: `{prefix}-{8 chars of [0-9a-z]}`. Mirror of the engine's
+ *  `VALID_TASK_ID` (`agent/task/persist.ts`). Enforced before deriving any
  *  output path so neither `../` nor a legacy `bg_<hex>` id can escape. */
 const VALID_TASK_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*-[0-9a-z]{8}$/;
 
@@ -46,7 +46,7 @@ function taskOutputFile(agentDir: string, taskId: string): string {
  *
  * Silently skips: filenames that don't match `VALID_TASK_ID`, files that fail
  * to read/parse, and records that are neither the current nor the legacy
- * task shape — matching agent-core's tolerant `listTasks`.
+ * task shape — matching the engine's tolerant `listTasks`.
  */
 export async function listBackgroundTasks(
   agentDir: string,
@@ -116,7 +116,7 @@ export interface TaskOutputWindow {
  *
  * Reads at most `maxBytes` bytes starting at byte `offset`. A window past EOF
  * is clamped to whatever remains; an offset at/after EOF yields empty content.
- * Mirrors agent-core's `readTaskOutputBytes` so large logs page identically.
+ * Mirrors the engine's `readTaskOutputBytes` so large logs page identically.
  */
 export async function readTaskOutput(
   agentDir: string,
@@ -150,7 +150,7 @@ export async function readTaskOutput(
   }
 }
 
-// ── normalization (ported from agent-core/agent/background/persist.ts) ───────
+// ── normalization (ported from agent-core-v2/agent/task/persist.ts) ────────
 
 type LegacyBackgroundTaskStatus =
   | 'running'

--- a/apps/vis/server/src/lib/wire-reader.ts
+++ b/apps/vis/server/src/lib/wire-reader.ts
@@ -5,7 +5,7 @@ import {
   migrateWireRecord,
   resolveWireMigrations,
   type WireMigration,
-} from '@moonshot-ai/agent-core/agent/records/migration/index';
+} from '@moonshot-ai/agent-core-v2/wire/migration/migration';
 
 import type { AgentRecord, WireEntry } from './agent-record-types';
 
@@ -19,7 +19,7 @@ export interface WireReadResult {
  *  below the known migration chain (below 1.0, or otherwise unrecognized-low):
  *  `resolveWireMigrations` threw for it. We retry from the oldest known version
  *  (1.0) and warn the caller; if even that fails we pass records through
- *  unchanged. (Versions at/above the current 1.4 never reach here — they
+ *  unchanged. (Versions at/above the current 1.5 never reach here — they
  *  resolve to an empty chain and are passed through directly.) */
 function bestEffortMigrations(): readonly WireMigration[] {
   try {
@@ -37,7 +37,7 @@ function bestEffortMigrations(): readonly WireMigration[] {
  *    - below-1.0 (or otherwise unrecognized-low) — `resolveWireMigrations`
  *      throws, so records run through the 1.0-onwards best-effort chain and a
  *      warning is added to `warnings[]` so the UI can surface the caveat;
- *    - at/above the current 1.4 (including future versions) — resolves to an
+ *    - at/above the current 1.5 (including future versions) — resolves to an
  *      empty chain, so records are passed through unchanged, with no migration
  *      and no warning. */
 export async function readAgentWire(path: string): Promise<WireReadResult> {

--- a/apps/vis/server/src/routes/cron.ts
+++ b/apps/vis/server/src/routes/cron.ts
@@ -13,9 +13,9 @@ export function cronRoute(home: string = KIMI_CODE_HOME): Hono {
     if (!detail) {
       return c.json({ error: 'session not found', code: 'NOT_FOUND' }, 404);
     }
-    // Cron jobs are persisted under each (non-sub) agent's homedir at
-    // `<homedir>/cron`, not the session root. Aggregate across agents; sub
-    // agents have no cron directory and simply contribute nothing.
+    // Cron state is per-agent (wire records in each agent's `wire.jsonl`,
+    // plus legacy `<homedir>/cron/*.json` files), not the session root.
+    // Aggregate across agents; sub agents simply contribute nothing.
     const cron: CronTask[] = [];
     const seen = new Set<string>();
     for (const agent of detail.agents) {

--- a/apps/vis/server/src/routes/logs.ts
+++ b/apps/vis/server/src/routes/logs.ts
@@ -22,7 +22,7 @@ export function logsRoute(home: string = KIMI_CODE_HOME): Hono {
     // The global diagnostic log is a single shared file. In an exported bundle
     // it is captured under the session dir (logs/global/kimi-code.log); for a
     // live local session it lives at <KIMI_CODE_HOME>/logs/kimi-code.log
-    // (agent-core's resolveGlobalLogPath), NOT under the session dir.
+    // (the engine's global log path), NOT under the session dir.
     const globalLog = detail.imported
       ? join(detail.sessionDir, ...GLOBAL_LOG_REL)
       : join(home, ...HOME_GLOBAL_LOG_REL);

--- a/apps/vis/server/test/fixtures/sessions/sample-compaction/agents/main/wire.jsonl
+++ b/apps/vis/server/test/fixtures/sessions/sample-compaction/agents/main/wire.jsonl
@@ -2,5 +2,5 @@
 {"type":"config.update","cwd":"/tmp/work","profileName":"agent","systemPrompt":"You are Kimi.","time":1779256791100}
 {"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"before compaction"}],"toolCalls":[]},"time":1779256800001}
 {"type":"context.append_message","message":{"role":"assistant","content":[{"type":"text","text":"assistant reply"}],"toolCalls":[]},"time":1779256800200}
-{"type":"context.apply_compaction","summary":"compacted summary","compactedCount":2,"tokensBefore":100,"tokensAfter":30,"time":1779256800500}
+{"type":"context.apply_compaction","summary":"compacted summary","compactedCount":2,"tokensBefore":100,"tokensAfter":30,"keptUserMessageCount":1,"time":1779256800500}
 {"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"after compaction"}],"toolCalls":[]},"time":1779256801000}

--- a/apps/vis/server/test/lib/context-projector.test.ts
+++ b/apps/vis/server/test/lib/context-projector.test.ts
@@ -1,5 +1,6 @@
 // apps/vis/server/test/lib/context-projector.test.ts
 import { describe, it, expect, afterEach } from 'vitest';
+import { estimateTokensForMessages } from '@moonshot-ai/agent-core-v2/kosong/contract/tokens';
 import { buildSessionFixture } from '../fixtures/build';
 import { projectContext } from '../../src/lib/context-projector';
 import { readAgentWire } from '../../src/lib/wire-reader';
@@ -277,17 +278,18 @@ describe('context-projector', () => {
       { lineNo: 4, data: { type: 'context.append_message' as const, message: { role: 'user' as const, content: [{ type: 'text' as const, text: 'new' }], toolCalls: [] } }, raw: {} },
     ];
     const proj = projectContext(entries as any);
-    // Model view: the kept user prompt + user-role summary + the new prompt.
+    // Model view: a legacy record (no keptUserMessageCount) rebuilds the
+    // history as `[summary, ...history.slice(compactedCount)]` — 'old' is
+    // compacted away — then the new prompt is appended.
     expect(proj.messages.map((m) => m.source)).toEqual([
-      'append_message', 'compaction_summary', 'append_message',
+      'compaction_summary', 'append_message',
     ]);
-    expect(proj.messages[0]!.message.content[0]).toMatchObject({ text: 'old' });
     // The compaction summary is a user message (the engine's own
     // representation), not a synthetic system message.
-    expect(proj.messages[1]!.message.role).toBe('user');
-    expect(proj.messages[1]!.message.origin).toEqual({ kind: 'compaction_summary' });
-    expect(proj.messages[1]!.message.content[0]).toMatchObject({ text: 'old stuff' });
-    expect(proj.messages[2]!.message.content[0]).toMatchObject({ text: 'new' });
+    expect(proj.messages[0]!.message.role).toBe('user');
+    expect(proj.messages[0]!.message.origin).toEqual({ kind: 'compaction_summary' });
+    expect(proj.messages[0]!.message.content[0]).toMatchObject({ text: 'old stuff' });
+    expect(proj.messages[1]!.message.content[0]).toMatchObject({ text: 'new' });
   });
 
   it('uses contextSummary only for the model view and raw summary for full history', () => {
@@ -299,8 +301,9 @@ describe('context-projector', () => {
     ];
 
     const model = projectContext(entries as any);
+    // Legacy record (no keptUserMessageCount): the pre-compaction prompt is
+    // compacted away, the model sees only the prefixed summary.
     expect(model.messages.map((m) => m.message.content[0])).toMatchObject([
-      { text: 'old' },
       { text: 'prefixed summary' },
     ]);
 
@@ -320,7 +323,8 @@ describe('context-projector', () => {
       { lineNo: 3, data: { type: 'context.append_message' as const,
           message: { role: 'assistant' as const, content: [{ type: 'text' as const, text: 'm2 (dropped)' }], toolCalls: [] } }, raw: {} },
       { lineNo: 4, data: { type: 'context.apply_compaction' as const,
-          summary: 'sum', compactedCount: 3, tokensBefore: 100, tokensAfter: 10 }, raw: {} },
+          summary: 'sum', compactedCount: 3, tokensBefore: 100, tokensAfter: 10,
+          keptUserMessageCount: 2 }, raw: {} },
     ];
     const proj = projectContext(entries as any);
     // [m0, m1, summary] — real user prompts are kept verbatim, the assistant
@@ -418,7 +422,8 @@ describe('context-projector', () => {
       { lineNo: 5, data: { type: 'context.append_message' as const,
           message: { role: 'assistant' as const, content: [{ type: 'text' as const, text: 'assistant reply' }], toolCalls: [] } }, raw: {} },
       { lineNo: 6, data: { type: 'context.apply_compaction' as const,
-          summary: 'sum', compactedCount: 5, tokensBefore: 100, tokensAfter: 10 }, raw: {} },
+          summary: 'sum', compactedCount: 5, tokensBefore: 100, tokensAfter: 10,
+          keptUserMessageCount: 1 }, raw: {} },
       { lineNo: 7, data: { type: 'context.append_message' as const,
           message: { role: 'user' as const, content: [{ type: 'text' as const, text: 'new' }], toolCalls: [], origin: { kind: 'user' as const } } }, raw: {} },
     ];
@@ -469,7 +474,8 @@ describe('context-projector', () => {
       { lineNo: 4, data: { type: 'context.append_message' as const, message: userMsg('u3') }, raw: {} },
       { lineNo: 5, data: { type: 'context.append_message' as const, message: userMsg('u4') }, raw: {} },
       { lineNo: 6, data: { type: 'context.apply_compaction' as const,
-          summary: 'sum', compactedCount: 3, tokensBefore: 100, tokensAfter: 10 }, raw: {} },
+          summary: 'sum', compactedCount: 3, tokensBefore: 100, tokensAfter: 10,
+          keptUserMessageCount: 3 }, raw: {} },
     ];
     const proj = projectContext(entries as any);
     // Correct: [u1, u3, u4, summary]. The marker is gone, all real prompts kept.
@@ -844,7 +850,8 @@ describe('context-projector', () => {
       { lineNo: 2, data: { type: 'context.append_message' as const,
           message: { role: 'user' as const, content: [{ type: 'text' as const, text: 'm1' }], toolCalls: [] } }, raw: {} },
       { lineNo: 3, data: { type: 'context.apply_compaction' as const,
-          summary: 'sum', compactedCount: 2, tokensBefore: 100, tokensAfter: 10 }, raw: {} },
+          summary: 'sum', compactedCount: 2, tokensBefore: 100, tokensAfter: 10,
+          keptUserMessageCount: 2 }, raw: {} },
     ];
     // No 2nd arg → 'model' default: the real user prompts are kept verbatim and
     // the summary is appended after them.
@@ -981,7 +988,7 @@ describe('context-projector', () => {
     expect(proj.config.thinkingEffort).toBe('medium');
   });
 
-  it('projects the legacy compaction variant (ContextMessage summary, count) without tokens', () => {
+  it('derives the fill from the reconstructed shape when the legacy compaction omits tokens', () => {
     const summaryMessage = {
       role: 'user' as const,
       content: [{ type: 'text' as const, text: 'compacted so far' }],
@@ -996,11 +1003,50 @@ describe('context-projector', () => {
     const bubble = proj.messages.at(-1)!;
     expect(bubble.source).toBe('compaction_summary');
     expect(bubble.message.content[0]).toMatchObject({ text: 'compacted so far' });
+    // No tokensAfter on the record → the engine's fallback: an estimate over
+    // the reconstructed shape (here just the summary bubble), NOT the stale
+    // pre-compaction 7777.
+    const expected = estimateTokensForMessages([bubble.message]);
+    expect(proj.contextTokens).toBe(expected);
+    expect(proj.contextTokens).not.toBe(7777);
     expect(bubble.compaction).toEqual({
-      compactedCount: 2, tokensBefore: undefined, tokensAfter: undefined,
+      compactedCount: 2, tokensBefore: undefined, tokensAfter: expected,
     });
-    // No tokensAfter on the record → the prior fill is kept.
-    expect(proj.contextTokens).toBe(7777);
+  });
+
+  it('apply_compaction replays a legacy tail even when compactedCount covers the whole history', () => {
+    // Legacy-tail rule (no keptUserMessageCount) is unconditional on how
+    // compactedCount compares to the current history length — the engine's
+    // restore is always `[summary, ...history.slice(compactedCount)]`.
+    const entries = [
+      { lineNo: 1, data: { type: 'context.append_message' as const,
+          message: { role: 'user' as const, content: [{ type: 'text' as const, text: 'u1' }], toolCalls: [], origin: { kind: 'user' as const } } }, raw: {} },
+      { lineNo: 2, data: { type: 'context.append_message' as const,
+          message: { role: 'assistant' as const, content: [{ type: 'text' as const, text: 'a1' }], toolCalls: [] } }, raw: {} },
+      { lineNo: 3, data: { type: 'context.apply_compaction' as const,
+          summary: 'sum', compactedCount: 99, tokensAfter: 50 }, raw: {} },
+    ];
+    const proj = projectContext(entries as any);
+    expect(proj.messages.map((m) => m.source)).toEqual(['compaction_summary']);
+    expect(proj.messages[0]!.message.content[0]).toMatchObject({ text: 'sum' });
+    expect(proj.contextTokens).toBe(50);
+  });
+
+  it('honors an explicit legacyTail flag even when keptUserMessageCount is present', () => {
+    const entries = [
+      { lineNo: 1, data: { type: 'context.append_message' as const,
+          message: { role: 'user' as const, content: [{ type: 'text' as const, text: 'u1' }], toolCalls: [], origin: { kind: 'user' as const } } }, raw: {} },
+      { lineNo: 2, data: { type: 'context.append_message' as const,
+          message: { role: 'assistant' as const, content: [{ type: 'text' as const, text: 'a2 (tail)' }], toolCalls: [] } }, raw: {} },
+      { lineNo: 3, data: { type: 'context.apply_compaction' as const,
+          summary: 'sum', compactedCount: 1, tokensAfter: 5,
+          keptUserMessageCount: 1, legacyTail: true }, raw: {} },
+    ];
+    const proj = projectContext(entries as any);
+    // Verbatim tail [summary, a2], not the kept-user selection.
+    expect(proj.messages.map((m) => m.source)).toEqual(['compaction_summary', 'append_message']);
+    expect(proj.messages[1]!.message.content[0]).toMatchObject({ text: 'a2 (tail)' });
+    expect(proj.contextTokens).toBe(5);
   });
 
   it('normalizes the legacy background_task origin to task', () => {

--- a/apps/vis/server/test/lib/context-projector.test.ts
+++ b/apps/vis/server/test/lib/context-projector.test.ts
@@ -18,7 +18,7 @@ describe('context-projector', () => {
     expect(proj.messages).toHaveLength(2);
     expect(proj.messages[0]!.message.role).toBe('user');
     // The assistant message is reconstructed from step.begin/content.part/step.end,
-    // not from a separate `context.append_message` (agent-core never emits one).
+    // not from a separate `context.append_message` (the engine never emits one).
     expect(proj.messages[1]!.message.role).toBe('assistant');
     expect(proj.messages[1]!.message.content).toEqual([{ type: 'text', text: 'hello' }]);
 
@@ -141,10 +141,10 @@ describe('context-projector', () => {
   });
 
   // ---- Fix G: tool.result content must match what the model saw ---------------
-  // agent-core's `ContextMemory.appendLoopEvent` (`tool.result` case) stores
+  // The engine's `ContextMemory.appendLoopEvent` (`tool.result` case) stores
   // `createToolMessage(toolCallId, toolResultOutputForModel(event.result))`, NOT
   // the raw `event.result.output`. `toolResultOutputForModel`
-  // (`packages/agent-core/src/agent/context/index.ts` ~line 350) normalizes
+  // (`packages/agent-core-v2/src/agent/contextMemory/`) normalizes
   // error / empty outputs with sentinel strings. The projector must replicate
   // that normalization so the model-view shows the content the model actually
   // received for failed / empty tool calls.
@@ -282,7 +282,7 @@ describe('context-projector', () => {
       'append_message', 'compaction_summary', 'append_message',
     ]);
     expect(proj.messages[0]!.message.content[0]).toMatchObject({ text: 'old' });
-    // The compaction summary is a user message (agent-core's own
+    // The compaction summary is a user message (the engine's own
     // representation), not a synthetic system message.
     expect(proj.messages[1]!.message.role).toBe('user');
     expect(proj.messages[1]!.message.origin).toEqual({ kind: 'compaction_summary' });
@@ -336,7 +336,7 @@ describe('context-projector', () => {
   });
 
   it('apply_compaction mirrors the legacy verbatim tail for records without keptUserMessageCount (model)', () => {
-    // A pre-rework record has no keptUserMessageCount. agent-core's restore keeps
+    // A pre-rework record has no keptUserMessageCount. the engine's restore keeps
     // the old `[summary, ...history.slice(compactedCount)]` tail (assistant/tool
     // included), so the model view must do the same instead of applying the new
     // kept-user selection — otherwise it would hide the assistant tail the resumed
@@ -383,7 +383,7 @@ describe('context-projector', () => {
 
     const proj = projectContext(entries as any);
     // [FIRST, head slice of middle, marker, tail slice of middle, LAST, summary]
-    // — mirrors agent-core's selectCompactionUserMessages + elision marker.
+    // — mirrors the engine's selectCompactionUserMessages + elision marker.
     expect(proj.messages).toHaveLength(6);
     const texts = proj.messages.map((m) =>
       m.message.content.map((p: any) => (p.type === 'text' ? p.text : '')).join(''),
@@ -443,8 +443,8 @@ describe('context-projector', () => {
     ]);
   });
 
-  // ---- Fix ④: UI-only markers must not offset agent-core history indices ------
-  // agent-core computes compactedCount (and the micro-compaction cutoff) as
+  // ---- Fix ④: UI-only markers must not offset the engine history indices ------
+  // the engine computes compactedCount (and the micro-compaction cutoff) as
   // indices into _history, which NEVER contains the synthetic 'undo'/'clear'
   // markers we push into our messages array. So index-based ops must count ONLY
   // real history entries (append_message + compaction_summary), skipping
@@ -457,7 +457,7 @@ describe('context-projector', () => {
     });
     // Step 1: append u1, u2 then undo(1) → removes u2, leaves [u1, <undo marker>].
     // Step 2: append u3, u4 → array is [u1, <undo marker>, u3, u4].
-    // History entries (agent-core _history, which has NO marker) are the three
+    // History entries (the engine _history, which has NO marker) are the three
     // real user prompts [u1, u3, u4]. Compaction keeps all of them (they fit the
     // budget) and appends the summary, dropping only the synthetic undo marker.
     // This pins that the marker does not offset the kept-user selection — a naive
@@ -592,7 +592,7 @@ describe('context-projector', () => {
 
   it('micro_compaction.apply counts think parts toward the min-content gate', () => {
     // A tool result dominated by a large `think` part (tiny text) must clear the
-    // min-content gate and be blanked — mirroring agent-core's token estimator,
+    // min-content gate and be blanked — mirroring the engine's token estimator,
     // which counts both text and think parts.
     const entries = [
       { lineNo: 1, data: { type: 'context.append_message' as const, message: {
@@ -610,9 +610,9 @@ describe('context-projector', () => {
 
   it('micro_compaction.apply weights non-ASCII (CJK) chars as full tokens', () => {
     // ~150 CJK chars. Under a naive chars/4 estimate this is ~38 tokens (< 100
-    // gate → NOT blanked, the bug). agent-core counts each non-ASCII char as a
+    // gate → NOT blanked, the bug). the engine counts each non-ASCII char as a
     // full token → ~150 tokens (>= gate → blanked). Assert it IS blanked, so a
-    // Chinese-heavy tool result diverges from agent-core no longer.
+    // Chinese-heavy tool result diverges from the engine no longer.
     const cjk = '中'.repeat(150);
     const entries = [
       { lineNo: 1, data: { type: 'context.append_message' as const, message: {
@@ -707,7 +707,7 @@ describe('context-projector', () => {
       origin: { kind: 'user' as const },
     });
     // A PRIOR undo must leave a surviving marker so that, at a LATER undo's clamp,
-    // the array length exceeds the history-entry count by that marker. agent-core
+    // the array length exceeds the history-entry count by that marker. the engine
     // clamps against `_history.length` (NO markers); clamping against
     // `messages.length` here would be one too high and wrongly blank a later
     // tool result.
@@ -796,7 +796,7 @@ describe('context-projector', () => {
   });
 
   // ---- Fix ②: contextTokens updates on clear / compaction lifecycle events ---
-  // agent-core ContextMemory sets _tokenCount on clear() (→ 0) and
+  // the engine ContextMemory sets _tokenCount on clear() (→ 0) and
   // applyCompaction(result) (→ result.tokensAfter), not only on step.end. These
   // are derived state, so they apply identically in both projection modes.
 
@@ -938,5 +938,100 @@ describe('context-projector', () => {
     // content is preserved.
     expect(proj.messages[0]!.message.content[0]).toMatchObject({ text: bigText });
     expect(proj.messages[1]!.message.content[0]).toMatchObject({ text: bigText });
+  });
+
+  it('folds v2 token_counting records into the context-window fill', () => {
+    const entries = [
+      { lineNo: 1, data: { type: 'token_counting.measured' as const, agentId: 'main', length: 10, tokens: 12345 }, raw: {} },
+      { lineNo: 2, data: { type: 'token_counting.turn_recorded' as const, agentId: 'main', turnId: 1, length: 12, tokens: 13000 }, raw: {} },
+    ];
+    const proj = projectContext(entries as any);
+    expect(proj.contextTokens).toBe(13000);
+  });
+
+  it('resets the context-window fill on context.clear after token_counting', () => {
+    const entries = [
+      { lineNo: 1, data: { type: 'token_counting.rebased' as const, agentId: 'main', length: 3, tokens: 5000, measured: true }, raw: {} },
+      { lineNo: 2, data: { type: 'context.clear' as const, agentId: 'main' }, raw: {} },
+    ];
+    const proj = projectContext(entries as any);
+    expect(proj.contextTokens).toBe(0);
+  });
+
+  it('reads the config snapshot from v2 profile.bind', () => {
+    const entries = [
+      { lineNo: 1, data: { type: 'profile.bind' as const, agentId: 'main',
+          modelAlias: 'k2', profileName: 'agent', thinkingEffort: 'high', systemPrompt: 'You are Kimi.',
+          environmentDisclosure: { cwd: '/repo' }, disallowedTools: [] }, raw: {} },
+    ];
+    const proj = projectContext(entries as any);
+    expect(proj.config).toEqual({
+      cwd: '/repo', modelAlias: 'k2', profileName: 'agent',
+      thinkingEffort: 'high', systemPrompt: 'You are Kimi.',
+    });
+  });
+
+  it('accepts v2 config.update with environmentDisclosure cwd and thinkingLevel', () => {
+    const entries = [
+      { lineNo: 1, data: { type: 'config.update' as const, agentId: 'main',
+          environmentDisclosure: { cwd: '/other' }, thinkingLevel: 'medium' }, raw: {} },
+    ];
+    const proj = projectContext(entries as any);
+    expect(proj.config.cwd).toBe('/other');
+    expect(proj.config.thinkingEffort).toBe('medium');
+  });
+
+  it('projects the legacy compaction variant (ContextMessage summary, count) without tokens', () => {
+    const summaryMessage = {
+      role: 'user' as const,
+      content: [{ type: 'text' as const, text: 'compacted so far' }],
+      toolCalls: [],
+    };
+    const entries = [
+      { lineNo: 1, data: { type: 'token_counting.measured' as const, agentId: 'main', length: 5, tokens: 7777 }, raw: {} },
+      { lineNo: 2, data: { type: 'context.apply_compaction' as const, agentId: 'main',
+          summary: summaryMessage, count: 2 }, raw: {} },
+    ];
+    const proj = projectContext(entries as any);
+    const bubble = proj.messages.at(-1)!;
+    expect(bubble.source).toBe('compaction_summary');
+    expect(bubble.message.content[0]).toMatchObject({ text: 'compacted so far' });
+    expect(bubble.compaction).toEqual({
+      compactedCount: 2, tokensBefore: undefined, tokensAfter: undefined,
+    });
+    // No tokensAfter on the record → the prior fill is kept.
+    expect(proj.contextTokens).toBe(7777);
+  });
+
+  it('normalizes the legacy background_task origin to task', () => {
+    const entries = [
+      { lineNo: 1, data: { type: 'context.append_message' as const, agentId: 'main',
+          message: { role: 'user' as const, content: [{ type: 'text' as const, text: 'bg done' }], toolCalls: [],
+            origin: { kind: 'background_task', status: 'completed' } } }, raw: {} },
+    ];
+    const proj = projectContext(entries as any);
+    expect(proj.messages[0]!.message.origin).toMatchObject({ kind: 'task', status: 'completed' });
+  });
+
+  it('ignores v2 lifecycle/task bookkeeping records for context state', () => {
+    const entries = [
+      { lineNo: 1, data: { type: 'turn.prompt' as const, agentId: 'main', input: [{ type: 'text' as const, text: 'hi' }], origin: { kind: 'user' as const } }, raw: {} },
+      { lineNo: 2, data: { type: 'turn.ended' as const, agentId: 'main', turnId: 1, reason: 'completed' as const }, raw: {} },
+      { lineNo: 3, data: { type: 'prompt.completed' as const, agentId: 'main', promptId: 'p1', finishedAt: '2026-09-01T00:00:00Z', reason: 'completed' as const }, raw: {} },
+      { lineNo: 4, data: { type: 'interaction.request' as const, agentId: 'main', id: 'i1', kind: 'approval' as const, request: {} }, raw: {} },
+      { lineNo: 5, data: { type: 'task.started' as const, agentId: 'main', info: { taskId: 'bash-abc12345', description: 'x', status: 'running' as const, startedAt: 1, endedAt: null } }, raw: {} },
+      { lineNo: 6, data: { type: 'cron.add' as const, agentId: 'main', task: { id: '01ARZ3NDEKTSV4RRFFQ69G5FAV', cron: '* * * * *', prompt: 'p', createdAt: 1 } }, raw: {} },
+      { lineNo: 7, data: { type: 'plan.revision' as const, agentId: 'main', id: 'plan1', version: 2, key: 'k', sha256: 's', bytes: 10 }, raw: {} },
+      { lineNo: 8, data: { type: 'runtime.set_binding' as const, agentId: 'main', workspaceId: 'w', runtimeId: 'r' }, raw: {} },
+      { lineNo: 9, data: { type: 'staleGuard.recorded' as const, path: '/x', mtimeMs: 1 }, raw: {} },
+      { lineNo: 10, data: { type: 'interruptionReminder.recorded' as const, agentId: 'main', turnId: 1 }, raw: {} },
+    ];
+    const proj = projectContext(entries as any);
+    // None of these append messages or move derived context state.
+    expect(proj.messages).toEqual([]);
+    expect(proj.contextTokens).toBe(0);
+    expect(proj.usage.byScope.session).toEqual({
+      inputOther: 0, output: 0, inputCacheRead: 0, inputCacheCreation: 0,
+    });
   });
 });

--- a/apps/vis/server/test/lib/cron-store.test.ts
+++ b/apps/vis/server/test/lib/cron-store.test.ts
@@ -124,4 +124,26 @@ describe('cron-store', () => {
     // No wire.jsonl at all — legacy sessions still list their files.
     expect((await listCronTasks(sessionDir)).map((t) => t.id)).toEqual(['a1b2c3d4']);
   });
+
+  it('ignores malformed cron.delete / cron.cursor payloads instead of throwing', async () => {
+    const { sessionDir, cleanup: c } = await buildSessionFixture('sample-main');
+    cleanup = c;
+    const lines = [
+      JSON.stringify({ type: 'metadata', protocol_version: '1.5', created_at: 1 }),
+      JSON.stringify({
+        type: 'cron.add',
+        agentId: 'main',
+        task: { id: '01ARZ3NDEKTSV4RRFFQ69G5FAV', cron: '* * * * *', prompt: 'p', createdAt: 1 },
+        time: 2,
+      }),
+      // Hand-edited / corrupted payloads: ids is not an array; cursor fields
+      // have the wrong types. The fold must skip them, not reject the read.
+      '{"type":"cron.delete","agentId":"main","ids":"not-an-array","time":3}',
+      '{"type":"cron.cursor","agentId":"main","id":42,"lastFiredAt":"soon","time":4}',
+    ];
+    await writeFile(join(sessionDir, 'wire.jsonl'), lines.join('\n') + '\n');
+
+    const cron = await listCronTasks(sessionDir);
+    expect(cron.map((t) => t.id)).toEqual(['01ARZ3NDEKTSV4RRFFQ69G5FAV']);
+  });
 });

--- a/apps/vis/server/test/lib/cron-store.test.ts
+++ b/apps/vis/server/test/lib/cron-store.test.ts
@@ -53,11 +53,75 @@ describe('cron-store', () => {
     expect(await listCronTasks(sessionDir)).toEqual([]);
   });
 
-  it('isSafeCronId accepts 8-hex ids only', () => {
+  it('isSafeCronId accepts 8-hex and ULID ids (mirrors the engine regex)', () => {
     expect(isSafeCronId('a1b2c3d4')).toBe(true);
     expect(isSafeCronId('deadbeef')).toBe(true);
-    expect(isSafeCronId('DEADBEEF')).toBe(false);
+    expect(isSafeCronId('DEADBEEF')).toBe(true);
+    expect(isSafeCronId('01ARZ3NDEKTSV4RRFFQ69G5FAV')).toBe(true);
     expect(isSafeCronId('abc')).toBe(false);
+    expect(isSafeCronId('01ARZ3NDEKTSV4RRFFQ69G5FAO')).toBe(false); // 'O' is outside the ULID alphabet
     expect(isSafeCronId('../escape')).toBe(false);
+  });
+
+  it('folds cron records from wire.jsonl (v2 layout)', async () => {
+    const { sessionDir, cleanup: c } = await buildSessionFixture('sample-main');
+    cleanup = c;
+    const taskA = {
+      id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      cron: '*/10 * * * *',
+      prompt: 'wire task a',
+      createdAt: 3000,
+      recurring: true,
+    };
+    const taskB = {
+      id: '01ARZ3NDEKTSV4RRFFQ69G5FB0',
+      cron: '0 8 * * *',
+      prompt: 'wire task b',
+      createdAt: 4000,
+    };
+    const lines = [
+      JSON.stringify({ type: 'metadata', protocol_version: '1.5', created_at: 1 }),
+      JSON.stringify({ type: 'cron.add', agentId: 'main', task: taskA, time: 10 }),
+      JSON.stringify({ type: 'cron.add', agentId: 'main', task: taskB, time: 11 }),
+      JSON.stringify({ type: 'cron.cursor', agentId: 'main', id: taskA.id, lastFiredAt: 9000, time: 12 }),
+      JSON.stringify({ type: 'cron.delete', agentId: 'main', ids: [taskB.id], time: 13 }),
+    ];
+    await writeFile(join(sessionDir, 'wire.jsonl'), lines.join('\n') + '\n');
+
+    const cron = await listCronTasks(sessionDir);
+    expect(cron).toHaveLength(1);
+    expect(cron[0]).toMatchObject({ ...taskA, lastFiredAt: 9000 });
+  });
+
+  it('lets wire records win over legacy cron files for the same id', async () => {
+    const { sessionDir, cleanup: c } = await buildSessionFixture('sample-main');
+    cleanup = c;
+    await writeCron(sessionDir, 'a1b2c3d4.json', {
+      id: 'a1b2c3d4', cron: '0 9 * * *', prompt: 'file version', createdAt: 1000,
+    });
+    const lines = [
+      JSON.stringify({ type: 'metadata', protocol_version: '1.5', created_at: 1 }),
+      JSON.stringify({
+        type: 'cron.add',
+        agentId: 'main',
+        task: { id: 'a1b2c3d4', cron: '0 10 * * *', prompt: 'wire version', createdAt: 1000 },
+        time: 10,
+      }),
+    ];
+    await writeFile(join(sessionDir, 'wire.jsonl'), lines.join('\n') + '\n');
+
+    const cron = await listCronTasks(sessionDir);
+    expect(cron).toHaveLength(1);
+    expect(cron[0]).toMatchObject({ cron: '0 10 * * *', prompt: 'wire version' });
+  });
+
+  it('treats a missing or unreadable wire.jsonl as no records', async () => {
+    const { sessionDir, cleanup: c } = await buildSessionFixture('sample-main');
+    cleanup = c;
+    await writeCron(sessionDir, 'a1b2c3d4.json', {
+      id: 'a1b2c3d4', cron: '0 9 * * *', prompt: 'only files', createdAt: 1000,
+    });
+    // No wire.jsonl at all — legacy sessions still list their files.
+    expect((await listCronTasks(sessionDir)).map((t) => t.id)).toEqual(['a1b2c3d4']);
   });
 });

--- a/apps/vis/server/test/lib/session-store.test.ts
+++ b/apps/vis/server/test/lib/session-store.test.ts
@@ -298,4 +298,48 @@ describe('session-store', () => {
     const main = d!.agents.find((a) => a.agentId === 'main')!;
     expect(main.swarmItem).toBeNull();
   });
+
+  it('prefers v2 labels for parentAgentId / swarmItem, top-level as fallback', async () => {
+    const { home, sessionDir, cleanup: c } = await buildSessionFixture('sample-main');
+    cleanup = c;
+    const { readFile, writeFile } = await import('node:fs/promises');
+    const { join } = await import('node:path');
+    const statePath = join(sessionDir, 'state.json');
+    const state = JSON.parse(await readFile(statePath, 'utf8'));
+    // v2 writes a fixed top-level `parentAgentId: 'main'` for every sub agent
+    // and puts the real parent / swarm label under `labels`.
+    state.agents['agent-1'] = {
+      type: 'sub',
+      parentAgentId: 'main',
+      labels: { parentAgentId: 'agent-0', swarmItem: 'batch item' },
+    };
+    await writeFile(statePath, JSON.stringify(state));
+
+    const d = await readSessionDetail(home, 'session_fixture');
+
+    const nested = d!.agents.find((a) => a.agentId === 'agent-1')!;
+    expect(nested.parentAgentId).toBe('agent-0');
+    expect(nested.swarmItem).toBe('batch item');
+    // agent-0 has no labels — the top-level v1 fields still apply.
+    const flat = d!.agents.find((a) => a.agentId === 'agent-0')!;
+    expect(flat.parentAgentId).toBe('main');
+  });
+
+  it('reads the legacy session-meta/state.json path when state.json is missing', async () => {
+    const { home, sessionDir, cleanup: c } = await buildSessionFixture('sample-main');
+    cleanup = c;
+    const { mkdir, rename } = await import('node:fs/promises');
+    const { join } = await import('node:path');
+    await mkdir(join(sessionDir, 'session-meta'), { recursive: true });
+    await rename(
+      join(sessionDir, 'state.json'),
+      join(sessionDir, 'session-meta', 'state.json'),
+    );
+
+    const sessions = await listSessions(home);
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.health).toBe('ok');
+    expect(sessions[0]!.title).toBe('fixture: hello world');
+  });
 });

--- a/apps/vis/server/test/lib/wire-reader.test.ts
+++ b/apps/vis/server/test/lib/wire-reader.test.ts
@@ -101,6 +101,33 @@ describe('wire-reader', () => {
     );
   });
 
+  it('passes v1.5 records through unchanged with no warnings', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'vis-v15-'));
+    const path = join(dir, 'wire.jsonl');
+    const records = [
+      { type: 'metadata', protocol_version: '1.5', created_at: 1 },
+      { type: 'token_counting.measured', agentId: 'main', length: 4, tokens: 1234, time: 2 },
+      {
+        type: 'cron.add',
+        agentId: 'main',
+        task: { id: '01ARZ3NDEKTSV4RRFFQ69G5FAV', cron: '* * * * *', prompt: 'p', createdAt: 3 },
+        time: 3,
+      },
+    ];
+    await writeFile(path, records.map((r) => JSON.stringify(r)).join('\n') + '\n');
+    try {
+      const result = await readAgentWire(path);
+      expect(result.metadata.protocolVersion).toBe('1.5');
+      expect(result.warnings).toEqual([]);
+      expect(result.records).toHaveLength(2);
+      // data === raw for current-protocol records (no migration applied).
+      expect(result.records[0]!.data).toEqual(result.records[0]!.raw);
+      expect(result.records[1]!.data).toEqual(result.records[1]!.raw);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('collects warnings for malformed body lines', async () => {
     const { sessionDir, cleanup: c } = await buildSessionFixture('sample-main');
     cleanup = c;

--- a/apps/vis/server/tsconfig.json
+++ b/apps/vis/server/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../../tsconfig.json",
-  "include": ["src", "test", "../../../packages/agent-core/src/prompt-modules.d.ts"]
+  "include": ["src", "test", "../../../packages/agent-core-v2/src/env.d.ts"]
 }

--- a/apps/vis/server/tsdown.config.ts
+++ b/apps/vis/server/tsdown.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from 'tsdown';
 
+import { rawTextPlugin } from '../../../build/raw-text-plugin.mjs';
+
 export default defineConfig({
   entry: { server: 'src/index.ts' },
   format: ['esm'],
   outDir: 'dist',
   clean: true,
-  external: ['@moonshot-ai/agent-core', '@moonshot-ai/kosong', '@moonshot-ai/kaos'],
+  plugins: [rawTextPlugin()],
+  deps: {
+    alwaysBundle: [/^@moonshot-ai\/agent-core-v2/],
+  },
 });

--- a/apps/vis/web/src/components/context/CompactionRibbon.tsx
+++ b/apps/vis/web/src/components/context/CompactionRibbon.tsx
@@ -25,8 +25,10 @@ export function CompactionRibbon({ message }: CompactionRibbonProps) {
       </div>
       {stats ? (
         <div className="text-center font-mono text-[10.5px] text-fg-3">
-          {stats.compactedCount} msgs · {stats.tokensBefore.toLocaleString()}→
-          {stats.tokensAfter.toLocaleString()} tok
+          {stats.compactedCount} msgs
+          {stats.tokensBefore !== undefined && stats.tokensAfter !== undefined
+            ? ` · ${stats.tokensBefore.toLocaleString()}→${stats.tokensAfter.toLocaleString()} tok`
+            : ''}
         </div>
       ) : null}
       {summary.length > 0 ? (

--- a/apps/vis/web/src/components/context/MessageBubble.tsx
+++ b/apps/vis/web/src/components/context/MessageBubble.tsx
@@ -28,8 +28,8 @@ function UserBubble({ m }: { m: ProjectedMessage }) {
   const origin = m.message.origin;
   const originKind = origin?.kind;
   // Badge every origin that is not a plain user prompt. This covers
-  // skill_activation, background_task, cron_job, cron_missed, retry,
-  // system_trigger, injection, hook_result, compaction_summary, etc.
+  // skill_activation, task (v2; v1: background_task), cron_job, cron_missed,
+  // retry, system_trigger, injection, hook_result, compaction_summary, etc.
   const showsOriginBadge = originKind !== undefined && originKind !== 'user';
   return (
     <article className={baseClass()} style={{ borderLeftColor: 'var(--color-user)' }}>

--- a/apps/vis/web/src/components/wire/WireRowDetail.tsx
+++ b/apps/vis/web/src/components/wire/WireRowDetail.tsx
@@ -54,7 +54,7 @@ export function WireRowDetail({ entry }: WireRowDetailProps) {
             className={`font-mono text-[10px] ${
               view === 'projected' ? 'text-fg-0' : 'text-fg-3 hover:text-fg-1'
             }`}
-            title="Same line after vis applied the agent-core migration chain"
+            title="Same line after vis applied the engine's wire migration chain"
           >
             {view === 'projected' ? '[ hide projected ]' : '[ {…} projected ]'}
           </button>

--- a/apps/vis/web/src/components/wire/parts.tsx
+++ b/apps/vis/web/src/components/wire/parts.tsx
@@ -242,6 +242,9 @@ export function LoopEventDetail({ event }: { event: LoopRecordedEvent }) {
           parsed = event.args;
         }
       }
+      // v2 no longer persists `description` / `display` on `tool.call`;
+      // read them tolerantly so v1 wires still render both.
+      const legacy = event as { description?: string; display?: unknown };
       return (
         <div className="space-y-2">
           <div className="grid grid-cols-[140px_1fr] gap-x-3 gap-y-[2px]">
@@ -257,10 +260,10 @@ export function LoopEventDetail({ event }: { event: LoopRecordedEvent }) {
             <FieldRow label="turnId">
               <Mono>{event.turnId}</Mono>
             </FieldRow>
-            {event.description ? (
+            {legacy.description ? (
               <FieldRow label="description" wide>
                 <pre className="whitespace-pre-wrap break-words text-fg-1">
-                  {event.description}
+                  {legacy.description}
                 </pre>
               </FieldRow>
             ) : null}
@@ -269,10 +272,10 @@ export function LoopEventDetail({ event }: { event: LoopRecordedEvent }) {
             <div className="mb-1 text-fg-2">args</div>
             <JsonViewer value={parsed} defaultOpenDepth={2} />
           </div>
-          {event.display ? (
+          {legacy.display ? (
             <div>
               <div className="mb-1 text-fg-2">display</div>
-              <JsonViewer value={event.display} defaultOpenDepth={1} />
+              <JsonViewer value={legacy.display} defaultOpenDepth={1} />
             </div>
           ) : null}
         </div>
@@ -281,6 +284,8 @@ export function LoopEventDetail({ event }: { event: LoopRecordedEvent }) {
     case 'tool.result': {
       const isError = event.result.isError === true;
       const output = event.result.output;
+      // v1 persisted `truncated` / `message`; v2 persists `note` instead.
+      const result = event.result as { truncated?: boolean; message?: string; note?: string };
       return (
         <div className="space-y-2">
           <div className="grid grid-cols-[140px_1fr] gap-x-3 gap-y-[2px]">
@@ -299,18 +304,23 @@ export function LoopEventDetail({ event }: { event: LoopRecordedEvent }) {
                 {String(isError)}
               </span>
             </FieldRow>
-            {event.result.truncated === true ? (
+            {result.truncated === true ? (
               <FieldRow label="truncated">
                 <span className="text-[var(--color-sev-warning)]">
                   true · output was paged or dropped before the model saw it
                 </span>
               </FieldRow>
             ) : null}
-            {event.result.message !== undefined ? (
+            {result.message !== undefined ? (
               <FieldRow label="message" wide>
                 <pre className="whitespace-pre-wrap break-words text-fg-1">
-                  {event.result.message}
+                  {result.message}
                 </pre>
+              </FieldRow>
+            ) : null}
+            {result.note !== undefined ? (
+              <FieldRow label="note" wide>
+                <pre className="whitespace-pre-wrap break-words text-fg-1">{result.note}</pre>
               </FieldRow>
             ) : null}
           </div>

--- a/apps/vis/web/src/components/wire/renderers.tsx
+++ b/apps/vis/web/src/components/wire/renderers.tsx
@@ -1,7 +1,7 @@
 // The single wire-renderer registry. Co-locates tone + label + headline +
 // detail for every record kind. Because `WIRE_RENDERERS` is typed as a mapped
 // type over the FULL `RecordType` union, TypeScript REQUIRES an entry for each
-// kind: adding a kind upstream in agent-core fails
+// kind: adding a kind upstream in agent-core-v2 fails
 // `pnpm --filter @moonshot-ai/vis-web typecheck` here until a renderer is
 // added. This is the anti-rot guarantee that keeps vis from silently falling
 // behind the wire protocol.
@@ -42,6 +42,16 @@ export interface WireRenderer<K extends RecordType> {
  *  over the full `RecordType` union, so TypeScript forces an entry per kind. */
 type RendererMap = { [K in RecordType]: WireRenderer<K> };
 
+/** Render the summary of a `context.apply_compaction` record across its v2
+ *  payload variants: a plain string on current records, a ContextMessage on
+ *  the legacy variant; fall back to `contextSummary` when neither holds. */
+function compactionSummaryText(r: AgentRecordOf<'context.apply_compaction'>): string {
+  const summary = r.summary;
+  if (typeof summary === 'string') return summary;
+  if (summary !== undefined) return firstText(summary.content);
+  return ('contextSummary' in r ? r.contextSummary : undefined) ?? '';
+}
+
 export const WIRE_RENDERERS: RendererMap = {
   metadata: {
     tone: 'meta',
@@ -67,11 +77,13 @@ export const WIRE_RENDERERS: RendererMap = {
     tone: 'config',
     label: 'config',
     headline: (r) => {
+      const cwd = r.environmentDisclosure?.cwd;
+      const effort = r.thinkingEffort ?? r.thinkingLevel;
       const parts: string[] = [];
       if (r.profileName !== undefined) parts.push(`profile=${r.profileName}`);
       if (r.modelAlias !== undefined) parts.push(`model=${r.modelAlias}`);
-      if (r.cwd !== undefined) parts.push(`cwd=${r.cwd}`);
-      if (r.thinkingEffort !== undefined) parts.push(`thinking=${r.thinkingEffort}`);
+      if (cwd !== undefined) parts.push(`cwd=${cwd}`);
+      if (effort !== undefined) parts.push(`thinking=${effort}`);
       if (r.systemPrompt !== undefined) parts.push(`system(${r.systemPrompt.length}b)`);
       return {
         main: (
@@ -255,37 +267,48 @@ export const WIRE_RENDERERS: RendererMap = {
   'context.apply_compaction': {
     tone: 'compaction',
     label: 'compacted',
-    headline: (r) => ({
-      main: (
-        <span className="flex items-center gap-2 min-w-0">
-          <Pill tone="compaction" variant="soft">
-            compacted
-          </Pill>
-          <Dim>
-            summary {r.summary.length}b · {r.tokensBefore}→{r.tokensAfter} tok · {r.compactedCount}{' '}
-            msgs
-          </Dim>
-        </span>
-      ),
-    }),
-    detail: (r) => (
-      <div className="grid grid-cols-[140px_1fr] gap-x-3 gap-y-[2px]">
-        <FieldRow label="summary" wide>
-          <SizePreview label="summary" sizeBytes={r.summary.length} preview={r.summary}>
-            <pre className="whitespace-pre-wrap break-words text-fg-1">{r.summary}</pre>
-          </SizePreview>
-        </FieldRow>
-        <FieldRow label="compactedCount">
-          <span className="text-[var(--color-sev-info)]">{r.compactedCount}</span>
-        </FieldRow>
-        <FieldRow label="tokensBefore">
-          <span className="text-[var(--color-sev-info)]">{r.tokensBefore}</span>
-        </FieldRow>
-        <FieldRow label="tokensAfter">
-          <span className="text-[var(--color-sev-info)]">{r.tokensAfter}</span>
-        </FieldRow>
-      </div>
-    ),
+    headline: (r) => {
+      // v2 payload variants: `summary` is a string on current records, a
+      // ContextMessage on the legacy variant (which uses `count` instead of
+      // `compactedCount`); `tokensBefore`/`tokensAfter` are optional.
+      const summaryText = compactionSummaryText(r);
+      const compactedCount = r.compactedCount ?? ('count' in r ? r.count : 0);
+      return {
+        main: (
+          <span className="flex items-center gap-2 min-w-0">
+            <Pill tone="compaction" variant="soft">
+              compacted
+            </Pill>
+            <Dim>
+              summary {summaryText.length}b · {r.tokensBefore ?? '?'}→{r.tokensAfter ?? '?'} tok ·{' '}
+              {compactedCount} msgs
+            </Dim>
+          </span>
+        ),
+      };
+    },
+    detail: (r) => {
+      const summaryText = compactionSummaryText(r);
+      const compactedCount = r.compactedCount ?? ('count' in r ? r.count : 0);
+      return (
+        <div className="grid grid-cols-[140px_1fr] gap-x-3 gap-y-[2px]">
+          <FieldRow label="summary" wide>
+            <SizePreview label="summary" sizeBytes={summaryText.length} preview={summaryText}>
+              <pre className="whitespace-pre-wrap break-words text-fg-1">{summaryText}</pre>
+            </SizePreview>
+          </FieldRow>
+          <FieldRow label="compactedCount">
+            <span className="text-[var(--color-sev-info)]">{compactedCount}</span>
+          </FieldRow>
+          <FieldRow label="tokensBefore">
+            <span className="text-[var(--color-sev-info)]">{r.tokensBefore ?? '(n/a)'}</span>
+          </FieldRow>
+          <FieldRow label="tokensAfter">
+            <span className="text-[var(--color-sev-info)]">{r.tokensAfter ?? '(n/a)'}</span>
+          </FieldRow>
+        </div>
+      );
+    },
   },
 
   'context.undo': {
@@ -642,7 +665,7 @@ export const WIRE_RENDERERS: RendererMap = {
     headline: () => ({ main: <Dim>goal cleared</Dim> }),
   },
 
-  // Observability records — the request trace (see agent-core records/types.ts).
+  // Observability records — the request trace (see the v2 wire manifest).
 
   'llm.tools_snapshot': {
     tone: 'tools',
@@ -787,6 +810,270 @@ export const WIRE_RENDERERS: RendererMap = {
           <Mono>#{r.hash.slice(0, 8)}</Mono>
         ),
     }),
+  },
+
+  'turn.ended': {
+    tone: 'turn',
+    label: 'turn✓',
+    headline: (r) => ({
+      main: (
+        <span className="flex items-center gap-2 min-w-0">
+          <Mono>turn {r.turnId}</Mono>
+          <Pill tone={r.reason === 'completed' ? 'success' : 'warning'} variant="soft">
+            {r.reason}
+          </Pill>
+          {r.durationMs !== undefined ? <Dim>{r.durationMs}ms</Dim> : null}
+        </span>
+      ),
+    }),
+  },
+
+  'turn.step.interrupted': {
+    tone: 'warning',
+    label: 'step×',
+    headline: (r) => ({
+      main: (
+        <span className="flex items-center gap-2 min-w-0">
+          <Mono>
+            turn {r.turnId} · step {r.step}
+          </Mono>
+          <Dim className="truncate">{r.reason}</Dim>
+        </span>
+      ),
+    }),
+  },
+
+  'turn.step.retrying': {
+    tone: 'warning',
+    label: 'retry↻',
+    headline: (r) => ({
+      main: (
+        <span className="flex items-center gap-2 min-w-0">
+          <Mono>
+            turn {r.turnId} · step {r.step}
+          </Mono>
+          <Pill tone="warning" variant="soft">
+            attempt {r.nextAttempt}/{r.maxAttempts}
+          </Pill>
+          <Dim className="truncate">
+            {r.errorName}: {truncate(r.errorMessage, 60)}
+          </Dim>
+        </span>
+      ),
+    }),
+  },
+
+  'prompt.accepted': {
+    tone: 'turn',
+    label: 'prompt+',
+    headline: (r) => ({ main: <Mono>{r.promptId}</Mono> }),
+  },
+
+  'prompt.aborted': {
+    tone: 'warning',
+    label: 'prompt×',
+    headline: (r) => ({ main: <Mono>{r.promptId}</Mono> }),
+  },
+
+  'prompt.completed': {
+    tone: 'turn',
+    label: 'prompt✓',
+    headline: (r) => ({
+      main: (
+        <span className="flex items-center gap-2">
+          <Mono>{r.promptId}</Mono>
+          <Pill tone={r.reason === 'completed' ? 'success' : 'warning'} variant="soft">
+            {r.reason}
+          </Pill>
+        </span>
+      ),
+    }),
+  },
+
+  'prompt.steered': {
+    tone: 'turn',
+    label: 'steer→',
+    headline: (r) => ({
+      main: <span className="truncate text-fg-1">→ {truncate(firstText(r.content), 80)}</span>,
+    }),
+  },
+
+  'interaction.request': {
+    tone: 'approval',
+    label: 'ask→',
+    headline: (r) => ({
+      main: (
+        <span className="flex items-center gap-2">
+          <Pill tone="approval" variant="soft">
+            {r.kind}
+          </Pill>
+          <Mono>{r.id}</Mono>
+        </span>
+      ),
+    }),
+  },
+
+  'interaction.resolved': {
+    tone: 'approval',
+    label: 'ask✓',
+    headline: (r) => ({ main: <Mono>{r.id}</Mono> }),
+  },
+
+  'task.started': {
+    tone: 'subagent',
+    label: 'task↻',
+    headline: (r) => ({ main: <Mono>{r.info.taskId}</Mono> }),
+  },
+
+  'task.terminated': {
+    tone: 'subagent',
+    label: 'task✓',
+    headline: (r) => ({
+      main: (
+        <span className="flex items-center gap-2">
+          <Mono>{r.info.taskId}</Mono>
+          <Dim>{r.info.status}</Dim>
+        </span>
+      ),
+    }),
+  },
+
+  'task.waitDelivered': {
+    tone: 'subagent',
+    label: 'task⇢',
+    headline: (r) => ({
+      main: (
+        <Dim>
+          wait delivered · {r.keys.length} task{r.keys.length === 1 ? '' : 's'}
+        </Dim>
+      ),
+    }),
+  },
+
+  'token_counting.measured': {
+    tone: 'meta',
+    label: 'tokens',
+    headline: (r) => ({ main: <Dim>context {r.tokens} tok (measured)</Dim> }),
+  },
+
+  'token_counting.truncated': {
+    tone: 'meta',
+    label: 'tokens',
+    headline: (r) => ({ main: <Dim>context {r.tokens} tok (truncated @ {r.length})</Dim> }),
+  },
+
+  'token_counting.rebased': {
+    tone: 'meta',
+    label: 'tokens',
+    headline: (r) => ({
+      main: (
+        <Dim>
+          context {r.tokens} tok (rebased{r.measured ? ', measured' : ''})
+        </Dim>
+      ),
+    }),
+  },
+
+  'token_counting.turn_recorded': {
+    tone: 'meta',
+    label: 'tokens',
+    headline: (r) => ({ main: <Dim>context {r.tokens} tok (turn {r.turnId})</Dim> }),
+  },
+
+  'cron.add': {
+    tone: 'lifecycle',
+    label: 'cron+',
+    headline: (r) => ({
+      main: (
+        <span className="flex items-center gap-2 min-w-0">
+          <Mono>{r.task.cron}</Mono>
+          <Dim className="truncate">{truncate(r.task.prompt, 60)}</Dim>
+        </span>
+      ),
+    }),
+  },
+
+  'cron.delete': {
+    tone: 'warning',
+    label: 'cron−',
+    headline: (r) => ({
+      main: (
+        <Dim>
+          {r.ids.length} task{r.ids.length === 1 ? '' : 's'} deleted
+        </Dim>
+      ),
+    }),
+  },
+
+  'cron.cursor': {
+    tone: 'lifecycle',
+    label: 'cron·fired',
+    headline: (r) => ({
+      main: (
+        <span className="flex items-center gap-2 min-w-0">
+          <Mono>{r.id}</Mono>
+          <Dim>fired {new Date(r.lastFiredAt).toLocaleString()}</Dim>
+        </span>
+      ),
+    }),
+  },
+
+  'plan.revision': {
+    tone: 'lifecycle',
+    label: 'plan·rev',
+    headline: (r) => ({
+      main: (
+        <span className="flex items-center gap-2 min-w-0">
+          <Mono>
+            plan {r.id} · v{r.version}
+          </Mono>
+          <Dim>{r.bytes}b</Dim>
+        </span>
+      ),
+    }),
+  },
+
+  'plugin.session_start': {
+    tone: 'meta',
+    label: 'plugin',
+    headline: (r) => ({
+      main: (
+        <Dim className="truncate">
+          session start{r.content !== null ? `: ${truncate(r.content, 60)}` : ''}
+        </Dim>
+      ),
+    }),
+  },
+
+  'runtime.set_binding': {
+    tone: 'meta',
+    label: 'runtime',
+    headline: (r) => ({
+      main: (
+        <span className="flex items-center gap-2 min-w-0">
+          <Mono>{r.runtimeId}</Mono>
+          <Dim className="truncate">workspace {r.workspaceId}</Dim>
+        </span>
+      ),
+    }),
+  },
+
+  'staleGuard.recorded': {
+    tone: 'meta',
+    label: 'stale',
+    headline: (r) => ({ main: <Dim className="truncate">{r.path}</Dim> }),
+  },
+
+  'staleGuard.cleared': {
+    tone: 'meta',
+    label: 'stale✓',
+    headline: () => ({ main: <Dim>stale guard cleared</Dim> }),
+  },
+
+  'interruptionReminder.recorded': {
+    tone: 'meta',
+    label: 'interrupted',
+    headline: (r) => ({ main: <Dim>interruption reminder · turn {r.turnId}</Dim> }),
   },
 };
 

--- a/apps/vis/web/src/lib/analysis.ts
+++ b/apps/vis/web/src/lib/analysis.ts
@@ -5,7 +5,7 @@
 // needs but the raw record list does not surface:
 //   - per-turn / per-step / per-tool wall-clock duration (from record `time`)
 //   - per-turn token cost (sum of step usages) and cache-hit rate
-//   - context-window fill over time (mirrors agent-core's snapshot formula)
+//   - context-window fill over time (mirrors the engine's snapshot formula)
 //   - tool-result truncation / size / error flags
 //   - tool usage stats (count, error rate, latency)
 //   - idle gaps (large wall-clock gaps between records → waiting)
@@ -50,7 +50,7 @@ export interface StepNode {
   finishReason?: string;
   isError?: boolean;
   usage?: TokenUsage;
-  /** Context-window fill after this step (the agent-core snapshot formula). */
+  /** Context-window fill after this step (the engine's snapshot formula). */
   contextTokens?: number;
   llmFirstTokenLatencyMs?: number;
   llmStreamDurationMs?: number;
@@ -180,7 +180,7 @@ function usageTotal(u: TokenUsage): number {
   return u.inputOther + u.output + u.inputCacheRead + u.inputCacheCreation;
 }
 
-/** Context-window fill after a step, mirroring agent-core ContextMemory. */
+/** Context-window fill after a step, mirroring the engine's token counting. */
 function contextFill(u: TokenUsage): number {
   return u.inputCacheRead + u.inputCacheCreation + u.inputOther + u.output;
 }
@@ -290,23 +290,58 @@ export function analyzeWire(entries: readonly WireEntry[]): Analysis {
         });
         if (contextTokens > peakContext) peakContext = contextTokens;
         break;
+      case 'token_counting.measured':
+      case 'token_counting.truncated':
+      case 'token_counting.rebased':
+      case 'token_counting.turn_recorded':
+        // v2's replacement for `context.update_token_count`: the record's
+        // `tokens` is the agent's current context-window fill.
+        contextTokens = rec.tokens;
+        contextSeries.push({
+          lineNo: entry.lineNo,
+          time: t,
+          turnIndex: current?.index ?? -1,
+          step: -1,
+          contextTokens,
+        });
+        if (contextTokens > peakContext) peakContext = contextTokens;
+        break;
       case 'context.clear':
         contextTokens = 0;
         break;
       case 'context.apply_compaction':
-        contextTokens = rec.tokensAfter;
-        contextSeries.push({ lineNo: entry.lineNo, time: t, turnIndex: current?.index ?? -1, step: -1, contextTokens });
-        if (contextTokens > peakContext) peakContext = contextTokens;
+        // `tokensAfter` is optional in the v2 payload (absent on legacy
+        // variants) — keep the prior count then.
+        if (rec.tokensAfter !== undefined) {
+          contextTokens = rec.tokensAfter;
+          contextSeries.push({ lineNo: entry.lineNo, time: t, turnIndex: current?.index ?? -1, step: -1, contextTokens });
+          if (contextTokens > peakContext) peakContext = contextTokens;
+        }
         break;
 
       case 'config.update': {
+        const cwd = rec.environmentDisclosure?.cwd;
+        const effort = rec.thinkingEffort ?? rec.thinkingLevel;
         const changed: { field: string; value: string }[] = [];
         if (rec.profileName !== undefined) changed.push({ field: 'profile', value: rec.profileName });
         if (rec.modelAlias !== undefined) changed.push({ field: 'model', value: rec.modelAlias });
-        if (rec.thinkingEffort !== undefined) changed.push({ field: 'thinking', value: rec.thinkingEffort });
-        if (rec.cwd !== undefined) changed.push({ field: 'cwd', value: rec.cwd });
+        if (effort !== undefined) changed.push({ field: 'thinking', value: effort });
+        if (cwd !== undefined) changed.push({ field: 'cwd', value: cwd });
         if (rec.systemPrompt !== undefined) changed.push({ field: 'systemPrompt', value: `${rec.systemPrompt.length} chars` });
         if (changed.length > 0) configChanges.push({ lineNo: entry.lineNo, time: t, changed });
+        break;
+      }
+
+      case 'profile.bind': {
+        // v2 writes most initial config state on `profile.bind` rather than
+        // `config.update`.
+        const changed: { field: string; value: string }[] = [];
+        if (rec.profileName !== undefined) changed.push({ field: 'profile', value: rec.profileName });
+        if (rec.modelAlias !== undefined) changed.push({ field: 'model', value: rec.modelAlias });
+        changed.push({ field: 'thinking', value: rec.thinkingEffort });
+        if (rec.environmentDisclosure !== undefined) changed.push({ field: 'cwd', value: rec.environmentDisclosure.cwd });
+        changed.push({ field: 'systemPrompt', value: `${rec.systemPrompt.length} chars` });
+        configChanges.push({ lineNo: entry.lineNo, time: t, changed });
         break;
       }
 
@@ -316,8 +351,10 @@ export function analyzeWire(entries: readonly WireEntry[]): Analysis {
           current ??= startTurn('prompt', entry.lineNo, t, '(no prompt record)', undefined);
           const step: StepNode = {
             uuid: ev.uuid,
-            step: ev.step,
-            turnId: ev.turnId,
+            // `step` / `turnId` are optional on v2 loop events; fall back so
+            // the timeline stays numeric for old and new wires alike.
+            step: ev.step ?? -1,
+            turnId: ev.turnId ?? '',
             beginLineNo: entry.lineNo,
             beginTime: t,
             content: { textChars: 0, thinkChars: 0 },
@@ -348,8 +385,8 @@ export function analyzeWire(entries: readonly WireEntry[]): Analysis {
               if (current) addUsage(current.tokens, ev.usage);
               addUsage(cache, ev.usage);
               // A zero-usage step.end (e.g. a content-filtered response) must
-              // not reset the context-window fill to 0 — agent-core's
-              // ContextMemory keeps the prior snapshot in that case. Carry the
+              // not reset the context-window fill to 0 — the engine's
+              // token counting keeps the prior snapshot in that case. Carry the
               // running value so the chart shows no false drop.
               const fill = contextFill(ev.usage);
               if (fill > 0) {
@@ -361,7 +398,7 @@ export function analyzeWire(entries: readonly WireEntry[]): Analysis {
                 lineNo: entry.lineNo,
                 time: t,
                 turnIndex: current?.index ?? -1,
-                step: ev.step,
+                step: ev.step ?? -1,
                 contextTokens,
               });
             }
@@ -372,7 +409,8 @@ export function analyzeWire(entries: readonly WireEntry[]): Analysis {
             callLineNo: entry.lineNo,
             toolCallId: ev.toolCallId,
             name: ev.name,
-            description: ev.description,
+            // v2 no longer persists `description`; v1 wires still carry it.
+            description: (ev as { description?: string }).description,
             callTime: t,
           };
           toolByCallId.set(ev.toolCallId, node);
@@ -390,7 +428,9 @@ export function analyzeWire(entries: readonly WireEntry[]): Analysis {
         } else if (ev.type === 'tool.result') {
           const node = toolByCallId.get(ev.toolCallId);
           const isError = ev.result.isError === true;
-          const truncated = ev.result.truncated === true;
+          // v1 persisted `truncated` / `message`; v2 persists `note` instead.
+          const result = ev.result as { truncated?: boolean; message?: string; note?: string };
+          const truncated = result.truncated === true;
           const bytes = outputSize(ev.result.output);
           if (node) {
             node.resultLineNo = entry.lineNo;
@@ -398,7 +438,7 @@ export function analyzeWire(entries: readonly WireEntry[]): Analysis {
             node.isError = isError;
             node.truncated = truncated;
             node.outputBytes = bytes;
-            node.resultMessage = ev.result.message;
+            node.resultMessage = result.message ?? result.note;
             if (node.callTime !== undefined && t !== undefined) node.durationMs = t - node.callTime;
             if (isError && current) current.toolErrorCount += 1;
             recordToolStat(toolStatMap, node);

--- a/apps/vis/web/src/lib/issues.ts
+++ b/apps/vis/web/src/lib/issues.ts
@@ -1,7 +1,7 @@
 // Aggregate every "something went wrong" signal from a wire timeline
 // into a flat list consumable by the Issues drawer. Pure — no React.
 //
-// Detection rules for the new agent-core wire protocol:
+// Detection rules for the engine's wire protocol:
 //   - tool.call without paired tool.result (orphan tool.call)
 //   - tool.result without preceding tool.call (orphan tool.result)
 //   - tool.result with isError (tool failed)
@@ -87,16 +87,18 @@ export function computeIssues(
             });
           }
           // Runtime failure / partial-output signals carried on the result.
+          // v1 persisted `truncated` / `message`; v2 persists `note` instead.
+          const result = ev.result as { truncated?: boolean; message?: string; note?: string };
           if (ev.result.isError === true) {
             out.push({
               severity: 'error',
               kind: 'tool_error',
               lineNo,
               summary: `${open?.name ?? 'tool'}#${ev.toolCallId.slice(-8)} returned an error`,
-              detail: ev.result.message,
+              detail: result.message ?? result.note,
             });
           }
-          if (ev.result.truncated === true) {
+          if (result.truncated === true) {
             out.push({
               severity: 'info',
               kind: 'tool_truncated',
@@ -108,8 +110,9 @@ export function computeIssues(
         } else if (ev.type === 'step.begin') {
           stepBeginByUuid.set(ev.uuid, {
             lineNo,
-            step: ev.step,
-            turnId: ev.turnId,
+            // `step` / `turnId` are optional on v2 loop events.
+            step: ev.step ?? -1,
+            turnId: ev.turnId ?? '',
           });
         } else if (ev.type === 'step.end') {
           stepBeginByUuid.delete(ev.uuid);

--- a/apps/vis/web/test/analysis.test.ts
+++ b/apps/vis/web/test/analysis.test.ts
@@ -47,7 +47,7 @@ describe('analyzeWire', () => {
     expect(tc.outputBytes).toBe(50);
     expect(tc.isError).toBe(false);
 
-    // Context-window fill snapshots (agent-core formula)
+    // Context-window fill snapshots (the engine's formula)
     expect(a.turns[0]!.steps[0]!.contextTokens).toBe(210); // 100+20+80+10
     expect(a.turns[0]!.steps[1]!.contextTokens).toBe(400); // 200+50+150+0
     expect(a.summary.peakContextTokens).toBe(400);

--- a/apps/vis/web/tsconfig.json
+++ b/apps/vis/web/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    // This package type-checks agent-core's source (consumed via source
+    // This package type-checks agent-core-v2's source (consumed via source
     // `exports`), whose services use legacy parameter decorators for DI, so the
     // experimental decorator transform must be enabled here too.
     "experimentalDecorators": true,
@@ -18,8 +18,8 @@
     "jsx": "react-jsx",
     "strict": true,
     // Unused-locals/params are intentionally NOT enforced here: this package
-    // type-checks agent-core's source (consumed via source `exports`), so these
-    // flags would surface dead code inside agent-core. Matches the repo norm
+    // type-checks agent-core-v2's source (consumed via source `exports`), so these
+    // flags would surface dead code inside agent-core-v2. Matches the repo norm
     // (root tsconfig and other packages do not set them); oxlint covers unused.
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,12 +224,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.13.7
         version: 1.19.14(hono@4.12.14)
-      '@moonshot-ai/agent-core':
+      '@moonshot-ai/agent-core-v2':
         specifier: workspace:^
-        version: link:../../../packages/agent-core
-      '@moonshot-ai/kosong':
-        specifier: workspace:^
-        version: link:../../../packages/kosong
+        version: link:../../../packages/agent-core-v2
       hono:
         specifier: ^4.7.7
         version: 4.12.14


### PR DESCRIPTION
## Related Issue

N/A — internal task (no linked issue). This unblocks the follow-up removal of `packages/agent-core` (v1), which lists `apps/vis/server` among its remaining consumers.

## Problem

`apps/vis` (the session/replay debug visualizer) still depended on the retired agent-core v1 engine, while the product (kap-server / klient / CLI) runs on agent-core-v2. As a result, vis read today's v2-written sessions through the v1 vocabulary:

- the Cron tab came back empty — v2 persists cron as durable wire records (`cron.add` / `cron.delete` / `cron.cursor`) instead of `<agentDir>/cron/*.json` files;
- agent trees were flattened and swarm badges missing — v2 writes the real `parentAgentId` / `swarmItem` under `state.json` agents' `labels`, keeping only a fixed top-level placeholder;
- the context-window token display was dead — v2 replaced `context.update_token_count` with `token_counting.*` records;
- and its compile-time dependency on `@moonshot-ai/agent-core` blocked deleting v1 entirely.

## What changed

- **Dependencies**: vis-server now depends solely on `@moonshot-ai/agent-core-v2` (the kosong message/usage types come from v2's re-exports). v2 is bundled into the vis-server build: its `exports` point at `src/*.ts`, which plain Node cannot load in strip-only mode (parameter properties, `.md?raw` imports), so the bundle inlines exactly the used graph (value imports via subpaths; type imports erased). The `build:deps` pre-build chain is gone.
- **Wire vocabulary**: the record union is rebuilt from v2's durable payload types (60 record kinds + metadata + the two v1-only legacy records old wires still contain). The context projector's exhaustiveness check and the web renderer registry now cover every v2 record kind.
- **Behavior alignment**: `token_counting.*` folds into the context-window fill; cron folds `cron.add` / `delete` / `cursor` from each agent's `wire.jsonl` with legacy files as fallback (wire wins); agent `parentAgentId` / `swarmItem` read labels-first with top-level fallback; `context.apply_compaction` tolerates the v2 three-variant payload (optional token counts, ContextMessage-summary legacy variant); `config.update` and `profile.bind` both feed the config snapshot (`environmentDisclosure.cwd`, `thinkingLevel`); legacy `background_task` origins normalize to `task`; v1-written wires (1.0–1.4) keep reading through the v2 migration chain, and the legacy `session-meta/state.json` metadata path is honored.
- **Web**: renderer entries for all new v2 record kinds; tool.call / tool.result tolerate both vocabularies (v1 `description` / `display` / `truncated` / `message`, v2 `note`, optional `step` / `turnId`); the compaction ribbon handles optional token counts.
- **Tests**: 14 new cases (wire-fold cron incl. legacy precedence, labels metadata, legacy session-meta path, token_counting fold, profile.bind / config.update, legacy compaction variant, origin normalization, v2 no-op records, 1.5 pass-through). Existing v1-format fixtures stay as legacy-read coverage.

Verified: vis-server / vis-web / root typecheck, 156 + 11 vitest cases, lint, full build; manually against real session homes — v1.5 sessions (new record kinds, token_counting context fill), v1.4 legacy sessions (migration chain), and a 174-agent swarm session (labels-sourced swarm badges), plus the built SPA.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`). — N/A, internal change
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — no changeset: vis packages never appear in one
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — internal debug tool, no user-facing docs touched
