### PR TITLE
fix(agent-core-v2): allow Bash cwd outside the workspace roots

### DIFF
--- a/.changeset/bash-cwd-workspace-restriction.md
+++ b/.changeset/bash-cwd-workspace-restriction.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Remove the workspace restriction on the Bash tool's cwd parameter.

--- a/packages/agent-core-v2/src/runtime/runtimeWorkspaceView.ts
+++ b/packages/agent-core-v2/src/runtime/runtimeWorkspaceView.ts
@@ -30,16 +30,14 @@ export class RuntimeWorkspaceView {
   resolve(path: string, cwd = this.workDir): string {
     const env = this.runtime.environment;
     const bridged = env.pathClass === 'win32' ? getShellPathBridge(env).fromShellPath(path) : path;
-    const resolved = this.runtime.path.isAbsolute(bridged)
+    return this.runtime.path.isAbsolute(bridged)
       ? this.runtime.path.resolve(bridged)
       : this.runtime.path.resolve(cwd, bridged);
-    this.assertAllowed(resolved);
-    return resolved;
   }
 
-  assertAllowed(path: string): void {
+  assertAllowed(path: string): string {
     const resolved = this.runtime.path.resolve(path);
-    if (this.roots.some((root) => contains(this.runtime, root, resolved))) return;
+    if (this.roots.some((root) => contains(this.runtime, root, resolved))) return resolved;
     throw new Error2(
       ErrorCodes.FS_PATH_ESCAPES,
       `path ${path} is outside runtime workspace ${this.binding.runtimeId}`,

--- a/packages/agent-core-v2/src/session/terminal/terminalService.ts
+++ b/packages/agent-core-v2/src/session/terminal/terminalService.ts
@@ -79,7 +79,7 @@ export class SessionTerminalService extends Disposable implements ISessionTermin
       ['terminal'],
     );
     const view = new RuntimeWorkspaceView(lease.runtime, this.workspace);
-    const cwd = input.cwd === undefined ? view.workDir : view.resolve(input.cwd);
+    const cwd = input.cwd === undefined ? view.workDir : view.assertAllowed(view.resolve(input.cwd));
     const shell = input.shell ?? lease.runtime.environment.shellPath;
     let process: TerminalProcess;
     try {

--- a/packages/agent-core-v2/test/os/backends/node-local/tools/bash.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/tools/bash.test.ts
@@ -859,6 +859,19 @@ describe('BashTool', () => {
     expect(exec.mock.calls[0]?.[1]).toEqual(['-c', "cd '/workspace/project' && pwd"]);
   });
 
+  it('accepts args.cwd outside the workspace roots', async () => {
+    const { runner, exec } = createTestRunner(processWithOutput({ stdout: 'out\n' }));
+    const tool = bashTool(runner);
+
+    const result = await executeTool(
+      tool,
+      context({ command: 'pwd', cwd: '/outside/workspace', timeout: 60 }),
+    );
+
+    expect(exec.mock.calls[0]?.[1]).toEqual(['-c', "cd '/outside/workspace' && pwd"]);
+    expect(result).toMatchObject({ output: 'out\n', isError: false });
+  });
+
   it('uses the kaos cwd as the default working directory', async () => {
     const { runner, exec } = createTestRunner(processWithOutput({ stdout: '' }));
     const tool = bashTool(runner, posixEnv, createTestCtx('/var/app'));

--- a/packages/agent-core-v2/test/runtime/runtimeWorkspaceView.test.ts
+++ b/packages/agent-core-v2/test/runtime/runtimeWorkspaceView.test.ts
@@ -19,7 +19,8 @@ describe('RuntimeWorkspaceView', () => {
     expect(view.resolve('src/index.ts')).toBe('/workspace/project/src/index.ts');
     expect(view.resolve('../shared/file.txt', '/workspace/project/src')).toBe('/workspace/project/shared/file.txt');
     expect(view.resolve('/shared/file.txt')).toBe('/shared/file.txt');
-    expect(() => view.resolve('../../outside')).toThrow('outside runtime workspace');
+    expect(view.resolve('../../outside')).toBe('/outside');
+    expect(() => view.assertAllowed(view.resolve('../../outside'))).toThrow('outside runtime workspace');
   });
 
   it('uses win32 path semantics and rejects sibling prefixes', () => {
@@ -29,7 +30,7 @@ describe('RuntimeWorkspaceView', () => {
     });
     expect(view.resolve('src\\index.ts')).toBe('C:\\workspace\\project\\src\\index.ts');
     expect(view.resolve('d:\\SHARED\\file.txt')).toBe('d:\\SHARED\\file.txt');
-    expect(() => view.resolve('C:\\workspace\\project-other\\file.txt')).toThrow('outside runtime workspace');
+    expect(() => view.assertAllowed(view.resolve('C:\\workspace\\project-other\\file.txt'))).toThrow('outside runtime workspace');
   });
 
   it('uses provider-owned workspace root mapping', () => {
@@ -71,8 +72,8 @@ describe('RuntimeWorkspaceView', () => {
     expect(win32View.binding.runtimeId).toBe('remote-win32');
     expect(posixView.resolve('/provider-a/shared/file.txt')).toBe('/provider-a/shared/file.txt');
     expect(win32View.resolve('D:\\provider-b\\shared\\file.txt')).toBe('D:\\provider-b\\shared\\file.txt');
-    expect(() => posixView.resolve('/provider-b/shared/file.txt')).toThrow('outside runtime workspace');
-    expect(() => win32View.resolve('C:\\provider-a\\repo\\file.txt')).toThrow('outside runtime workspace');
+    expect(() => posixView.assertAllowed(posixView.resolve('/provider-b/shared/file.txt'))).toThrow('outside runtime workspace');
+    expect(() => win32View.assertAllowed(win32View.resolve('C:\\provider-a\\repo\\file.txt'))).toThrow('outside runtime workspace');
   });
 
   it('translates Git Bash POSIX paths on win32 bash runtimes', () => {
@@ -95,7 +96,7 @@ describe('RuntimeWorkspaceView', () => {
     expect(view.resolve('/cygdrive/c/workspace/project/package.json')).toBe(
       'C:\\workspace\\project\\package.json',
     );
-    expect(() => view.resolve('/tmp/scratch.txt')).toThrow('outside runtime workspace');
+    expect(() => view.assertAllowed(view.resolve('/tmp/scratch.txt'))).toThrow('outside runtime workspace');
   });
 
   it('deduplicates roots and preserves generation identity', () => {


### PR DESCRIPTION
## Related Issue

No linked issue — internal bug report (client screenshot showed the model hitting this error and working around it via in-command `cd`).

## Problem

The Bash tool's `cwd` parameter rejects paths outside the runtime workspace roots with `path ... is outside runtime workspace local`. This limit is not an effective boundary for Bash: the command body itself is unchecked, so `cd <path> && ...` inside the command bypasses it freely. Its only real effect is that the model burns one error turn before working around it. The check was introduced incidentally by the runtime-binding refactor (#2961) as a side effect of routing all tool paths through runtime mapping — not as a deliberate Bash safety boundary. Actual gating of out-of-workspace execution belongs to the permission policy chain.

## What changed

- `RuntimeWorkspaceView.resolve` is a pure path mapping again (shell path bridging + absolutize); the built-in out-of-workspace assertion is removed.
- `assertAllowed` now returns the validated path so callers that need the boundary compose it explicitly — `terminalService` keeps its exact out-of-workspace rejection behavior via `view.assertAllowed(view.resolve(input.cwd))`.
- The Bash tool returns to the baseline `view.resolve(args.cwd ?? view.workDir)` form, so `cwd` accepts directories outside the workspace in every permission mode. Relative-path resolution against the session workDir and win32 Git Bash path bridging are unchanged, as are the path-access checks of the file tools (Read/Write/Edit/Glob/Grep), which never went through `view.resolve`.
- Tests: new bash case covering `cwd` outside the workspace roots; runtimeWorkspaceView tests move the escape assertions from `resolve` to `assertAllowed` and pin `resolve` as a non-throwing pure mapping.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (no issue — internal report, see Problem).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
