### PR TITLE
feat(plugins): hide official plugins from marketplace listings

### DIFF
--- a/apps/kimi-code/src/tui/commands/plugins.ts
+++ b/apps/kimi-code/src/tui/commands/plugins.ts
@@ -46,7 +46,6 @@ import {
   type PluginMarketplace,
   type PluginMarketplaceEntry,
 } from '#/utils/plugin-marketplace';
-import { openUrl } from '#/utils/open-url';
 import type { SlashCommandHost } from './dispatch';
 
 interface ShowPluginsPickerOptions {
@@ -737,12 +736,6 @@ async function handlePluginsPanelSelection(
         selection.source,
         isOfficialPluginSource(selection.source),
       );
-      return;
-    case 'open-url':
-      host.restoreEditor();
-      openUrl(selection.url);
-      host.showStatus(`Opening the ${selection.label} page in your browser…`, 'success');
-      host.showStatus(`If it did not open, visit ${selection.url}`);
       return;
   }
 }

--- a/apps/kimi-code/src/tui/components/dialogs/plugins-selector.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/plugins-selector.ts
@@ -33,28 +33,6 @@ const INSTALL_TRUST_EXIT = 'exit';
 const INSTALL_TRUST_TRUST = 'trust';
 const ELLIPSIS = '…';
 
-// Hardcoded Web Bridge promotion: a built-in fallback shown only while the
-// marketplace catalog is loading, unreachable, or predates the real
-// `kimi-webbridge` entry. Selecting it opens the install page in the browser;
-// once the catalog carries the real entry, that row wins and installs
-// normally.
-const WEB_BRIDGE_URL = 'https://www.kimi.com/features/webbridge#local-agent';
-const WEB_BRIDGE_ENTRY: PluginMarketplaceEntry = {
-  id: 'kimi-webbridge',
-  displayName: 'Kimi WebBridge',
-  source: WEB_BRIDGE_URL,
-  tier: 'official',
-  homepage: WEB_BRIDGE_URL,
-  description: 'Control your real browser from Kimi Code — navigate, click, type, and screenshot',
-};
-
-// Only the hardcoded pinned row should open the WebBridge install page. Match
-// by reference (not id) so a catalog entry on another tab that happens to
-// reuse the same id still installs normally instead of being hijacked.
-function isPinnedWebBridgeEntry(entry: PluginMarketplaceEntry): boolean {
-  return entry === WEB_BRIDGE_ENTRY;
-}
-
 interface PluginsOverviewItem {
   readonly value: string;
   readonly kind: 'plugin' | 'action';
@@ -333,8 +311,7 @@ export type PluginsPanelSelection =
   | { readonly kind: 'details'; readonly id: string }
   | { readonly kind: 'reload' }
   | { readonly kind: 'install'; readonly entry: PluginMarketplaceEntry }
-  | { readonly kind: 'install-source'; readonly source: string }
-  | { readonly kind: 'open-url'; readonly url: string; readonly label: string };
+  | { readonly kind: 'install-source'; readonly source: string };
 
 export interface PluginsPanelOptions {
   readonly installed: readonly PluginSummary[];
@@ -463,16 +440,9 @@ export class PluginsPanelComponent extends Container implements Focusable {
     // capability rows still render and install — built-in runtime setup
     // must never be blocked by an unrelated catalog fetch.
     if (this.market.status !== 'loaded') {
-      return this.pendingBuiltInEntries.some((entry) => entry.id === WEB_BRIDGE_ENTRY.id)
-        ? this.pendingBuiltInEntries
-        : [...this.pendingBuiltInEntries, WEB_BRIDGE_ENTRY];
+      return this.pendingBuiltInEntries;
     }
-    // The real catalog entry wins when present (it installs the actual
-    // plugin); the hardcoded promo row is only a fallback while the catalog
-    // is loading, unreachable, or predates it — never a duplicate row.
-    return this.officialCatalogEntries.some((entry) => entry.id === WEB_BRIDGE_ENTRY.id)
-      ? this.officialCatalogEntries
-      : [WEB_BRIDGE_ENTRY, ...this.officialCatalogEntries];
+    return this.officialCatalogEntries;
   }
 
   /** Capability rows synthesized from the engine's registry, independent of
@@ -604,10 +574,6 @@ export class PluginsPanelComponent extends Container implements Focusable {
     if (matchesKey(data, Key.enter)) {
       const entry = entries[this.selectedIndex];
       if (entry === undefined) return;
-      if (isPinnedWebBridgeEntry(entry)) {
-        this.opts.onSelect({ kind: 'open-url', url: WEB_BRIDGE_URL, label: entry.displayName });
-        return;
-      }
       this.opts.onSelect({ kind: 'install', entry });
     }
   }
@@ -720,10 +686,6 @@ export class PluginsPanelComponent extends Container implements Focusable {
     width: number,
     entries: readonly PluginMarketplaceEntry[],
     indexOffset = 0,
-    // Counts (installed/available footer) are computed over this list:
-    // the Official tab renders the pinned promo as a row but excludes it
-    // from the catalog counts, matching its pre-catalog semantics.
-    entriesForCount: readonly PluginMarketplaceEntry[] = entries,
   ): void {
     const colors = currentTheme.palette;
     if (this.market.status === 'loading' || this.market.status === 'idle') {
@@ -742,13 +704,13 @@ export class PluginsPanelComponent extends Container implements Focusable {
         lines.push(...this.renderMarketplaceRow(entries[i]!, i + indexOffset, width));
       }
     }
-    const installedCount = entriesForCount.filter((entry) =>
+    const installedCount = entries.filter((entry) =>
       this.isMarketplaceEntryInstalled(entry),
     ).length;
     lines.push('');
     lines.push(
       mutedHintLine(
-        ` ${installedCount} installed · ${entriesForCount.length - installedCount} available`,
+        ` ${installedCount} installed · ${entries.length - installedCount} available`,
         colors,
       ),
     );
@@ -757,9 +719,7 @@ export class PluginsPanelComponent extends Container implements Focusable {
 
   private renderOfficial(lines: string[], width: number): void {
     // Loading / error: `officialEntries` carries the locally-known
-    // capability rows (plus the promo fallback when webbridge is not among
-    // them), so built-in setup works before the catalog arrives. Once
-    // loaded, the promo appears only when the catalog lacks the real entry.
+    // capability rows, so built-in setup works before the catalog arrives.
     if (this.market.status !== 'loaded') {
       const entries = this.officialEntries;
       for (let i = 0; i < entries.length; i += 1) {
@@ -768,7 +728,7 @@ export class PluginsPanelComponent extends Container implements Focusable {
       this.renderMarketplaceTab(lines, width, [], entries.length);
       return;
     }
-    this.renderMarketplaceTab(lines, width, this.officialEntries, 0, this.officialCatalogEntries);
+    this.renderMarketplaceTab(lines, width, this.officialEntries);
   }
 
   private renderThirdParty(lines: string[], width: number): void {
@@ -787,9 +747,8 @@ export class PluginsPanelComponent extends Container implements Focusable {
     const labelStyle = selected ? chalk.hex(colors.primary).bold : chalk.hex(colors.text);
     const prefix = chalk.hex(selected ? colors.primary : colors.textDim)(`  ${pointer} `);
     const capability = this.capabilityForEntry(entry);
-    const status = isPinnedWebBridgeEntry(entry)
-      ? 'open in browser'
-      : capability?.install.running === true
+    const status =
+      capability?.install.running === true
         ? 'installing…'
         : marketplaceEntryStatus(
             entry,

--- a/apps/kimi-code/test/tui/components/dialogs/plugins-selector.test.ts
+++ b/apps/kimi-code/test/tui/components/dialogs/plugins-selector.test.ts
@@ -459,20 +459,20 @@ describe('plugins selector dialogs', () => {
     expect(out).toContain('0 installed · 1 available');
   });
 
-  it('renders the hardcoded Web Bridge entry on the Official tab while loading', () => {
+  it('renders no fallback entries on the Official tab while loading', () => {
     const { panel } = makePanel({ initialTab: 'official' });
-    // The catalog is still loading, but the built-in Web Bridge entry is shown
-    // immediately because it is baked into the TUI, not fetched.
+    // The catalog is still loading and there are no locally-known capability
+    // rows, so the tab shows only the loading state.
     const out = strip(renderRaw(panel));
-    expect(out).toContain('Kimi WebBridge  open in browser');
+    expect(out).not.toContain('Kimi WebBridge');
     expect(out).toContain('Loading marketplace');
   });
 
-  it('keeps the Web Bridge entry visible when the Official catalog errors', () => {
+  it('renders no fallback entries when the Official catalog errors', () => {
     const { panel } = makePanel({ initialTab: 'official' });
     panel.setMarketplaceError('fetch failed');
     const out = strip(renderRaw(panel));
-    expect(out).toContain('Kimi WebBridge  open in browser');
+    expect(out).not.toContain('Kimi WebBridge');
     expect(out).toContain('Marketplace unavailable: fetch failed');
   });
 
@@ -515,15 +515,13 @@ describe('plugins selector dialogs', () => {
     const { panel, onSelect } = makePanel({ initialTab: 'official', capabilities });
 
     // No setMarketplace yet — built-in runtime setup must not wait on the
-    // remote catalog: the engine-known rows render (and the promo is
-    // suppressed by the real webbridge row).
+    // remote catalog: the engine-known rows render immediately.
     const out = strip(renderRaw(panel));
     expect(out).toContain('Kimi Computer Use  install');
     expect(out).toContain('Kimi WebBridge  install');
     expect(out).toContain('Background GUI automation');
     expect(out).not.toContain('id kimi-cu');
     expect(out).not.toContain('Official plugin');
-    expect(out).not.toContain('open in browser');
     expect(out).toContain('Loading marketplace');
 
     panel.handleInput('\r'); // index 0 → kimi-cu routes to capability install
@@ -547,26 +545,13 @@ describe('plugins selector dialogs', () => {
 
     const out = strip(renderRaw(panel));
     expect(out).not.toContain('Kimi Computer Use');
-    expect(out).toContain('Kimi WebBridge  open in browser');
+    expect(out).not.toContain('Kimi WebBridge');
     expect(out).toContain('Loading marketplace');
   });
 
-  it('opens the Web Bridge webpage on Enter instead of installing', () => {
+  it('installs a catalog official entry on Enter', async () => {
     const { panel, onSelect } = makePanel({ initialTab: 'official' });
     panel.setMarketplace(marketplaceEntries, '/tmp/marketplace.json');
-    // Web Bridge is pinned at index 0, so Enter selects it directly.
-    panel.handleInput('\r');
-    expect(onSelect).toHaveBeenCalledWith({
-      kind: 'open-url',
-      url: 'https://www.kimi.com/features/webbridge#local-agent',
-      label: 'Kimi WebBridge',
-    });
-  });
-
-  it('installs a catalog official entry after navigating past Web Bridge', () => {
-    const { panel, onSelect } = makePanel({ initialTab: 'official' });
-    panel.setMarketplace(marketplaceEntries, '/tmp/marketplace.json');
-    panel.handleInput('\u001B[B'); // ↓ → kimi-datasource
     panel.handleInput('\r');
     expect(onSelect).toHaveBeenCalledWith({
       kind: 'install',
@@ -574,34 +559,9 @@ describe('plugins selector dialogs', () => {
     });
   });
 
-  it('lets the real catalog entry win over the pinned Web Bridge promo', () => {
-    const entries = [
-      {
-        id: 'kimi-webbridge',
-        tier: 'official' as const,
-        displayName: 'Kimi WebBridge',
-        source: 'capability:kimi-webbridge',
-      },
-      ...officialEntries,
-    ];
-    const { panel, onSelect } = makePanel({ initialTab: 'official' });
-    panel.setMarketplace(entries, '/tmp/marketplace.json');
-    const out = strip(renderRaw(panel));
-    // Exactly one row, and it is the installable catalog copy — the hardcoded
-    // open-in-browser promo is suppressed.
-    expect(out.split('Kimi WebBridge').length - 1).toBe(1);
-    expect(out).not.toContain('open in browser');
-    panel.handleInput('\r'); // index 0 → the real entry installs
-    expect(onSelect).toHaveBeenCalledWith({
-      kind: 'install',
-      entry: expect.objectContaining({ id: 'kimi-webbridge', source: 'capability:kimi-webbridge' }),
-    });
-  });
-
-  it('installs a Curated entry whose id matches the pinned WebBridge', () => {
+  it('installs a Curated entry that reuses the kimi-webbridge id', () => {
     // A curated/custom marketplace entry can legitimately reuse the
-    // kimi-webbridge id; on the Curated tab it must install normally, not
-    // open the WebBridge page (that shortcut is reserved for the pinned row).
+    // kimi-webbridge id; it renders and installs as a plain plugin.
     const entries = [
       {
         id: 'kimi-webbridge',

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -7044,9 +7044,6 @@ command = "vim"
     await vi.waitFor(() => {
       expect(stripSgr(panel.render(120).join('\n'))).toContain('Kimi Datasource');
     });
-    // The pinned Kimi WebBridge row leads the Official tab, so move down to
-    // the Kimi Datasource entry before installing.
-    panel.handleInput('\u001B[B');
     panel.handleInput('\r');
 
     await vi.waitFor(() => {
@@ -7254,9 +7251,6 @@ command = "vim"
       await vi.waitFor(() => {
         expect(stripSgr(panel.render(120).join('\n'))).toContain('Kimi Datasource');
       });
-      // The pinned Kimi WebBridge row leads the Official tab, so move down to
-      // the Kimi Datasource entry before installing.
-      panel.handleInput('\u001B[B');
       panel.handleInput('\r');
 
       await vi.waitFor(() => {

--- a/apps/kimi-code/test/utils/plugin-marketplace.test.ts
+++ b/apps/kimi-code/test/utils/plugin-marketplace.test.ts
@@ -227,13 +227,8 @@ describe('loadPluginMarketplace', () => {
         version: '6.0.3',
       }),
     );
-    expect(marketplace.plugins).toContainEqual(
-      expect.objectContaining({
-        id: 'kimi-datasource',
-        tier: 'official',
-        source: join(REPO_ROOT, 'plugins/official/kimi-datasource'),
-      }),
-    );
+    // Official Kimi-branded plugins are temporarily hidden from the catalog.
+    expect(marketplace.plugins.some((entry) => entry.tier === 'official')).toBe(false);
   });
 
   it('loads the default CDN marketplace with injectable fetch', async () => {

--- a/packages/agent-core-v2/src/app/capability/capabilityService.ts
+++ b/packages/agent-core-v2/src/app/capability/capabilityService.ts
@@ -86,17 +86,11 @@ export class CapabilityService extends Disposable implements ICapabilityService 
   }
 
   describeCapabilities(): readonly CapabilityDescriptor[] {
-    return [...this.entries.values()].map((entry) => ({
-      id: entry.id,
-      pluginId: entry.pluginId,
-      displayName: entry.displayName,
-      description: entry.description,
-      supported: entry.supported,
-    }));
+    return [];
   }
 
   listCapabilities(): Promise<readonly CapabilityStatus[]> {
-    return Promise.all([...this.entries.values()].map((entry) => this.statusOfSafe(entry)));
+    return Promise.resolve([]);
   }
 
   async getCapability(id: string): Promise<CapabilityStatus> {
@@ -185,31 +179,6 @@ export class CapabilityService extends Disposable implements ICapabilityService 
       steps: detected.steps,
       version: detected.version,
     };
-  }
-
-  private async statusOfSafe(entry: CapabilityEntry): Promise<CapabilityStatus> {
-    try {
-      return await this.statusOf(entry);
-    } catch (error) {
-      const install = this.installProgress.get(entry.id) ?? IDLE_PROGRESS;
-      const detail = error instanceof Error ? error.message : String(error);
-      const base = {
-        id: entry.id,
-        pluginId: entry.pluginId,
-        displayName: entry.displayName,
-        description: entry.description,
-        install,
-      };
-      if (!entry.supported) {
-        return { ...base, supported: false, state: 'unsupported', steps: [] };
-      }
-      return {
-        ...base,
-        supported: true,
-        state: 'partial',
-        steps: [{ id: 'detect', state: 'failed' as const, detail }],
-      };
-    }
   }
 }
 

--- a/packages/agent-core-v2/test/app/capability/capabilityService.test.ts
+++ b/packages/agent-core-v2/test/app/capability/capabilityService.test.ts
@@ -53,7 +53,7 @@ function expectErrorCode(error: unknown, code: string): void {
 }
 
 describe('CapabilityService', () => {
-  it('lists entries with readiness computed from required steps', async () => {
+  it('hides entries from listings while per-entry readiness stays available', async () => {
     const service = fakeService([
       fakeEntry({
         id: 'kimi-cu',
@@ -71,33 +71,14 @@ describe('CapabilityService', () => {
         },
       }),
     ]);
-    const list = await service.listCapabilities();
-    expect(list.map((c) => [c.id, c.state])).toEqual([
-      ['kimi-cu', 'ready'],
-      ['kimi-webbridge', 'partial'],
-    ]);
-    expect(list[0]?.pluginId).toBe('kimi-cu-win');
-  });
-
-  it('isolates a failing detector to its own entry', async () => {
-    const broken: CapabilityEntry = {
-      id: 'kimi-cu',
-      displayName: 'kimi-cu',
-      description: 'fake',
-      supported: true,
-      detect: () => Promise.reject(new Error('probe timed out')),
-      install: () => Promise.resolve(undefined),
-    };
-    const service = fakeService([
-      broken,
-      fakeEntry({ id: 'kimi-webbridge', detect: { steps: [{ id: 'daemon', state: 'ok' }] } }),
-    ]);
-
-    const list = await service.listCapabilities();
-    expect(list.find((c) => c.id === 'kimi-webbridge')?.state).toBe('ready');
-    const cu = list.find((c) => c.id === 'kimi-cu');
-    expect(cu?.state).toBe('partial');
-    expect(cu?.steps).toEqual([{ id: 'detect', state: 'failed', detail: 'probe timed out' }]);
+    // Official capabilities are temporarily hidden from listings; the
+    // registry keeps answering per-entry status for installed users.
+    expect(await service.listCapabilities()).toEqual([]);
+    const cu = await service.getCapability('kimi-cu');
+    expect(cu.state).toBe('ready');
+    expect(cu.pluginId).toBe('kimi-cu-win');
+    const webbridge = await service.getCapability('kimi-webbridge');
+    expect(webbridge.state).toBe('partial');
   });
 
   it('marks optional steps as non-blocking for ready', async () => {
@@ -123,11 +104,11 @@ describe('CapabilityService', () => {
       fakeEntry({ id: 'kimi-cu', detect: { steps: [{ id: 'plugin', state: 'missing' }] } }),
       fakeEntry({ id: 'kimi-webbridge', supported: false }),
     ]);
-    const list = await service.listCapabilities();
-    expect(list.find((c) => c.id === 'kimi-cu')?.state).toBe('not_installed');
-    const unsupported = list.find((c) => c.id === 'kimi-webbridge');
-    expect(unsupported?.state).toBe('unsupported');
-    expect(unsupported?.supported).toBe(false);
+    const cu = await service.getCapability('kimi-cu');
+    expect(cu.state).toBe('not_installed');
+    const unsupported = await service.getCapability('kimi-webbridge');
+    expect(unsupported.state).toBe('unsupported');
+    expect(unsupported.supported).toBe(false);
   });
 
   it('throws capability.not_found for unknown ids', async () => {
@@ -205,14 +186,16 @@ describe('CapabilityService', () => {
     expect.unreachable('install never settled');
   });
 
-  it('describes the registry without running detectors', async () => {
+  it('hides descriptors from listings while the registry stays intact', async () => {
     const service = fakeService([
       fakeEntry({ id: 'kimi-cu', supported: true }),
       fakeEntry({ id: 'kimi-webbridge', supported: false }),
     ]);
-    const descriptors = service.describeCapabilities();
-    expect(descriptors.map((d) => d.id)).toEqual(['kimi-cu', 'kimi-webbridge']);
-    expect(descriptors.find((d) => d.id === 'kimi-webbridge')?.supported).toBe(false);
+    // Official capabilities are temporarily hidden from listings; the
+    // registry keeps answering per-entry status for installed users.
+    expect(service.describeCapabilities()).toEqual([]);
+    expect((await service.getCapability('kimi-cu')).state).toBe('ready');
+    expect((await service.getCapability('kimi-webbridge')).supported).toBe(false);
   });
 
   it('emits onDidChangeInstall on every progress transition', async () => {

--- a/packages/kap-server/test/capabilities.test.ts
+++ b/packages/kap-server/test/capabilities.test.ts
@@ -63,27 +63,13 @@ describe('server-v2 /api/v1 capabilities', () => {
     return { status: res.status, body: (await res.json()) as Envelope<T> };
   }
 
-  it('lists both built-in capabilities with the documented shape', async () => {
+  it('lists no capabilities while official entries are hidden from listings', async () => {
     const { body } = await getJson<unknown>('/api/v1/capabilities');
     expect(body.code).toBe(0);
     const parsed = listCapabilitiesResponseSchema.parse(body.data);
-    const ids = parsed.capabilities.map((c) => c.id).toSorted();
-    expect(ids).toEqual(['kimi-cu', 'kimi-webbridge']);
-    for (const capability of parsed.capabilities) {
-      expect(capabilityStatusSchema.parse(capability)).toBeTruthy();
-      expect(capability.install.running).toBe(false);
-    }
-    const kimiCu = parsed.capabilities.find((c) => c.id === 'kimi-cu');
-    if (process.platform === 'darwin' || (process.platform === 'win32' && process.arch === 'x64')) {
-      expect(kimiCu?.supported).toBe(true);
-    } else {
-      expect(kimiCu?.supported).toBe(false);
-      expect(kimiCu?.state).toBe('unsupported');
-    }
-    const webbridge = parsed.capabilities.find((c) => c.id === 'kimi-webbridge');
-    expect(webbridge?.supported).toBe(true);
-    expect(webbridge?.steps.find((s) => s.id === 'skill')?.state).toBe('missing');
-    expect(webbridge?.steps.find((s) => s.id === 'extension')?.optional).toBe(true);
+    // Official capabilities are temporarily hidden from listings; per-entry
+    // get/install keep working for already-installed users.
+    expect(parsed.capabilities).toEqual([]);
   });
 
   it('gets a single capability and 40418s on an unknown id', async () => {

--- a/packages/kap-server/test/plugins.test.ts
+++ b/packages/kap-server/test/plugins.test.ts
@@ -371,37 +371,20 @@ describe('server-v2 /api/v1 plugins', () => {
       '/api/v1/plugins/marketplace',
     );
     expect(body.code).toBe(0);
-    expect(body.data.entries.find((e) => e.id === 'kimi-webbridge')?.capabilityId).toBe(
-      'kimi-webbridge',
+    // Official capabilities are temporarily hidden from listings: even with
+    // the default catalog, no capability rows are synthesized and catalog
+    // entries carrying a capability id stay out.
+    expect(body.data.entries.find((e) => e.id === 'kimi-webbridge')).toBeUndefined();
+    expect(body.data.entries.find((e) => e.id === 'kimi-cu')).toBeUndefined();
+
+    // An installed instance does not leak back into the marketplace listing.
+    const cuSource = await makePluginDir('kimi-cu', '0.1.0');
+    await call('POST', '/api/v1/plugins', { source: cuSource });
+    const after = await call<{ entries: { id: string }[] }>(
+      'GET',
+      '/api/v1/plugins/marketplace',
     );
-
-    const cuSupported = process.platform === 'darwin' || (process.platform === 'win32' && process.arch === 'x64');
-    const after0 = await call<{
-      entries: { id: string; capabilityId?: string; installed?: { version?: string } }[];
-    }>('GET', '/api/v1/plugins/marketplace');
-    if (!cuSupported) {
-      expect(after0.body.data.entries.find((e) => e.id === 'kimi-cu')).toBeUndefined();
-      return;
-    }
-
-    const winSource = await makePluginDir('kimi-cu-win', '0.5.4');
-    await call('POST', '/api/v1/plugins', { source: winSource });
-    const after = await call<{
-      entries: { id: string; capabilityId?: string; installed?: { version?: string } }[];
-    }>('GET', '/api/v1/plugins/marketplace');
-    const cu = after.body.data.entries.find((e) => e.id === 'kimi-cu');
-    expect(cu?.capabilityId).toBe('kimi-cu');
-    expect(cu?.installed?.version).toBe('0.5.4');
-
-    const staleSource = await makePluginDir('kimi-cu', '0.1.0');
-    await call('POST', '/api/v1/plugins', { source: staleSource });
-    const both = await call<{
-      entries: { id: string; installed?: { version?: string } }[];
-    }>('GET', '/api/v1/plugins/marketplace');
-    const expected = process.platform === 'win32' && process.arch === 'x64' ? '0.5.4' : '0.1.0';
-    expect(both.body.data.entries.find((e) => e.id === 'kimi-cu')?.installed?.version).toBe(
-      expected,
-    );
+    expect(after.body.data.entries.find((e) => e.id === 'kimi-cu')).toBeUndefined();
   });
 
   it('maps an unreachable marketplace to 50001', async () => {
@@ -500,31 +483,20 @@ describe('server-v2 /api/v1 plugins', () => {
       }[];
     }>('GET', '/api/v1/plugins/marketplace');
     expect(body.code).toBe(0);
-    const datasource = body.data.entries.find((e) => e.id === 'kimi-datasource');
-    expect(datasource?.source.startsWith('http')).toBe(false);
-    expect(datasource?.source.endsWith(join('plugins', 'official', 'kimi-datasource'))).toBe(true);
-    const webbridge = body.data.entries.find((e) => e.id === 'kimi-webbridge');
-    expect(webbridge?.capabilityId).toBe('kimi-webbridge');
-    const cuSupported = process.platform === 'darwin' || (process.platform === 'win32' && process.arch === 'x64');
-    const cu = body.data.entries.find((e) => e.id === 'kimi-cu');
-    if (!cuSupported) {
-      expect(cu).toBeUndefined();
-      return;
-    }
-    expect(cu?.tier).toBe('official');
-    expect(cu?.capabilityId).toBe('kimi-cu');
-    expect(cu?.source).toBe('capability:kimi-cu');
-    expect(cu?.displayName).toBe('Kimi Computer Use');
+    // Official Kimi-branded plugins are temporarily hidden from the catalog:
+    // no official rows, including capability rows from the engine registry.
+    expect(body.data.entries.find((e) => e.id === 'kimi-datasource')).toBeUndefined();
+    expect(body.data.entries.find((e) => e.id === 'kimi-webbridge')).toBeUndefined();
+    expect(body.data.entries.find((e) => e.id === 'kimi-cu')).toBeUndefined();
 
+    // An installed instance does not leak back into the marketplace listing.
     const cuSource = await makePluginDir('kimi-cu', '0.5.8');
     await call('POST', '/api/v1/plugins', { source: cuSource });
-    const after = await call<{
-      entries: { id: string; installed?: { version?: string; enabled: boolean } }[];
-    }>('GET', '/api/v1/plugins/marketplace');
-    expect(after.body.data.entries.find((e) => e.id === 'kimi-cu')?.installed).toEqual({
-      version: '0.5.8',
-      enabled: true,
-    });
+    const after = await call<{ entries: { id: string }[] }>(
+      'GET',
+      '/api/v1/plugins/marketplace',
+    );
+    expect(after.body.data.entries.find((e) => e.id === 'kimi-cu')).toBeUndefined();
   });
 
   it('expands ~ in local catalog paths like the CLI loader', async () => {

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -2,24 +2,6 @@
   "version": "1",
   "plugins": [
     {
-      "id": "kimi-datasource",
-      "tier": "official",
-      "displayName": "Kimi Datasource",
-      "version": "3.4.0",
-      "description": "Stocks and financials from Wind, S&P Capital IQ, SEC EDGAR, etc.; news from Caixin, Xinhua Finance; macro from World Bank, IMF, FRED, NBS; corporate, academic, legal data, and more",
-      "keywords": ["data", "mcp"],
-      "source": "./official/kimi-datasource"
-    },
-    {
-      "id": "kimi-webbridge",
-      "tier": "official",
-      "displayName": "Kimi WebBridge",
-      "version": "1.11.3",
-      "description": "Control your real browser from Kimi Code.",
-      "keywords": ["browser", "automation", "webbridge"],
-      "source": "./official/kimi-webbridge"
-    },
-    {
       "id": "superpowers",
       "tier": "curated",
       "displayName": "Superpowers",


### PR DESCRIPTION
## Problem

Kimi Datasource, Kimi WebBridge, and Kimi Computer Use are not ready for users, but they still show up in every plugin listing: the TUI plugins dialog, the bundled `plugins/marketplace.json`, the capabilities REST API, and the kap-server web marketplace route (which synthesizes official rows from the engine's capability registry).

## Fix

Hide them everywhere listings are produced, without touching install/upgrade paths:

- `plugins/marketplace.json`: drop the two official-tier entries (curated entries stay)
- `capabilityService.listCapabilities()` **and** `describeCapabilities()`: return empty; the registry stays, so `getCapability`/`installCapability` keep working for installed users
- kap-server marketplace route: no capability-synthesized official rows (catalog entries carrying a capability id are also suppressed for the default catalog)
- TUI plugins-selector: remove the hardcoded WebBridge promo fallback row and its open-url selection variant

Installed instances remain visible and manageable exclusively on the Installed tab. Revert this commit to restore the listings.

## Tests

- Updated: plugins-selector, plugin-marketplace, capabilityService, kap-server capabilities/plugins, kimi-tui-message-flow
- Full suites: apps/kimi-code 3258 passed; agent-core-v2 6136 passed; kap-server 1318 passed + 1 skipped; `tsc --noEmit` clean in all three