### PR TITLE
feat(vscode): engine-backed @ file suggestions

### DIFF
--- a/.changeset/sdk-suggest-files.md
+++ b/.changeset/sdk-suggest-files.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code-sdk": minor
 ---
 
-Add `suggestFiles(workDir, { query, limit })` to `KimiHarness`: session-less fuzzy file suggestions backed by the agent-core-v2 workspace fs service. Returns `undefined` on the v1 engine.
+Add `suggestFiles(workDir, { query, limit })` to `KimiHarness`: session-less fuzzy file suggestions from the agent-core-v2 workspace fs service, `undefined` on the v1 engine.

--- a/.changeset/sdk-suggest-files.md
+++ b/.changeset/sdk-suggest-files.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code-sdk": minor
+---
+
+Add `suggestFiles(workDir, { query, limit })` to `KimiHarness`: session-less fuzzy file suggestions backed by the agent-core-v2 workspace fs service. Returns `undefined` on the v1 engine.

--- a/.changeset/vscode-at-engine-suggest.md
+++ b/.changeset/vscode-at-engine-suggest.md
@@ -1,0 +1,5 @@
+---
+"kimi-code": patch
+---
+
+Highlight matched characters in @ file suggestions and allow folders to be inserted as mentions.

--- a/.changeset/vscode-at-menu-entries.md
+++ b/.changeset/vscode-at-menu-entries.md
@@ -1,0 +1,5 @@
+---
+"kimi-code": patch
+---
+
+Show the image/video picker entry in the @ menu only before a search query is typed, and remove the Browse folders mode.

--- a/.changeset/vscode-at-scroll-jitter.md
+++ b/.changeset/vscode-at-scroll-jitter.md
@@ -1,0 +1,5 @@
+---
+"kimi-code": patch
+---
+
+Fix the @ and / suggestion lists jittering when the mouse rests at the scroll edge.

--- a/apps/vscode/shared/types.ts
+++ b/apps/vscode/shared/types.ts
@@ -17,6 +17,8 @@ export interface ProjectFile {
   path: string;
   name: string;
   isDirectory: boolean;
+  /** Matched-character offsets into `path`, for mention-style highlighting. */
+  matchPositions?: number[];
 }
 
 export interface FileChange {

--- a/apps/vscode/src/handlers/file.handler.ts
+++ b/apps/vscode/src/handlers/file.handler.ts
@@ -9,11 +9,10 @@ import {
   resolveWorkspacePath,
   type WorkspacePath,
 } from "../utils/workspace-path";
-import type { Handler } from "./types";
+import type { Handler, HandlerContext } from "./types";
 
 interface GetProjectFilesParams {
   query?: string;
-  directory?: string;
 }
 interface PickMediaParams { maxCount?: number; includeVideo?: boolean }
 interface FilePathParams { filePath: string }
@@ -34,12 +33,30 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
   ".ico": "image/x-icon",
 };
 
+const FILE_SUGGEST_LIMIT = 20;
+
 const getProjectFiles: Handler<GetProjectFilesParams | undefined, ProjectFile[]> = async (params, ctx) => {
-  if (!ctx.workDirUri) return [];
-  return params?.directory !== undefined
-    ? ctx.fileManager.listDirectory(ctx.workDirUri, params.directory)
-    : ctx.fileManager.searchFiles(ctx.workDirUri, params?.query);
+  if (!ctx.workDirUri || !ctx.workDir) return [];
+  const suggested = await suggestFiles(ctx, params?.query ?? "");
+  if (suggested !== undefined) return suggested;
+  return ctx.fileManager.searchFiles(ctx.workDirUri, params?.query);
 };
+
+async function suggestFiles(ctx: HandlerContext, query: string): Promise<ProjectFile[] | undefined> {
+  try {
+    const result = await ctx.harness.suggestFiles(ctx.requireWorkDir(), { query, limit: FILE_SUGGEST_LIMIT });
+    if (result === undefined) return undefined;
+    return result.items.map((item) => ({
+      path: item.path,
+      name: item.name,
+      isDirectory: item.kind === "directory",
+      matchPositions: [...item.matchPositions],
+    }));
+  } catch (error) {
+    ctx.logError("File suggest failed", error);
+    return [];
+  }
+}
 
 const pickMedia: Handler<PickMediaParams, string[]> = async (params) => {
   const maxCount = params.maxCount ?? 9;

--- a/apps/vscode/src/managers/file.manager.ts
+++ b/apps/vscode/src/managers/file.manager.ts
@@ -7,7 +7,6 @@ import { buildCaseInsensitiveGlobLiteral } from "../utils/string";
 import {
   isWorkspacePathContained,
   relativeWorkspacePath,
-  resolveWorkspacePath,
 } from "../utils/workspace-path";
 
 export type BroadcastFn = (event: string, data: unknown, webviewId?: string) => void;
@@ -42,16 +41,6 @@ const IGNORE_DIRS = new Set([
   "jspm_packages",
   ".turbo",
 ]);
-
-const IGNORE_EXT = new Set([".lock", ".log", ".map", ".min.js", ".min.css", ".chunk.js", ".chunk.css"]);
-
-function shouldIgnore(name: string): boolean {
-  if (IGNORE_DIRS.has(name)) {
-    return true;
-  }
-  const ext = path.extname(name).toLowerCase();
-  return IGNORE_EXT.has(ext);
-}
 
 const SEARCH_EXCLUDE = `{${[...IGNORE_DIRS].map((d) => `**/${d}`).join(",")}}`;
 
@@ -168,34 +157,6 @@ export class FileManager {
       }),
     );
     return results.filter((result): result is ProjectFile => result !== undefined);
-  }
-
-  async listDirectory(workDirUri: vscode.Uri, directory: string): Promise<ProjectFile[]> {
-    const requested = resolveWorkspacePath(workDirUri, directory, { allowRoot: true });
-    if (requested === undefined || !(await isWorkspacePathContained(workDirUri, requested.uri))) return [];
-    try {
-      const entries = await vscode.workspace.fs.readDirectory(requested.uri);
-      const resolvedEntries = await Promise.all(
-        entries.map(async ([name, type]): Promise<ProjectFile | undefined> => {
-          if (shouldIgnore(name)) return undefined;
-          const relativePath = requested.relativePath ? `${requested.relativePath}/${name}` : name;
-          const entry = resolveWorkspacePath(workDirUri, relativePath);
-          if (entry === undefined || !(await isWorkspacePathContained(workDirUri, entry.uri))) return undefined;
-          return {
-            path: entry.relativePath,
-            name,
-            isDirectory: (type & vscode.FileType.Directory) !== 0,
-          };
-        }),
-      );
-      return resolvedEntries
-        .filter((entry): entry is ProjectFile => entry !== undefined)
-        .toSorted((a, b) =>
-          a.isDirectory === b.isDirectory ? a.name.localeCompare(b.name) : a.isDirectory ? -1 : 1,
-        );
-    } catch {
-      return [];
-    }
   }
 
   dispose(): void {

--- a/apps/vscode/test/webview/mention-insert.test.ts
+++ b/apps/vscode/test/webview/mention-insert.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { computeMentionInsert } from '@/components/inputarea/utils';
+
+describe('computeMentionInsert', () => {
+  it('replaces the active token with the mention and moves the cursor past it', () => {
+    const result = computeMentionInsert({
+      text: 'check @ap',
+      cursorPos: 9,
+      filePath: 'src/app.ts',
+      activeToken: { start: 6 },
+      isAppend: false,
+    });
+    expect(result.newText).toBe('check @src/app.ts ');
+    expect(result.newCursorPos).toBe(result.newText.length);
+  });
+
+  it('appends the mention when there is no active token', () => {
+    const result = computeMentionInsert({
+      text: 'hi ',
+      cursorPos: 3,
+      filePath: 'a.ts',
+      activeToken: null,
+      isAppend: true,
+    });
+    expect(result.newText).toBe('hi @a.ts ');
+    expect(result.newCursorPos).toBe(result.newText.length);
+  });
+
+  it('quotes a path containing spaces so whitespace cannot split the mention', () => {
+    const result = computeMentionInsert({
+      text: '@my',
+      cursorPos: 3,
+      filePath: 'My Folder/app.ts',
+      activeToken: { start: 0 },
+      isAppend: false,
+    });
+    expect(result.newText).toBe('@"My Folder/app.ts" ');
+    expect(result.newCursorPos).toBe(result.newText.length);
+  });
+
+  it('quotes a path containing spaces in append mode', () => {
+    const result = computeMentionInsert({
+      text: '',
+      cursorPos: 0,
+      filePath: 'My Folder',
+      activeToken: null,
+      isAppend: true,
+    });
+    expect(result.newText).toBe('@"My Folder" ');
+  });
+});

--- a/apps/vscode/test/webview/mention-match.test.ts
+++ b/apps/vscode/test/webview/mention-match.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { mentionMatchSpans } from '@/lib/mention-match';
+
+describe('mentionMatchSpans', () => {
+  it('returns the whole text as a plain span when positions are missing or empty', () => {
+    expect(mentionMatchSpans('app.ts', undefined, 0)).toEqual([{ text: 'app.ts', hit: false }]);
+    expect(mentionMatchSpans('app.ts', [], 0)).toEqual([{ text: 'app.ts', hit: false }]);
+    expect(mentionMatchSpans('', [0], 0)).toEqual([{ text: '', hit: false }]);
+  });
+
+  it('splits hit and plain runs by position', () => {
+    expect(mentionMatchSpans('app.ts', [0, 1, 4], 0)).toEqual([
+      { text: 'ap', hit: true },
+      { text: 'p.', hit: false },
+      { text: 't', hit: true },
+      { text: 's', hit: false },
+    ]);
+  });
+
+  it('shifts path-frame positions into the name frame via start', () => {
+    // path 'src/app.ts' (len 10), name 'app.ts' → start = 6
+    expect(mentionMatchSpans('app.ts', [6, 7, 10], 6)).toEqual([
+      { text: 'ap', hit: true },
+      { text: 'p.', hit: false },
+      { text: 't', hit: true },
+      { text: 's', hit: false },
+    ]);
+  });
+
+  it('drops positions outside the text frame', () => {
+    expect(mentionMatchSpans('app.ts', [0, 1, 2], 6)).toEqual([{ text: 'app.ts', hit: false }]);
+    expect(mentionMatchSpans('src', [0, 6, 7], 0)).toEqual([
+      { text: 's', hit: true },
+      { text: 'rc', hit: false },
+    ]);
+  });
+
+  it('handles adjacent hits as a single run', () => {
+    expect(mentionMatchSpans('abc', [0, 1, 2], 0)).toEqual([{ text: 'abc', hit: true }]);
+  });
+});

--- a/apps/vscode/test/webview/mention-match.test.ts
+++ b/apps/vscode/test/webview/mention-match.test.ts
@@ -35,6 +35,24 @@ describe('mentionMatchSpans', () => {
     ]);
   });
 
+  it('extends a hit across the complete surrogate pair', () => {
+    // 'a😀b': 😀 occupies UTF-16 units 1 and 2; a match reported at offset 1
+    // must not split the pair between two spans.
+    expect(mentionMatchSpans('a\u{1F600}b', [1], 0)).toEqual([
+      { text: 'a', hit: false },
+      { text: '\u{1F600}', hit: true },
+      { text: 'b', hit: false },
+    ]);
+  });
+
+  it('keeps an unmatched surrogate pair in one plain run', () => {
+    expect(mentionMatchSpans('\u{1F600}ab', [2], 0)).toEqual([
+      { text: '\u{1F600}', hit: false },
+      { text: 'a', hit: true },
+      { text: 'b', hit: false },
+    ]);
+  });
+
   it('handles adjacent hits as a single run', () => {
     expect(mentionMatchSpans('abc', [0, 1, 2], 0)).toEqual([{ text: 'abc', hit: true }]);
   });

--- a/apps/vscode/test/webview/useFilePicker.test.tsx
+++ b/apps/vscode/test/webview/useFilePicker.test.tsx
@@ -67,30 +67,25 @@ describe('search', () => {
   });
 });
 
-describe('search and folder modes', () => {
-  it('loads the given directory in folder mode', async () => {
-    const { result } = renderHook(() => useFilePicker(at(''), noop, noop, noop), { wrapper: createWrapper() });
-    await waitFor(() => { expect(getProjectFiles).toHaveBeenCalledTimes(1); });
-
-    act(() => {
-      result.current.setFilePickerMode('folder');
-      result.current.setFolderPath('src');
+describe('media option', () => {
+  it('shows the media option only for an empty query', async () => {
+    const { result, rerender } = renderHook(({ token }) => useFilePicker(token, noop, noop, noop), {
+      initialProps: { token: at('') as Token },
+      wrapper: createWrapper(),
     });
-    await waitFor(() => { expect(getProjectFiles).toHaveBeenCalledWith({ directory: 'src' }); });
+    expect(result.current.showMediaOption).toBe(true);
+    expect(result.current.fileMenuHeaderCount).toBe(1);
+
+    rerender({ token: at('a') });
+    expect(result.current.showMediaOption).toBe(false);
+    expect(result.current.fileMenuHeaderCount).toBe(0);
   });
 
-  it('shows directory contents in folder mode', async () => {
-    getProjectFiles.mockImplementation((params?: { directory?: string }) =>
-      Promise.resolve(params?.directory ? [{ name: 'index.ts', path: 'src/index.ts', isDirectory: false }] : []),
-    );
+  it('hides the media option when media cannot be added', () => {
+    useChatStore.setState({ isStreaming: true });
     const { result } = renderHook(() => useFilePicker(at(''), noop, noop, noop), { wrapper: createWrapper() });
-    await waitFor(() => { expect(getProjectFiles).toHaveBeenCalled(); });
-
-    act(() => {
-      result.current.setFilePickerMode('folder');
-      result.current.setFolderPath('src');
-    });
-    await waitFor(() => { expect(result.current.fileItems).toEqual([{ name: 'index.ts', path: 'src/index.ts', isDirectory: false }]); });
+    expect(result.current.showMediaOption).toBe(false);
+    expect(result.current.fileMenuHeaderCount).toBe(0);
   });
 });
 
@@ -121,6 +116,15 @@ describe('keyboard navigation', () => {
     expect(result.current.selectedIndex).toBe(maxIndex - 1);
   });
 
+  it('calls onPickMedia when Enter selects the media option', async () => {
+    const onPickMedia = vi.fn();
+    const { result } = renderHook(() => useFilePicker(at(''), noop, onPickMedia, noop), { wrapper: createWrapper() });
+
+    expect(result.current.selectedIndex).toBe(0);
+    key(result, 'Enter');
+    expect(onPickMedia).toHaveBeenCalledTimes(1);
+  });
+
   it('calls onInsertFile when Enter selects a file', async () => {
     getProjectFiles.mockResolvedValue([{ name: 'a.ts', path: 'src/a.ts', isDirectory: false }]);
     const onInsertFile = vi.fn();
@@ -134,19 +138,16 @@ describe('keyboard navigation', () => {
     expect(onInsertFile).toHaveBeenCalledWith('src/a.ts');
   });
 
-  it('enters folder mode when Enter selects a directory', async () => {
-    getProjectFiles.mockImplementation((params?: { query?: string }) =>
-      Promise.resolve(params?.query ? [{ name: 'src', path: 'src', isDirectory: true }] : []),
-    );
-    const { result } = renderHook(() => useFilePicker(at('sr'), noop, noop, noop), { wrapper: createWrapper() });
+  it('calls onInsertFile with the directory path when Enter selects a directory', async () => {
+    getProjectFiles.mockResolvedValue([{ name: 'src', path: 'src', isDirectory: true }]);
+    const onInsertFile = vi.fn();
+    const { result } = renderHook(() => useFilePicker(at('sr'), onInsertFile, noop, noop), { wrapper: createWrapper() });
     await waitFor(() => { expect(result.current.fileItems).toHaveLength(1); });
 
     act(() => {
       result.current.setSelectedIndex(result.current.fileMenuHeaderCount);
     });
     key(result, 'Enter');
-    expect(result.current.filePickerMode).toBe('folder');
-    expect(result.current.folderPath).toBe('src');
-    await waitFor(() => { expect(getProjectFiles).toHaveBeenCalledWith({ directory: 'src' }); });
+    expect(onInsertFile).toHaveBeenCalledWith('src');
   });
 });

--- a/apps/vscode/test/webview/useFilePicker.test.tsx
+++ b/apps/vscode/test/webview/useFilePicker.test.tsx
@@ -49,6 +49,14 @@ describe('search', () => {
     expect(result.current.fileItems[0]).toMatchObject({ name: 'app.ts', path: 'src/app.ts' });
   });
 
+  it('caps the displayed items at 50', async () => {
+    getProjectFiles.mockResolvedValue(
+      Array.from({ length: 60 }, (_, i) => ({ name: `f${i}.ts`, path: `f${i}.ts`, isDirectory: false })),
+    );
+    const { result } = renderHook(() => useFilePicker(at('f'), noop, noop, noop), { wrapper: createWrapper() });
+    await waitFor(() => { expect(result.current.fileItems).toHaveLength(50); });
+  });
+
   it('debounces rapid query changes into a single request after 100ms', async () => {
     const { rerender } = renderHook(({ token }) => useFilePicker(token, noop, noop, noop), {
       initialProps: { token: at('') as Token },

--- a/apps/vscode/test/webview/useFilePicker.test.tsx
+++ b/apps/vscode/test/webview/useFilePicker.test.tsx
@@ -133,6 +133,32 @@ describe('keyboard navigation', () => {
     expect(onPickMedia).toHaveBeenCalledTimes(1);
   });
 
+  it('ignores confirmation while results are stale for the current query', async () => {
+    getProjectFiles.mockResolvedValue([{ name: 'a.ts', path: 'src/a.ts', isDirectory: false }]);
+    const onInsertFile = vi.fn();
+    const { result, rerender } = renderHook(({ token }) => useFilePicker(token, onInsertFile, noop, noop), {
+      initialProps: { token: at('a') as Token },
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => { expect(result.current.fileItems).toHaveLength(1); });
+
+    let resolveNext: (value: unknown) => void = noop;
+    getProjectFiles.mockImplementation(() => new Promise((resolve) => { resolveNext = resolve; }));
+    rerender({ token: at('ap') });
+    expect(result.current.isStale).toBe(true);
+
+    key(result, 'Enter');
+    expect(onInsertFile).not.toHaveBeenCalled();
+
+    await waitFor(() => { expect(getProjectFiles).toHaveBeenCalledWith({ query: 'ap' }); });
+    act(() => { resolveNext([{ name: 'app.ts', path: 'src/app.ts', isDirectory: false }]); });
+    await waitFor(() => { expect(result.current.fileItems[0]?.name).toBe('app.ts'); });
+    expect(result.current.isStale).toBe(false);
+
+    key(result, 'Enter');
+    expect(onInsertFile).toHaveBeenCalledWith('src/app.ts');
+  });
+
   it('calls onInsertFile when Enter selects a file', async () => {
     getProjectFiles.mockResolvedValue([{ name: 'a.ts', path: 'src/a.ts', isDirectory: false }]);
     const onInsertFile = vi.fn();

--- a/apps/vscode/test/webview/useFilePicker.test.tsx
+++ b/apps/vscode/test/webview/useFilePicker.test.tsx
@@ -148,6 +148,7 @@ describe('keyboard navigation', () => {
     expect(result.current.isStale).toBe(true);
 
     key(result, 'Enter');
+    act(() => { result.current.handleSelectItem(result.current.fileItems[0]!); });
     expect(onInsertFile).not.toHaveBeenCalled();
 
     await waitFor(() => { expect(getProjectFiles).toHaveBeenCalledWith({ query: 'ap' }); });

--- a/apps/vscode/test/webview/useFilePicker.test.tsx
+++ b/apps/vscode/test/webview/useFilePicker.test.tsx
@@ -124,6 +124,36 @@ describe('keyboard navigation', () => {
     expect(result.current.selectedIndex).toBe(maxIndex - 1);
   });
 
+  it('lets Enter fall through when there is no selectable entry', async () => {
+    getProjectFiles.mockResolvedValue([]);
+    const { result } = renderHook(() => useFilePicker(at('zzz'), noop, noop, noop), { wrapper: createWrapper() });
+    await waitFor(() => { expect(result.current.isLoading).toBe(false); });
+
+    let handled = true;
+    act(() => {
+      handled = result.current.handleFileMenuKey({ key: 'Enter', preventDefault: vi.fn() } as unknown as React.KeyboardEvent);
+    });
+    expect(handled).toBe(false);
+  });
+
+  it('clamps the selection when fresh results shrink the list', async () => {
+    getProjectFiles.mockResolvedValue([
+      { name: 'a.ts', path: 'a.ts', isDirectory: false },
+      { name: 'b.ts', path: 'b.ts', isDirectory: false },
+    ]);
+    const { result, rerender } = renderHook(({ token }) => useFilePicker(token, noop, noop, noop), {
+      initialProps: { token: at('a') as Token },
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => { expect(result.current.fileItems).toHaveLength(2); });
+
+    getProjectFiles.mockResolvedValue([{ name: 'app.ts', path: 'app.ts', isDirectory: false }]);
+    rerender({ token: at('ap') });
+    act(() => { result.current.setSelectedIndex(1); });
+    await waitFor(() => { expect(result.current.fileItems).toHaveLength(1); });
+    expect(result.current.selectedIndex).toBe(0);
+  });
+
   it('calls onPickMedia when Enter selects the media option', async () => {
     const onPickMedia = vi.fn();
     const { result } = renderHook(() => useFilePicker(at(''), noop, onPickMedia, noop), { wrapper: createWrapper() });

--- a/apps/vscode/test/workspace-paths.test.ts
+++ b/apps/vscode/test/workspace-paths.test.ts
@@ -6,7 +6,7 @@
  * VS Code host APIs are the only stubbed boundary.
  * Run: pnpm --filter kimi-code exec vitest run --config vitest.config.ts test/workspace-paths.test.ts
  */
-import { mkdtemp, mkdir, readFile, readdir, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -153,12 +153,6 @@ let extraRoots: string[];
 beforeEach(async () => {
   root = await mkdtemp(join(tmpdir(), "kimi-vscode-workspace-paths-"));
   vscodeHost.workspaceFolders.splice(0, vscodeHost.workspaceFolders.length, { uri: vscodeHost.Uri.file(root) });
-  vscodeHost.readDirectory.mockImplementation(async (uri: { fsPath: string }) =>
-    (await readdir(uri.fsPath, { withFileTypes: true })).map((entry) => [
-      entry.name,
-      entry.isDirectory() ? 2 : entry.isSymbolicLink() ? 64 : 1,
-    ]),
-  );
   vscodeHost.stat.mockImplementation((uri: { fsPath: string }) => stat(uri.fsPath));
   vscodeHost.readFile.mockImplementation((uri: { fsPath: string }) => readFile(uri.fsPath));
   vscodeHost.findFiles.mockResolvedValue([]);
@@ -177,58 +171,6 @@ afterEach(async () => {
 });
 
 describe("Webview workspace paths (selected-directory containment)", () => {
-  it("returns no entries when directory traversal is requested", async () => {
-    const workDir = join(root, "project");
-    await mkdir(workDir);
-
-    const files = await getProjectFiles(workDir, { directory: "../" });
-
-    expect(files).toEqual([]);
-    expect(vscodeHost.readDirectory).not.toHaveBeenCalled();
-  });
-
-  it("returns no entries when an absolute directory is requested", async () => {
-    const workDir = join(root, "project");
-    await mkdir(workDir);
-
-    const files = await getProjectFiles(workDir, { directory: join(root, "outside") });
-
-    expect(files).toEqual([]);
-    expect(vscodeHost.readDirectory).not.toHaveBeenCalled();
-  });
-
-  it("returns no entries when a Windows absolute directory is requested", async () => {
-    const workDir = join(root, "project");
-    await mkdir(workDir);
-
-    const files = await getProjectFiles(workDir, { directory: "C:\\outside" });
-
-    expect(files).toEqual([]);
-    expect(vscodeHost.readDirectory).not.toHaveBeenCalled();
-  });
-
-  it("returns no entries when a Windows drive-relative directory is requested", async () => {
-    const workDir = join(root, "project");
-    await mkdir(workDir);
-
-    const files = await getProjectFiles(workDir, { directory: "C:outside" });
-
-    expect(files).toEqual([]);
-    expect(vscodeHost.readDirectory).not.toHaveBeenCalled();
-  });
-
-  it("omits a symlink when its target is outside the selected working directory", async () => {
-    const workDir = join(root, "project");
-    const outside = join(root, "outside");
-    await Promise.all([mkdir(workDir), mkdir(outside)]);
-    await writeFile(join(outside, "secret.txt"), "secret");
-    await symlink(outside, join(workDir, "outside-link"));
-
-    const files = await getProjectFiles(workDir, { directory: "." });
-
-    expect(files).toEqual([]);
-  });
-
   it("searches within the selected subdirectory using work-directory-relative results", async () => {
     const workDir = join(root, "project", "subproject");
     const inside = join(workDir, "src", "inside.ts");
@@ -244,26 +186,40 @@ describe("Webview workspace paths (selected-directory containment)", () => {
     expect(files).toEqual([{ path: "src/inside.ts", name: "inside.ts", isDirectory: false }]);
   });
 
-  it("normalizes native Windows separators during directory navigation", async () => {
+  it("maps engine suggestions without touching the local file search", async () => {
     const workDir = join(root, "project");
-    await mkdir(join(workDir, "src", "nested"), { recursive: true });
-    await writeFile(join(workDir, "src", "nested", "app.ts"), "app");
+    await mkdir(workDir);
+    const ctx = createContext(vscodeHost.Uri.file(workDir));
+    const suggestFiles = vi.mocked(ctx.harness.suggestFiles);
+    suggestFiles.mockResolvedValue({
+      items: [
+        { path: "src/app.ts", name: "app.ts", kind: "file", matchPositions: [4, 5, 6] },
+        { path: "src", name: "src", kind: "directory", matchPositions: [] },
+      ],
+      truncated: false,
+    });
 
-    const files = await getProjectFiles(workDir, { directory: "src\\nested" });
+    const files = await fileHandlers[Methods.GetProjectFiles]!({ query: "app" }, ctx);
 
-    expect(files).toEqual([{ path: "src/nested/app.ts", name: "app.ts", isDirectory: false }]);
+    expect(suggestFiles).toHaveBeenCalledWith(workDir, { query: "app", limit: 20 });
+    expect(vscodeHost.findFiles).not.toHaveBeenCalled();
+    expect(files).toEqual([
+      { path: "src/app.ts", name: "app.ts", isDirectory: false, matchPositions: [4, 5, 6] },
+      { path: "src", name: "src", isDirectory: true, matchPositions: [] },
+    ]);
   });
 
-  it("preserves the remote workspace URI while listing a directory", async () => {
-    const remoteRoot = vscodeHost.Uri.remote("ssh-remote+example", "/workspace/project");
-    vscodeHost.readDirectory.mockResolvedValue([["remote.ts", 1]]);
-    const ctx = createContext(remoteRoot);
+  it("degrades to an empty list when engine suggestions fail", async () => {
+    const workDir = join(root, "project");
+    await mkdir(workDir);
+    const ctx = createContext(vscodeHost.Uri.file(workDir));
+    vi.mocked(ctx.harness.suggestFiles).mockRejectedValue(new Error("engine down"));
 
-    const files = await fileHandlers[Methods.GetProjectFiles]!({ directory: "." }, ctx);
+    const files = await fileHandlers[Methods.GetProjectFiles]!({ query: "app" }, ctx);
 
-    const requestedUri = vscodeHost.readDirectory.mock.calls[0]?.[0];
-    expect(requestedUri).toMatchObject({ scheme: "vscode-remote", authority: "ssh-remote+example" });
-    expect(files).toEqual([{ path: "remote.ts", name: "remote.ts", isDirectory: false }]);
+    expect(files).toEqual([]);
+    expect(ctx.logError).toHaveBeenCalled();
+    expect(vscodeHost.findFiles).not.toHaveBeenCalled();
   });
 
   it("refuses to open a symlink whose target lies outside the selected working directory", async () => {
@@ -461,7 +417,7 @@ describe("native workspace path comparison (Windows drive and UNC semantics)", (
   });
 });
 
-async function getProjectFiles(workDir: string, params: { query?: string; directory?: string }) {
+async function getProjectFiles(workDir: string, params: { query?: string }) {
   return fileHandlers[Methods.GetProjectFiles]!(params, createContext(vscodeHost.Uri.file(workDir)));
 }
 
@@ -476,7 +432,9 @@ function createContext(workDirUri: InstanceType<typeof vscodeHost.Uri>): Handler
     requireWorkDir: () => workDirUri.fsPath,
     requireWorkDirUri: () => workDirUri as vscode.Uri,
     fileManager,
-  } as HandlerContext;
+    harness: { suggestFiles: vi.fn(async () => undefined) },
+    logError: vi.fn(),
+  } as unknown as HandlerContext;
 }
 
 function createBridge(): BridgeHandler {

--- a/apps/vscode/webview-ui/src/components/FilePickerMenu.tsx
+++ b/apps/vscode/webview-ui/src/components/FilePickerMenu.tsx
@@ -14,6 +14,7 @@ interface FilePickerMenuProps {
   items: FileItem[];
   selectedIndex: number;
   isLoading?: boolean;
+  isStale?: boolean;
   showMediaOption?: boolean;
   onSelectMedia?: () => void;
   onSelectItem: (item: FileItem) => void;
@@ -39,6 +40,7 @@ export function FilePickerMenu({
   items,
   selectedIndex,
   isLoading,
+  isStale = false,
   showMediaOption = true,
   onSelectMedia,
   onSelectItem,
@@ -77,7 +79,7 @@ export function FilePickerMenu({
           <span className="text-xs">Select images or videos…</span>
         </button>
       )}
-      <div className="max-h-64 overflow-y-auto">
+      <div className={cn("max-h-64 overflow-y-auto", isStale && "opacity-60")}>
         {isLoading ? (
           <div className="px-2 py-4 text-center text-xs text-muted-foreground">Loading…</div>
         ) : items.length === 0 ? (

--- a/apps/vscode/webview-ui/src/components/FilePickerMenu.tsx
+++ b/apps/vscode/webview-ui/src/components/FilePickerMenu.tsx
@@ -59,6 +59,7 @@ export function FilePickerMenu({
   }, [selectedIndex]);
 
   const handleHover = (index: number) => {
+    if (isStale) return;
     hoverSelectionRef.current = index;
     onHover(index);
   };

--- a/apps/vscode/webview-ui/src/components/FilePickerMenu.tsx
+++ b/apps/vscode/webview-ui/src/components/FilePickerMenu.tsx
@@ -1,54 +1,47 @@
-import { useEffect, useRef } from "react";
-import { IconFolder, IconFile, IconArrowLeft, IconFolderOpen, IconPhoto } from "@tabler/icons-react";
+import { Fragment, useEffect, useRef } from "react";
+import { IconFolder, IconFile, IconPhoto } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
-
-export type FilePickerMode = "search" | "folder";
+import { mentionMatchSpans, type MentionMatchSpan } from "@/lib/mention-match";
 
 export interface FileItem {
   name: string;
   path: string;
   isDirectory: boolean;
-  highlightedName?: React.ReactNode;
+  matchPositions?: number[];
 }
 
 interface FilePickerMenuProps {
-  mode: FilePickerMode;
   items: FileItem[];
-  currentPath: string;
   selectedIndex: number;
   isLoading?: boolean;
   showMediaOption?: boolean;
   onSelectMedia?: () => void;
-  onSwitchToFolder: () => void;
-  onSwitchToSearch: () => void;
   onSelectItem: (item: FileItem) => void;
-  onNavigateUp: () => void;
-  onNavigateInto: (item: FileItem) => void;
   onHover: (index: number) => void;
 }
 
-function truncateMiddle(str: string, maxLen: number): string {
-  if (str.length <= maxLen) return str;
-  const ellipsis = "…";
-  const charsToShow = maxLen - ellipsis.length;
-  const frontChars = Math.ceil(charsToShow / 2);
-  const backChars = Math.floor(charsToShow / 2);
-  return str.slice(0, frontChars) + ellipsis + str.slice(-backChars);
+function parentDir(path: string): string {
+  const trimmed = path.endsWith("/") ? path.slice(0, -1) : path;
+  const idx = trimmed.lastIndexOf("/");
+  return idx === -1 ? "" : trimmed.slice(0, idx);
+}
+
+function nameSpans(item: FileItem): MentionMatchSpan[] {
+  const path = item.path.endsWith("/") ? item.path.slice(0, -1) : item.path;
+  return mentionMatchSpans(item.name, item.matchPositions, Math.max(0, path.length - item.name.length));
+}
+
+function dirSpans(item: FileItem): MentionMatchSpan[] {
+  return mentionMatchSpans(parentDir(item.path), item.matchPositions, 0);
 }
 
 export function FilePickerMenu({
-  mode,
   items,
-  currentPath,
   selectedIndex,
   isLoading,
   showMediaOption = true,
   onSelectMedia,
-  onSwitchToFolder,
-  onSwitchToSearch,
   onSelectItem,
-  onNavigateUp,
-  onNavigateInto,
   onHover,
 }: FilePickerMenuProps) {
   const selectedRef = useRef<HTMLButtonElement>(null);
@@ -57,112 +50,64 @@ export function FilePickerMenu({
     selectedRef.current?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex]);
 
-  const preventFocus = (e: React.MouseEvent) => e.preventDefault();
-
-  // Calculate header count based on mode and options
-  const getHeaderCount = () => {
-    if (mode === "search") {
-      // Select media (if shown) + Browse folders
-      return showMediaOption ? 2 : 1;
-    } else {
-      // Back to search + optional parent nav
-      return currentPath ? 2 : 1;
-    }
-  };
-
-  const headerCount = getHeaderCount();
+  const headerCount = showMediaOption ? 1 : 0;
 
   return (
     <div className="rounded-md border bg-popover shadow-md overflow-hidden">
-      {mode === "search" ? (
-        <>
-          {showMediaOption && onSelectMedia && (
-            <button
-              ref={selectedIndex === 0 ? selectedRef : null}
-              onMouseDown={preventFocus}
-              onClick={onSelectMedia}
-              onMouseEnter={() => onHover(0)}
-              className={cn("w-full px-2 py-1.5 text-left flex items-center gap-2 border-b border-border", selectedIndex === 0 ? "bg-accent" : "hover:bg-accent/50")}
-            >
-              <IconPhoto className="size-3.5 text-muted-foreground" />
-              <span className="text-xs">Select images or videos…</span>
-            </button>
-          )}
-          <button
-            ref={selectedIndex === (showMediaOption ? 1 : 0) ? selectedRef : null}
-            onMouseDown={preventFocus}
-            onClick={onSwitchToFolder}
-            onMouseEnter={() => onHover(showMediaOption ? 1 : 0)}
-            className={cn(
-              "w-full px-2 py-1.5 text-left flex items-center gap-2 border-b border-border",
-              selectedIndex === (showMediaOption ? 1 : 0) ? "bg-accent" : "hover:bg-accent/50",
-            )}
-          >
-            <IconFolderOpen className="size-3.5 text-muted-foreground" />
-            <span className="text-xs">Browse folders…</span>
-          </button>
-        </>
-      ) : (
-        <>
-          <button
-            ref={selectedIndex === 0 ? selectedRef : null}
-            onMouseDown={preventFocus}
-            onClick={onSwitchToSearch}
-            onMouseEnter={() => onHover(0)}
-            className={cn("w-full px-2 py-1.5 text-left flex items-center gap-2 border-b border-border", selectedIndex === 0 ? "bg-accent" : "hover:bg-accent/50")}
-          >
-            <IconArrowLeft className="size-3.5 text-muted-foreground" />
-            <span className="text-xs">Back to search</span>
-          </button>
-          {currentPath && (
-            <button
-              ref={selectedIndex === 1 ? selectedRef : null}
-              onMouseDown={preventFocus}
-              onClick={onNavigateUp}
-              onMouseEnter={() => onHover(1)}
-              className={cn("w-full px-2 py-1.5 text-left flex items-center gap-2 border-b border-border/50", selectedIndex === 1 ? "bg-accent" : "hover:bg-accent/50")}
-            >
-              <IconFolder className="size-3.5 text-muted-foreground" />
-              <span className="text-xs font-medium">..</span>
-              <span className="text-[10px] text-muted-foreground truncate">({currentPath.split("/").pop()})</span>
-            </button>
-          )}
-        </>
+      {showMediaOption && onSelectMedia && (
+        <button
+          ref={selectedIndex === 0 ? selectedRef : null}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={onSelectMedia}
+          onMouseMove={() => onHover(0)}
+          className={cn("w-full px-2 py-1.5 text-left flex items-center gap-2 border-b border-border", selectedIndex === 0 ? "bg-accent" : "hover:bg-accent/50")}
+        >
+          <IconPhoto className="size-3.5 text-muted-foreground" />
+          <span className="text-xs">Select images or videos…</span>
+        </button>
       )}
       <div className="max-h-64 overflow-y-auto">
         {isLoading ? (
           <div className="px-2 py-4 text-center text-xs text-muted-foreground">Loading…</div>
         ) : items.length === 0 ? (
-          <div className="px-2 py-4 text-center text-xs text-muted-foreground">{mode === "search" ? "No files found" : "Empty folder"}</div>
+          <div className="px-2 py-4 text-center text-xs text-muted-foreground">No files found</div>
         ) : (
           items.map((item, idx) => {
             const itemIndex = idx + headerCount;
+            const dir = parentDir(item.path);
             return (
               <button
                 key={item.path}
                 ref={itemIndex === selectedIndex ? selectedRef : null}
-                onMouseDown={preventFocus}
-                onClick={() => {
-                  if (item.isDirectory && mode === "search") {
-                    onNavigateInto(item);
-                  } else {
-                    onSelectItem(item);
-                  }
-                }}
-                onMouseEnter={() => onHover(itemIndex)}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => onSelectItem(item)}
+                onMouseMove={() => onHover(itemIndex)}
                 className={cn("w-full px-2 py-1.5 text-left flex items-center justify-between gap-3", itemIndex === selectedIndex ? "bg-accent" : "hover:bg-accent/50")}
               >
                 <span className="flex items-center gap-1.5 text-xs shrink-0">
                   {item.isDirectory ? <IconFolder className="size-3 text-muted-foreground" /> : <IconFile className="size-3 text-muted-foreground" />}
                   <span className={cn(item.isDirectory && "font-medium")}>
-                    {mode === "folder" ? item.name : item.highlightedName || item.name}
+                    {nameSpans(item).map((span, spanIdx) =>
+                      span.hit ? (
+                        <span key={spanIdx} className="text-foreground font-semibold">{span.text}</span>
+                      ) : (
+                        <Fragment key={spanIdx}>{span.text}</Fragment>
+                      ),
+                    )}
                     {item.isDirectory && "/"}
                   </span>
                 </span>
-                <span className="flex items-center gap-1.5">
-                  <span className="text-[10px] text-muted-foreground truncate max-w-32">{truncateMiddle(item.path, 25)}</span>
-                  {item.isDirectory && mode === "folder" && <span className="text-[10px] text-muted-foreground">→</span>}
-                </span>
+                {dir && (
+                  <span className="text-[10px] text-muted-foreground truncate max-w-32">
+                    {dirSpans(item).map((span, spanIdx) =>
+                      span.hit ? (
+                        <span key={spanIdx} className="text-foreground">{span.text}</span>
+                      ) : (
+                        <Fragment key={spanIdx}>{span.text}</Fragment>
+                      ),
+                    )}
+                  </span>
+                )}
               </button>
             );
           })

--- a/apps/vscode/webview-ui/src/components/FilePickerMenu.tsx
+++ b/apps/vscode/webview-ui/src/components/FilePickerMenu.tsx
@@ -45,10 +45,21 @@ export function FilePickerMenu({
   onHover,
 }: FilePickerMenuProps) {
   const selectedRef = useRef<HTMLButtonElement>(null);
+  const hoverSelectionRef = useRef<number | null>(null);
 
   useEffect(() => {
+    if (hoverSelectionRef.current === selectedIndex) {
+      hoverSelectionRef.current = null;
+      return;
+    }
+    hoverSelectionRef.current = null;
     selectedRef.current?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex]);
+
+  const handleHover = (index: number) => {
+    hoverSelectionRef.current = index;
+    onHover(index);
+  };
 
   const headerCount = showMediaOption ? 1 : 0;
 
@@ -59,7 +70,7 @@ export function FilePickerMenu({
           ref={selectedIndex === 0 ? selectedRef : null}
           onMouseDown={(e) => e.preventDefault()}
           onClick={onSelectMedia}
-          onMouseMove={() => onHover(0)}
+          onMouseMove={() => handleHover(0)}
           className={cn("w-full px-2 py-1.5 text-left flex items-center gap-2 border-b border-border", selectedIndex === 0 ? "bg-accent" : "hover:bg-accent/50")}
         >
           <IconPhoto className="size-3.5 text-muted-foreground" />
@@ -81,7 +92,7 @@ export function FilePickerMenu({
                 ref={itemIndex === selectedIndex ? selectedRef : null}
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={() => onSelectItem(item)}
-                onMouseMove={() => onHover(itemIndex)}
+                onMouseMove={() => handleHover(itemIndex)}
                 className={cn("w-full px-2 py-1.5 text-left flex items-center justify-between gap-3", itemIndex === selectedIndex ? "bg-accent" : "hover:bg-accent/50")}
               >
                 <span className="flex items-center gap-1.5 text-xs shrink-0">

--- a/apps/vscode/webview-ui/src/components/SlashCommandMenu.tsx
+++ b/apps/vscode/webview-ui/src/components/SlashCommandMenu.tsx
@@ -44,10 +44,21 @@ function highlightMatch(text: string, query: string): React.ReactNode {
 
 export function SlashCommandMenu({ commands, query, selectedIndex, onSelect, onHover }: SlashCommandMenuProps) {
   const selectedRef = useRef<HTMLButtonElement>(null);
+  const hoverSelectionRef = useRef<number | null>(null);
 
   useEffect(() => {
+    if (hoverSelectionRef.current === selectedIndex) {
+      hoverSelectionRef.current = null;
+      return;
+    }
+    hoverSelectionRef.current = null;
     selectedRef.current?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex]);
+
+  const handleHover = (index: number) => {
+    hoverSelectionRef.current = index;
+    onHover(index);
+  };
 
   if (commands.length === 0) {
     return <div className="rounded-md border bg-popover shadow-md p-3 text-xs text-muted-foreground text-center">No commands found</div>;
@@ -61,7 +72,7 @@ export function SlashCommandMenu({ commands, query, selectedIndex, onSelect, onH
             key={cmd.name}
             ref={idx === selectedIndex ? selectedRef : null}
             onClick={() => onSelect(cmd.name)}
-            onMouseMove={() => onHover(idx)}
+            onMouseMove={() => handleHover(idx)}
             className={cn("w-full px-2 py-1.5 text-left flex items-center justify-between gap-3", idx === selectedIndex ? "bg-accent" : "hover:bg-accent/50")}
           >
             <span className="text-xs shrink-0">{highlightMatch(`/${cmd.name}`, query)}</span>

--- a/apps/vscode/webview-ui/src/components/SlashCommandMenu.tsx
+++ b/apps/vscode/webview-ui/src/components/SlashCommandMenu.tsx
@@ -61,7 +61,7 @@ export function SlashCommandMenu({ commands, query, selectedIndex, onSelect, onH
             key={cmd.name}
             ref={idx === selectedIndex ? selectedRef : null}
             onClick={() => onSelect(cmd.name)}
-            onMouseEnter={() => onHover(idx)}
+            onMouseMove={() => onHover(idx)}
             className={cn("w-full px-2 py-1.5 text-left flex items-center justify-between gap-3", idx === selectedIndex ? "bg-accent" : "hover:bg-accent/50")}
           >
             <span className="text-xs shrink-0">{highlightMatch(`/${cmd.name}`, query)}</span>

--- a/apps/vscode/webview-ui/src/components/inputarea/InputArea.tsx
+++ b/apps/vscode/webview-ui/src/components/inputarea/InputArea.tsx
@@ -213,15 +213,11 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
 
   const {
     showFileMenu,
-    filePickerMode,
-    folderPath,
     fileItems,
     selectedIndex: fileSelectedIndex,
     isLoading: isFileLoading,
     showMediaOption,
     setSelectedIndex: setFileSelectedIndex,
-    setFilePickerMode,
-    setFolderPath,
     handleFileMenuKey,
     resetFilePicker,
   } = useFilePicker(
@@ -338,35 +334,14 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
         {showFileMenu && (
           <div ref={menuRef} className="absolute bottom-full left-0 right-0 mb-2 z-10">
             <FilePickerMenu
-              mode={filePickerMode}
               items={fileItems}
-              currentPath={folderPath}
               selectedIndex={fileSelectedIndex}
               isLoading={isFileLoading}
               showMediaOption={showMediaOption}
               onSelectMedia={() => {
                 void handlePickMedia();
               }}
-              onSwitchToFolder={() => {
-                setFilePickerMode("folder");
-                setFolderPath("");
-                setFileSelectedIndex(0);
-              }}
-              onSwitchToSearch={() => {
-                setFilePickerMode("search");
-                setFolderPath("");
-                setFileSelectedIndex(0);
-              }}
               onSelectItem={(item) => { applyMention(item.path); }}
-              onNavigateUp={() => {
-                setFolderPath(folderPath.split("/").slice(0, -1).join("/"));
-                setFileSelectedIndex(0);
-              }}
-              onNavigateInto={(item) => {
-                setFilePickerMode("folder");
-                setFolderPath(item.path);
-                setFileSelectedIndex(0);
-              }}
               onHover={setFileSelectedIndex}
             />
           </div>

--- a/apps/vscode/webview-ui/src/components/inputarea/InputArea.tsx
+++ b/apps/vscode/webview-ui/src/components/inputarea/InputArea.tsx
@@ -219,6 +219,7 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
     isStale: isFileStale,
     showMediaOption,
     setSelectedIndex: setFileSelectedIndex,
+    handleSelectItem: handleSelectFileItem,
     handleFileMenuKey,
     resetFilePicker,
   } = useFilePicker(
@@ -343,7 +344,7 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
               onSelectMedia={() => {
                 void handlePickMedia();
               }}
-              onSelectItem={(item) => { applyMention(item.path); }}
+              onSelectItem={handleSelectFileItem}
               onHover={setFileSelectedIndex}
             />
           </div>

--- a/apps/vscode/webview-ui/src/components/inputarea/InputArea.tsx
+++ b/apps/vscode/webview-ui/src/components/inputarea/InputArea.tsx
@@ -216,6 +216,7 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
     fileItems,
     selectedIndex: fileSelectedIndex,
     isLoading: isFileLoading,
+    isStale: isFileStale,
     showMediaOption,
     setSelectedIndex: setFileSelectedIndex,
     handleFileMenuKey,
@@ -337,6 +338,7 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
               items={fileItems}
               selectedIndex={fileSelectedIndex}
               isLoading={isFileLoading}
+              isStale={isFileStale}
               showMediaOption={showMediaOption}
               onSelectMedia={() => {
                 void handlePickMedia();

--- a/apps/vscode/webview-ui/src/components/inputarea/hooks/useFilePicker.tsx
+++ b/apps/vscode/webview-ui/src/components/inputarea/hooks/useFilePicker.tsx
@@ -30,6 +30,7 @@ interface UseFilePickerResult {
   showMediaOption: boolean;
   fileMenuHeaderCount: number;
   setSelectedIndex: (index: number) => void;
+  handleSelectItem: (item: FileItem) => void;
   handleFileMenuKey: (e: React.KeyboardEvent) => boolean;
   resetFilePicker: () => void;
 }
@@ -86,6 +87,14 @@ export function useFilePicker(activeToken: ActiveToken | null, onInsertFile: (pa
     onInsertFile(item.path);
   }, [selectedIndex, showMediaOption, isStale, fileMenuHeaderCount, fileItems, onPickMedia, onInsertFile]);
 
+  const handleSelectItem = useCallback(
+    (item: FileItem) => {
+      if (isStale) return;
+      onInsertFile(item.path);
+    },
+    [isStale, onInsertFile],
+  );
+
   const handleFileMenuKey = useCallback(
     (e: React.KeyboardEvent): boolean => {
       if (!showFileMenu) return false;
@@ -126,6 +135,7 @@ export function useFilePicker(activeToken: ActiveToken | null, onInsertFile: (pa
     showMediaOption,
     fileMenuHeaderCount,
     setSelectedIndex,
+    handleSelectItem,
     handleFileMenuKey,
     resetFilePicker,
   };

--- a/apps/vscode/webview-ui/src/components/inputarea/hooks/useFilePicker.tsx
+++ b/apps/vscode/webview-ui/src/components/inputarea/hooks/useFilePicker.tsx
@@ -6,12 +6,11 @@ import { useChatStore } from "@/stores";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { MEDIA_CONFIG } from "@/services/config";
 
-export type FilePickerMode = "search" | "folder";
-
 export interface FileItem {
   name: string;
   path: string;
   isDirectory: boolean;
+  matchPositions?: number[];
 }
 
 interface ActiveToken {
@@ -24,16 +23,12 @@ const NO_FILES: ProjectFile[] = [];
 
 interface UseFilePickerResult {
   showFileMenu: boolean;
-  filePickerMode: FilePickerMode;
-  folderPath: string;
   fileItems: FileItem[];
   selectedIndex: number;
   isLoading: boolean;
   showMediaOption: boolean;
   fileMenuHeaderCount: number;
   setSelectedIndex: (index: number) => void;
-  setFilePickerMode: (mode: FilePickerMode) => void;
-  setFolderPath: (path: string) => void;
   handleFileMenuKey: (e: React.KeyboardEvent) => boolean;
   resetFilePicker: () => void;
 }
@@ -43,8 +38,6 @@ export function useFilePicker(activeToken: ActiveToken | null, onInsertFile: (pa
   const canAddMedia = !isStreaming && draftMedia.length < MEDIA_CONFIG.maxCount;
 
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [filePickerMode, setFilePickerMode] = useState<FilePickerMode>("search");
-  const [folderPath, setFolderPath] = useState("");
 
   const showFileMenu = activeToken?.trigger === "@";
   const query = activeToken?.query || "";
@@ -53,103 +46,48 @@ export function useFilePicker(activeToken: ActiveToken | null, onInsertFile: (pa
   const searchQuery = useQuery({
     queryKey: ["projectFiles", "search", debouncedQuery],
     queryFn: () => bridge.getProjectFiles({ query: debouncedQuery || undefined }),
-    enabled: showFileMenu && filePickerMode === "search",
+    enabled: showFileMenu,
     placeholderData: keepPreviousData,
   });
   const searchResults = searchQuery.data ?? NO_FILES;
-  const isSearchLoading = searchQuery.isLoading;
-
-  const folderQuery = useQuery({
-    queryKey: ["projectFiles", "folder", folderPath || "."],
-    queryFn: () => bridge.getProjectFiles({ directory: folderPath || "." }),
-    enabled: showFileMenu && filePickerMode === "folder",
-  });
-  const folderItems = folderQuery.data ?? NO_FILES;
-  const isFolderLoading = folderQuery.isLoading;
-
-  useEffect(() => {
-    if (!showFileMenu) {
-      setFilePickerMode("search");
-      setFolderPath("");
-    }
-  }, [showFileMenu]);
+  const isLoading = searchQuery.isLoading;
 
   useEffect(() => {
     setSelectedIndex(0);
-  }, [query, filePickerMode, folderPath]);
+  }, [query]);
 
   const fileItems = useMemo((): FileItem[] => {
-    if (filePickerMode === "folder") {
-      return folderItems.map((f) => ({
-        name: f.name,
-        path: f.path,
-        isDirectory: f.isDirectory,
-      }));
-    }
-    return searchResults.slice(0, 50).map((f) => ({
+    return searchResults.map((f) => ({
       name: f.name,
       path: f.path,
       isDirectory: f.isDirectory,
+      matchPositions: f.matchPositions,
     }));
-  }, [filePickerMode, folderItems, searchResults]);
+  }, [searchResults]);
 
-  const isLoading = filePickerMode === "search" ? isSearchLoading : isFolderLoading;
-  const showMediaOption = filePickerMode === "search" && canAddMedia;
-  const fileMenuHeaderCount = filePickerMode === "search" ? (showMediaOption ? 2 : 1) : folderPath ? 2 : 1;
+  const showMediaOption = canAddMedia && query === "";
+  const fileMenuHeaderCount = showMediaOption ? 1 : 0;
 
   const resetFilePicker = useCallback(() => {
     setSelectedIndex(0);
-    setFilePickerMode("search");
-    setFolderPath("");
   }, []);
 
   const handleFileMenuConfirm = useCallback(() => {
-    if (filePickerMode === "search") {
-      if (showMediaOption && selectedIndex === 0) {
-        onPickMedia();
-        return;
-      }
-
-      const browseIndex = showMediaOption ? 1 : 0;
-      if (selectedIndex === browseIndex) {
-        setFilePickerMode("folder");
-        setFolderPath("");
-        setSelectedIndex(0);
-        return;
-      }
-    }
-
-    if (filePickerMode === "folder" && selectedIndex === 0) {
-      setFilePickerMode("search");
-      setFolderPath("");
-      setSelectedIndex(0);
+    if (showMediaOption && selectedIndex === 0) {
+      onPickMedia();
       return;
     }
 
-    if (filePickerMode === "folder" && selectedIndex === 1 && folderPath) {
-      setFolderPath(folderPath.split("/").slice(0, -1).join("/"));
-      setSelectedIndex(0);
-      return;
-    }
-
-    const itemIndex = selectedIndex - fileMenuHeaderCount;
-    const item = fileItems[itemIndex];
+    const item = fileItems[selectedIndex - fileMenuHeaderCount];
     if (!item) return;
-
-    if (filePickerMode === "search" && item.isDirectory) {
-      setFilePickerMode("folder");
-      setFolderPath(item.path);
-      setSelectedIndex(0);
-    } else {
-      onInsertFile(item.path);
-    }
-  }, [filePickerMode, selectedIndex, showMediaOption, folderPath, fileMenuHeaderCount, fileItems, onPickMedia, onInsertFile]);
+    onInsertFile(item.path);
+  }, [selectedIndex, showMediaOption, fileMenuHeaderCount, fileItems, onPickMedia, onInsertFile]);
 
   const handleFileMenuKey = useCallback(
     (e: React.KeyboardEvent): boolean => {
       if (!showFileMenu) return false;
 
-      const maxIdx = fileMenuHeaderCount + fileItems.length - 1;
+      const maxIdx = Math.max(0, fileMenuHeaderCount + fileItems.length - 1);
 
       switch (e.key) {
         case "ArrowDown":
@@ -160,26 +98,6 @@ export function useFilePicker(activeToken: ActiveToken | null, onInsertFile: (pa
           e.preventDefault();
           setSelectedIndex((i) => Math.max(i - 1, 0));
           return true;
-        case "ArrowLeft":
-          if (filePickerMode !== "folder") return false;
-          e.preventDefault();
-          if (folderPath) {
-            setFolderPath(folderPath.split("/").slice(0, -1).join("/"));
-          } else {
-            setFilePickerMode("search");
-          }
-          setSelectedIndex(0);
-          return true;
-        case "ArrowRight": {
-          if (filePickerMode !== "folder") return false;
-          e.preventDefault();
-          const itemForRight = fileItems[selectedIndex - fileMenuHeaderCount];
-          if (itemForRight?.isDirectory) {
-            setFolderPath(itemForRight.path);
-            setSelectedIndex(0);
-          }
-          return true;
-        }
         case "Tab":
         case "Enter":
           e.preventDefault();
@@ -187,33 +105,23 @@ export function useFilePicker(activeToken: ActiveToken | null, onInsertFile: (pa
           return true;
         case "Escape":
           e.preventDefault();
-          if (filePickerMode === "folder") {
-            setFilePickerMode("search");
-            setFolderPath("");
-            setSelectedIndex(0);
-          } else {
-            onCancel();
-          }
+          onCancel();
           return true;
         default:
           return false;
       }
     },
-    [showFileMenu, fileMenuHeaderCount, fileItems, filePickerMode, folderPath, selectedIndex, handleFileMenuConfirm, onCancel],
+    [showFileMenu, fileMenuHeaderCount, fileItems, handleFileMenuConfirm, onCancel],
   );
 
   return {
     showFileMenu,
-    filePickerMode,
-    folderPath,
     fileItems,
     selectedIndex,
     isLoading,
     showMediaOption,
     fileMenuHeaderCount,
     setSelectedIndex,
-    setFilePickerMode,
-    setFolderPath,
     handleFileMenuKey,
     resetFilePicker,
   };

--- a/apps/vscode/webview-ui/src/components/inputarea/hooks/useFilePicker.tsx
+++ b/apps/vscode/webview-ui/src/components/inputarea/hooks/useFilePicker.tsx
@@ -26,6 +26,7 @@ interface UseFilePickerResult {
   fileItems: FileItem[];
   selectedIndex: number;
   isLoading: boolean;
+  isStale: boolean;
   showMediaOption: boolean;
   fileMenuHeaderCount: number;
   setSelectedIndex: (index: number) => void;
@@ -51,6 +52,7 @@ export function useFilePicker(activeToken: ActiveToken | null, onInsertFile: (pa
   });
   const searchResults = searchQuery.data ?? NO_FILES;
   const isLoading = searchQuery.isLoading;
+  const isStale = debouncedQuery !== query || searchQuery.isPlaceholderData;
 
   useEffect(() => {
     setSelectedIndex(0);
@@ -78,10 +80,11 @@ export function useFilePicker(activeToken: ActiveToken | null, onInsertFile: (pa
       return;
     }
 
+    if (isStale) return;
     const item = fileItems[selectedIndex - fileMenuHeaderCount];
     if (!item) return;
     onInsertFile(item.path);
-  }, [selectedIndex, showMediaOption, fileMenuHeaderCount, fileItems, onPickMedia, onInsertFile]);
+  }, [selectedIndex, showMediaOption, isStale, fileMenuHeaderCount, fileItems, onPickMedia, onInsertFile]);
 
   const handleFileMenuKey = useCallback(
     (e: React.KeyboardEvent): boolean => {
@@ -119,6 +122,7 @@ export function useFilePicker(activeToken: ActiveToken | null, onInsertFile: (pa
     fileItems,
     selectedIndex,
     isLoading,
+    isStale,
     showMediaOption,
     fileMenuHeaderCount,
     setSelectedIndex,

--- a/apps/vscode/webview-ui/src/components/inputarea/hooks/useFilePicker.tsx
+++ b/apps/vscode/webview-ui/src/components/inputarea/hooks/useFilePicker.tsx
@@ -57,7 +57,7 @@ export function useFilePicker(activeToken: ActiveToken | null, onInsertFile: (pa
   }, [query]);
 
   const fileItems = useMemo((): FileItem[] => {
-    return searchResults.map((f) => ({
+    return searchResults.slice(0, 50).map((f) => ({
       name: f.name,
       path: f.path,
       isDirectory: f.isDirectory,

--- a/apps/vscode/webview-ui/src/components/inputarea/hooks/useFilePicker.tsx
+++ b/apps/vscode/webview-ui/src/components/inputarea/hooks/useFilePicker.tsx
@@ -71,6 +71,10 @@ export function useFilePicker(activeToken: ActiveToken | null, onInsertFile: (pa
   const showMediaOption = canAddMedia && query === "";
   const fileMenuHeaderCount = showMediaOption ? 1 : 0;
 
+  useEffect(() => {
+    setSelectedIndex((i) => Math.min(i, Math.max(0, fileMenuHeaderCount + fileItems.length - 1)));
+  }, [fileMenuHeaderCount, fileItems.length]);
+
   const resetFilePicker = useCallback(() => {
     setSelectedIndex(0);
   }, []);
@@ -112,6 +116,7 @@ export function useFilePicker(activeToken: ActiveToken | null, onInsertFile: (pa
           return true;
         case "Tab":
         case "Enter":
+          if (fileMenuHeaderCount + fileItems.length === 0) return false;
           e.preventDefault();
           handleFileMenuConfirm();
           return true;

--- a/apps/vscode/webview-ui/src/components/inputarea/utils.ts
+++ b/apps/vscode/webview-ui/src/components/inputarea/utils.ts
@@ -13,16 +13,19 @@ interface InsertMentionResult {
 
 export function computeMentionInsert(params: InsertMentionParams): InsertMentionResult {
   const { text, cursorPos, filePath, activeToken, isAppend } = params;
+  // Quote paths containing spaces, as the CLI/TUI mention completers do, so
+  // whitespace cannot split the mention.
+  const target = filePath.includes(" ") ? `"${filePath}"` : filePath;
 
   if (isAppend || !activeToken) {
-    const newText = text + `@${filePath} `;
+    const newText = text + `@${target} `;
     return { newText, newCursorPos: newText.length };
   }
 
   const before = text.slice(0, activeToken.start);
   const after = text.slice(cursorPos);
-  const newText = `${before}@${filePath} ${after}`;
-  const newCursorPos = activeToken.start + 1 + filePath.length + 1;
+  const newText = `${before}@${target} ${after}`;
+  const newCursorPos = activeToken.start + 1 + target.length + 1;
 
   return { newText, newCursorPos };
 }

--- a/apps/vscode/webview-ui/src/lib/mention-match.ts
+++ b/apps/vscode/webview-ui/src/lib/mention-match.ts
@@ -21,6 +21,16 @@ export function mentionMatchSpans(
     if (i >= 0 && i < text.length) hits.add(i);
   }
   if (hits.size === 0) return [{ text, hit: false }];
+  for (const i of [...hits]) {
+    const code = text.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff && i + 1 < text.length) {
+      const next = text.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) hits.add(i + 1);
+    } else if (code >= 0xdc00 && code <= 0xdfff && i > 0) {
+      const prev = text.charCodeAt(i - 1);
+      if (prev >= 0xd800 && prev <= 0xdbff) hits.add(i - 1);
+    }
+  }
   const spans: MentionMatchSpan[] = [];
   let runStart = 0;
   let runHit = hits.has(0);

--- a/apps/vscode/webview-ui/src/lib/mention-match.ts
+++ b/apps/vscode/webview-ui/src/lib/mention-match.ts
@@ -1,0 +1,37 @@
+export interface MentionMatchSpan {
+  text: string;
+  hit: boolean;
+}
+
+/**
+ * Split `text` into hit/plain runs from match positions. `positions` index
+ * into the full path; `start` shifts them into this text's frame.
+ */
+export function mentionMatchSpans(
+  text: string,
+  positions: readonly number[] | undefined,
+  start: number,
+): MentionMatchSpan[] {
+  if (positions === undefined || positions.length === 0 || text.length === 0) {
+    return [{ text, hit: false }];
+  }
+  const hits = new Set<number>();
+  for (const pos of positions) {
+    const i = pos - start;
+    if (i >= 0 && i < text.length) hits.add(i);
+  }
+  if (hits.size === 0) return [{ text, hit: false }];
+  const spans: MentionMatchSpan[] = [];
+  let runStart = 0;
+  let runHit = hits.has(0);
+  for (let i = 1; i < text.length; i++) {
+    const hit = hits.has(i);
+    if (hit !== runHit) {
+      spans.push({ text: text.slice(runStart, i), hit: runHit });
+      runStart = i;
+      runHit = hit;
+    }
+  }
+  spans.push({ text: text.slice(runStart), hit: runHit });
+  return spans;
+}

--- a/apps/vscode/webview-ui/src/lib/mention-match.ts
+++ b/apps/vscode/webview-ui/src/lib/mention-match.ts
@@ -1,3 +1,6 @@
+const SURROGATE_PAIR_AT_START = /^[\uD800-\uDBFF][\uDC00-\uDFFF]/;
+const SURROGATE_PAIR_EXACT = /^[\uD800-\uDBFF][\uDC00-\uDFFF]$/;
+
 export interface MentionMatchSpan {
   text: string;
   hit: boolean;
@@ -21,14 +24,11 @@ export function mentionMatchSpans(
     if (i >= 0 && i < text.length) hits.add(i);
   }
   if (hits.size === 0) return [{ text, hit: false }];
-  for (const i of [...hits]) {
-    const code = text.charCodeAt(i);
-    if (code >= 0xd800 && code <= 0xdbff && i + 1 < text.length) {
-      const next = text.charCodeAt(i + 1);
-      if (next >= 0xdc00 && next <= 0xdfff) hits.add(i + 1);
-    } else if (code >= 0xdc00 && code <= 0xdfff && i > 0) {
-      const prev = text.charCodeAt(i - 1);
-      if (prev >= 0xd800 && prev <= 0xdbff) hits.add(i - 1);
+  for (const i of Array.from(hits)) {
+    if (SURROGATE_PAIR_AT_START.test(text.slice(i, i + 2))) {
+      hits.add(i + 1);
+    } else if (SURROGATE_PAIR_EXACT.test(text.slice(i - 1, i + 1))) {
+      hits.add(i - 1);
     }
   }
   const spans: MentionMatchSpan[] = [];

--- a/packages/node-sdk/src/kimi-harness.ts
+++ b/packages/node-sdk/src/kimi-harness.ts
@@ -42,6 +42,8 @@ import type {
   SessionSummary,
   SessionSummaryPage,
   SkillSummary,
+  SuggestFilesInput,
+  SuggestFilesResult,
   TelemetryClient,
   TelemetryContextPatch,
   TelemetryProperties,
@@ -335,6 +337,15 @@ export class KimiHarness {
   /** Skills visible to a new session in `workDir`, without creating that session. */
   async listWorkspaceSkills(workDir: string): Promise<readonly SkillSummary[]> {
     return this.rpc.listWorkspaceSkills(workDir);
+  }
+
+  /**
+   * File suggestions for @ mention-style completion under `workDir`, no
+   * session required. `undefined` on the v1 engine, which has no equivalent
+   * capability; callers fall back to their own file search there.
+   */
+  async suggestFiles(workDir: string, input: SuggestFilesInput): Promise<SuggestFilesResult | undefined> {
+    return this.rpc.suggestFiles(workDir, input);
   }
 
   /**

--- a/packages/node-sdk/src/rpc.ts
+++ b/packages/node-sdk/src/rpc.ts
@@ -70,6 +70,8 @@ import type {
   SessionSummaryPage,
   SkillSummary,
   PluginCommandDef,
+  SuggestFilesInput,
+  SuggestFilesResult,
   Unsubscribe,
   UploadFileOptions,
   WorkspaceTrustInfo,
@@ -854,6 +856,17 @@ export abstract class SDKRpcClientBase {
    */
   async listPluginCommandsGlobal(): Promise<readonly PluginCommandDef[]> {
     return [];
+  }
+
+  /**
+   * Workspace-root file suggestions, no session required. The v1 engine has
+   * no equivalent capability, so the base reports `undefined`; the v2 client
+   * overrides with the workspace handler's fs service.
+   */
+  async suggestFiles(workDir: string, input: SuggestFilesInput): Promise<SuggestFilesResult | undefined> {
+    void workDir;
+    void input;
+    return undefined;
   }
 
   async listBackgroundTasks(

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -153,6 +153,7 @@ import {
 import { encodeWorkDirKey } from '@moonshot-ai/agent-core-v2/_base/utils/workdir-slug';
 import { McpConnectionManager } from '@moonshot-ai/agent-core-v2/mcpCore/connection-manager';
 import { loadMcpServers } from '@moonshot-ai/agent-core-v2/app/mcpConfig/configLoader';
+import { fsSuggestRequestSchema } from '@moonshot-ai/agent-core-v2/workspace/workspaceFs/fs';
 import { IAppendLogStore } from '@moonshot-ai/agent-core-v2/persistence/interface/appendLogStore';
 import type { McpServerConfig as WorkspaceMcpServerConfig } from '@moonshot-ai/agent-core-v2/mcpCore/config-schema';
 import {
@@ -633,15 +634,24 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
    * the web client's @ mention results.
    */
   override async suggestFiles(workDir: string, input: SuggestFilesInput): Promise<SuggestFilesResult | undefined> {
-    const handler = await this.engineAccessor
-      .get(IWorkspaceInstanceManager)
-      .getOrCreate({ root: normalizeRequiredWorkDir('suggestFiles', workDir) });
-    const result = await handler.program.fs.suggest({
+    const parsed = fsSuggestRequestSchema.safeParse({
       query: input.query,
       limit: input.limit ?? 50,
       follow_gitignore: true,
       show_hidden: false,
     });
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      const where = issue !== undefined && issue.path.length > 0 ? `${String(issue.path[0])}: ` : '';
+      throw new KimiError(
+        ErrorCodes.REQUEST_INVALID,
+        `suggestFiles ${where}${issue?.message ?? 'invalid input'}`,
+      );
+    }
+    const handler = await this.engineAccessor
+      .get(IWorkspaceInstanceManager)
+      .getOrCreate({ root: normalizeRequiredWorkDir('suggestFiles', workDir) });
+    const result = await handler.program.fs.suggest(parsed.data);
     return {
       items: result.items.map((item) => ({
         path: item.path,

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -16,6 +16,9 @@
  * - `listWorkspaceSkills` → not covered by the klient facade, so it goes
  *   through the `engineAccessor` escape hatch (the workspace handler's
  *   `IWorkspaceSkillCatalog`) instead.
+ * - `suggestFiles` → same escape hatch (the workspace handler's
+ *   `IWorkspaceFsService`); the v1 client inherits the base's `undefined`
+ *   (capability absent).
  * - `getConfig` / `setConfig` / `removeProvider` / `getConfigDiagnostics` →
  *   `klient.global.config.*`, with the v1 `KimiConfig` shape restored by the
  *   pure mapping layer in `src/v2/config-mapper.ts`.
@@ -316,6 +319,8 @@ import type {
   SessionTodoItem,
   SessionUsage,
   SkillSummary,
+  SuggestFilesInput,
+  SuggestFilesResult,
   TelemetryClient,
   UploadFileOptions,
   WorkspaceTrustInfo,
@@ -619,6 +624,33 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
     const catalog = handler.program.skills;
     await catalog.ready;
     return catalog.catalog.listSkills().map(summarizeSkill);
+  }
+
+  /**
+   * Through the workspace handler's `IWorkspaceFsService` — the same engine
+   * suggest the kap-server `fs:suggest` routes serve (fuzzy scoring,
+   * directories included, gitignore respected), so in-process hosts match
+   * the web client's @ mention results.
+   */
+  override async suggestFiles(workDir: string, input: SuggestFilesInput): Promise<SuggestFilesResult | undefined> {
+    const handler = await this.engineAccessor
+      .get(IWorkspaceInstanceManager)
+      .getOrCreate({ root: normalizeRequiredWorkDir('suggestFiles', workDir) });
+    const result = await handler.program.fs.suggest({
+      query: input.query,
+      limit: input.limit ?? 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    return {
+      items: result.items.map((item) => ({
+        path: item.path,
+        name: item.name,
+        kind: item.kind,
+        matchPositions: item.match_positions,
+      })),
+      truncated: result.truncated,
+    };
   }
 
   /**

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -113,6 +113,29 @@ export interface WorkspaceTrustInfo {
   readonly gatedMcpServers: readonly WorkspaceTrustMcpServerInfo[];
 }
 
+/**
+ * File-suggestion query against a workspace root, no session required. Only
+ * meaningful on the agent-core-v2 engine; the v1 engine has no equivalent
+ * and reports `undefined`.
+ */
+export interface SuggestFilesInput {
+  readonly query: string;
+  readonly limit?: number;
+}
+
+export interface SuggestFilesItem {
+  readonly path: string;
+  readonly name: string;
+  readonly kind: 'file' | 'directory' | 'symlink';
+  /** Matched-character offsets into `path`, for mention-style highlighting. */
+  readonly matchPositions: readonly number[];
+}
+
+export interface SuggestFilesResult {
+  readonly items: readonly SuggestFilesItem[];
+  readonly truncated: boolean;
+}
+
 /** Metadata of one upload in the engine's daemon file store. */
 export type { FileMeta } from '@moonshot-ai/agent-core-v2/app/file/fileService';
 

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -824,6 +824,21 @@ key = "${titleOAuthRef.key}"
     }
   });
 
+  it('rejects an out-of-range suggestFiles limit before touching the engine', async () => {
+    const { harness } = await makeHarness();
+    const workDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-work-'));
+    tempDirs.push(workDir);
+    try {
+      for (const limit of [0, -1, 201, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+        await expect(harness.suggestFiles(workDir, { query: 'a', limit })).rejects.toMatchObject({
+          code: ErrorCodes.REQUEST_INVALID,
+        });
+      }
+    } finally {
+      await harness.close();
+    }
+  });
+
   it('honors skillDirs (explicit dirs) over default user / project discovery', async () => {
     const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-'));
     tempDirs.push(homeDir);

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -800,6 +800,30 @@ key = "${titleOAuthRef.key}"
     }
   });
 
+  it('serves suggestFiles through the workspace handler fs service', async () => {
+    const { harness } = await makeHarness();
+    const workDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-work-'));
+    tempDirs.push(workDir);
+    await mkdir(join(workDir, 'src'), { recursive: true });
+    await writeFile(join(workDir, 'src', 'app.ts'), 'app');
+    await writeFile(join(workDir, 'src', 'index.ts'), 'index');
+    await writeFile(join(workDir, 'README.md'), 'readme');
+    try {
+      const matched = await harness.suggestFiles(workDir, { query: 'app', limit: 20 });
+      expect(matched?.items).toContainEqual(
+        expect.objectContaining({ kind: 'file', path: 'src/app.ts', name: 'app.ts' }),
+      );
+      const appItem = matched?.items.find((item) => item.name === 'app.ts');
+      expect(appItem?.matchPositions.length).toBeGreaterThan(0);
+
+      const topLevel = await harness.suggestFiles(workDir, { query: '', limit: 20 });
+      expect(topLevel?.items).toContainEqual(expect.objectContaining({ kind: 'directory', name: 'src' }));
+      expect(topLevel?.items).toContainEqual(expect.objectContaining({ kind: 'file', name: 'README.md' }));
+    } finally {
+      await harness.close();
+    }
+  });
+
   it('honors skillDirs (explicit dirs) over default user / project discovery', async () => {
     const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-'));
     tempDirs.push(homeDir);


### PR DESCRIPTION
## Related Issue

无关联 issue（内部改进）。

## Problem

VS Code 扩展的 @ 文件选择器有三个问题：

1. @ 搜索使用扩展自实现的 `vscode.workspace.findFiles` glob 匹配，而非引擎（kap-server / agent-core-v2 `WorkspaceFsService.suggest`）提供的模糊搜索能力，结果与 web 版不一致（无模糊评分、无目录、不过滤 gitignore、无高亮信息）。
2. 弹出层中鼠标 hover 到滚动区边缘时滚动区抖动：hover 选中触发 `scrollIntoView`，条目被拉入视图后列表位移，鼠标继续移动时落到新条目再次触发选中与滚动，形成往复。
3. 菜单顶部的 "Select images or videos" 与 "Browse folders" 两项无条件展示；期望仅在 @ 后 search 字符串为空时展示。经讨论，"Browse folders" 模式直接删除（web 版无此功能）。

## What changed

- `packages/node-sdk`：`KimiHarness` 新增 `suggestFiles(workDir, { query, limit })`。v2 客户端经 `engineAccessor` → `IWorkspaceInstanceManager.getOrCreate({ root })` → workspace handler 的 `IWorkspaceFsService.suggest()`（与 kap-server `fs:suggest` 路由同源），与 `listWorkspaceSkills` 的既有逃生舱模式一致；基类默认返回 `undefined`（v1 引擎无此能力）。
- `apps/vscode` 扩展宿主：`getProjectFiles` 改调引擎 suggest（显式 `limit: 20`，与 web 相同），`undefined`（v1）回退原 `FileManager.searchFiles`，运行期错误记日志并返回空列表（与 web 行为一致）；结果携带 `matchPositions`。删除 bridge 的 `directory` 参数与 `FileManager.listDirectory`。
- `apps/vscode` webview：
  - 删除 folder 浏览模式（入口按钮、状态、键盘导航）；目录条目点击/Enter 直接插入路径作为 mention（对齐 web）。
  - "Select images or videos…" 仅在 search 字符串为空且可添加媒体时展示。
  - 新增 `mentionMatchSpans`（与 web 相同的切段逻辑，无三方库）：文件名命中字符加粗、父目录路径命中变色，右侧路径列改为父目录。
  - 抖动修复（`FilePickerMenu` 与 `SlashCommandMenu`）：`onMouseEnter` 改为 `onMouseMove`（radix/cmdk 惯用法），且鼠标 hover 驱动的选中变化不再触发 `scrollIntoView`（值比较 ref 识别选中来源），键盘导航的自动滚动保持不变。
  - v1 回退路径的菜单渲染上限保持原来的 50 条。
- 测试：node-sdk 新增 `suggestFiles` 集成用例；webview 新增 media 门控、目录插入、50 条上限、`mentionMatchSpans` 用例；删除 7 个 folder 模式用例并给 handler 测试 mock 补 harness。
- 4 个 changeset：`@moonshot-ai/kimi-code-sdk` minor；`kimi-code` patch ×3。

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
