### PR TITLE
fix remote control multi endpoint still use default credentials

### DIFF
--- a/apps/kimi-code/src/cli/sub/web/remote-control.ts
+++ b/apps/kimi-code/src/cli/sub/web/remote-control.ts
@@ -7,6 +7,9 @@ import {
   createKimiDeviceId,
   FileTokenStorage,
   KIMI_CODE_PROVIDER_NAME,
+  kimiCodeEnvBaseUrl,
+  kimiCodeEnvOAuthHost,
+  resolveKimiCodeOAuthKey,
   resolveKimiTokenStorageName,
 } from '@moonshot-ai/kimi-code-oauth';
 import { WebSocket, type RawData } from 'ws';
@@ -294,8 +297,18 @@ export async function startRemoteControl(
     throw new Error('Remote Control requires local server authentication.');
   }
   const storage = new FileTokenStorage(join(options.homeDir, 'credentials'));
+  // Resolve the credential slot the same way login and the runtime provider
+  // do: with KIMI_CODE_OAUTH_HOST / KIMI_CODE_BASE_URL overrides the token
+  // lives in an env-scoped slot (kimi-code-env-<hash>), and reading only the
+  // default slot would pick up a credential for the wrong environment.
   const token = await storage.load(
-    resolveKimiTokenStorageName({ providerName: KIMI_CODE_PROVIDER_NAME }),
+    resolveKimiTokenStorageName({
+      providerName: KIMI_CODE_PROVIDER_NAME,
+      oauthKey: resolveKimiCodeOAuthKey({
+        oauthHost: kimiCodeEnvOAuthHost(),
+        baseUrl: kimiCodeEnvBaseUrl(),
+      }),
+    }),
   );
   if (token?.refreshToken === undefined || token.refreshToken.length === 0) {
     throw new Error('Remote Control requires a Kimi login. Run `kimi login` first.');

--- a/apps/kimi-code/test/cli/web/remote-control.test.ts
+++ b/apps/kimi-code/test/cli/web/remote-control.test.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path';
 import {
   FileTokenStorage,
   KIMI_CODE_PROVIDER_NAME,
+  resolveKimiCodeOAuthKey,
   resolveKimiTokenStorageName,
   type TokenInfo,
 } from '@moonshot-ai/kimi-code-oauth';
@@ -241,6 +242,61 @@ describe('Remote Control tunnel', () => {
         stderr: { write: () => true },
       }),
     ).rejects.toThrow(/DEVICE_LIMIT_EXCEEDED.*membership allows 3 devices/);
+  });
+
+  it('loads the env-scoped credential when OAuth env overrides are set', async () => {
+    const oauthHost = 'https://auth.dev.example.test';
+    const baseUrl = 'https://api.dev.example.test/coding/v1';
+    vi.stubEnv('KIMI_CODE_OAUTH_HOST', oauthHost);
+    vi.stubEnv('KIMI_CODE_BASE_URL', baseUrl);
+    const homeDir = mkdtempSync(join(tmpdir(), 'kimi-rc-env-'));
+    cleanups.push(() => rmSync(homeDir, { recursive: true, force: true }));
+    const storage = new FileTokenStorage(join(homeDir, 'credentials'));
+    // The default (production) slot holds a credential for a different
+    // environment; the dev login wrote to the env-scoped slot instead.
+    await storage.save(resolveKimiTokenStorageName({ providerName: KIMI_CODE_PROVIDER_NAME }), {
+      ...TOKEN,
+      refreshToken: 'prod-refresh-token',
+    });
+    await storage.save(
+      resolveKimiTokenStorageName({
+        providerName: KIMI_CODE_PROVIDER_NAME,
+        oauthKey: resolveKimiCodeOAuthKey({ oauthHost, baseUrl }),
+      }),
+      { ...TOKEN, refreshToken: 'dev-refresh-token' },
+    );
+    const relay = await startAuthRelay();
+    let handle: RemoteControlHandle | undefined;
+    cleanups.push(async () => handle?.close());
+
+    handle = await startRemoteControl({
+      homeDir,
+      localOrigin: 'http://127.0.0.1:1',
+      localServerToken: 'local-server-token',
+      relayOrigin: `http://127.0.0.1:${relay.port}/coding-relay`,
+      stderr: { write: () => true },
+    });
+
+    const bearerTokens = relay.requests.map(
+      (request) => request.authorization ?? request.protocol?.replace('kimi-code.bearer.', ''),
+    );
+    expect(bearerTokens).toContain('dev-refresh-token');
+    expect(bearerTokens).not.toContain('prod-refresh-token');
+  });
+
+  it('ignores the default credential slot when OAuth env overrides are set', async () => {
+    vi.stubEnv('KIMI_CODE_OAUTH_HOST', 'https://auth.dev.example.test');
+    const homeDir = await createRemoteControlHome(TOKEN.refreshToken);
+
+    await expect(
+      startRemoteControl({
+        homeDir,
+        localOrigin: 'http://127.0.0.1:1',
+        localServerToken: 'local-server-token',
+        relayOrigin: 'http://127.0.0.1:1',
+        stderr: { write: () => true },
+      }),
+    ).rejects.toThrow('Remote Control requires a Kimi login');
   });
 
   it('uses only Authorization when the refresh token is not a valid subprotocol token', async () => {


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
External PRs are accepted for approved bug fixes only: link an issue that a maintainer has approved (an `/approve` comment). External feature PRs are not accepted.
外部 PR 仅接受获批准的 bug 修复：请链接维护者已批准（`/approve` 评论）的 issue；不接受外部 feature PR。

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Link the issue this change came from. External PRs must link an issue approved by a maintainer (an `/approve` comment) — PRs without one may be closed. -->

Resolve #(issue_number)

## Problem

<!-- What user need or limitation does this address? If the linked issue already covers this, write "See linked issue". -->

## What changed

<!-- What did you implement, and why does this approach fit Kimi Code? -->

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [ ] I have added tests that prove my feature works.
- [ ] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
