### PR TITLE
chore: add changeset for the kimi-cli migration re-prompt fix

### DIFF
--- a/.changeset/migration-reprompt-condition.md
+++ b/.changeset/migration-reprompt-condition.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the condition for showing the kimi-cli migration prompt.


### PR DESCRIPTION
## Related Issue

Follow-up to #3467 (fix(migration-legacy): stop re-prompting for kimi-cli migration once completed or dismissed), which merged without a changeset.

## Problem

The user-facing fix in #3467 shipped with no changelog entry.

## What changed

Adds a single patch changeset for `@moonshot-ai/kimi-code`: "Fix the condition for showing the kimi-cli migration prompt."

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
