### PR TITLE
chore(changesets): drop unpublished @moonshot-ai/kimi-code entries

### DIFF
--- a/.changeset/file-history-turn-snapshots.md
+++ b/.changeset/file-history-turn-snapshots.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": minor
----
-
-Add experimental turn-level file snapshots (enable with KIMI_CODE_EXPERIMENTAL_FILE_HISTORY=1): each turn records the files it edits — their content from before the first edit and after the turn ends — keeping the last five editing turns for the thirty most recently active sessions of each workspace.

--- a/.changeset/fork-quiescence-guard.md
+++ b/.changeset/fork-quiescence-guard.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": minor
----
-
-Forking a session is now refused while it still has a queued prompt or while another fork of it is copying, so a fork never captures a session that is about to change.


### PR DESCRIPTION
## Related Issue

N/A — internal release management.

## Problem

Two pending changesets for `@moonshot-ai/kimi-code` (the experimental turn-level file history snapshots and the fork quiescence guard) would be published in the upcoming 0.41.0 release. They should not ship in 0.41.0.

## What changed

- Deleted `.changeset/file-history-turn-snapshots.md` and `.changeset/fork-quiescence-guard.md`.
- Only the release-note entries are removed; the underlying features remain in the codebase and can be re-changeset later if needed.
- Remaining unpublished changesets: 1 minor for `@moonshot-ai/kimi-code-sdk`, 3 patches for the VSCode extension (`kimi-code`).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.