### PR TITLE
fix(agent-core-v2): assemble flag-gated features after config ready

### DIFF
--- a/.changeset/tower-config-experimental-assembly.md
+++ b/.changeset/tower-config-experimental-assembly.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix tower mode not turning on when enabled through the [experimental] section in config.toml.

--- a/packages/agent-core-v2/src/features/featureAssembly.ts
+++ b/packages/agent-core-v2/src/features/featureAssembly.ts
@@ -2,6 +2,7 @@ import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiatio
 
 export interface IFeatureAssemblyService {
   readonly _serviceBrand: undefined;
+  readonly ready: Promise<void>;
 }
 
 export const IFeatureAssemblyService: ServiceIdentifier<IFeatureAssemblyService> =

--- a/packages/agent-core-v2/src/features/featureAssemblyService.ts
+++ b/packages/agent-core-v2/src/features/featureAssemblyService.ts
@@ -1,19 +1,41 @@
+import type { ServiceClassRecipe } from '#/_base/di/fiber';
+import { IConfigService } from '#/app/config/config';
 import { IFeatureManager } from '#/app/feature/featureManager';
+import { IFlagService } from '#/app/flag/flag';
+import type { FlagId } from '#/app/flag/flagRegistry';
 import { LifecycleScope } from '#/app/scopes';
 import { ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { Service } from '#/_base/di/service';
 
 import { IFeatureAssemblyService } from './featureAssembly';
-import { getFeatureRecipes } from './featureRegistry';
+import { getFeatureRegistrations } from './featureRegistry';
 
 export class FeatureAssemblyService extends Service implements IFeatureAssemblyService {
   declare readonly _serviceBrand: undefined;
+  readonly ready: Promise<void>;
 
-  constructor(@IFeatureManager featureManager: IFeatureManager) {
+  constructor(
+    @IFeatureManager featureManager: IFeatureManager,
+    @IConfigService config: IConfigService,
+    @IFlagService flags: IFlagService,
+  ) {
     super();
-    for (const recipe of getFeatureRecipes()) {
-      featureManager.provideUnit(recipe);
+    const gated: { recipe: ServiceClassRecipe; flag: FlagId }[] = [];
+    for (const { recipe, flag } of getFeatureRegistrations()) {
+      if (flag === undefined) {
+        featureManager.provideUnit(recipe);
+      } else {
+        gated.push({ recipe, flag });
+      }
     }
+    this.ready = config.ready.then(() => {
+      for (const { recipe, flag } of gated) {
+        if (flags.enabled(flag)) {
+          featureManager.provideUnit(recipe);
+        }
+      }
+    });
+    void this.ready.catch(() => {});
   }
 }
 

--- a/packages/agent-core-v2/src/features/featureRegistry.ts
+++ b/packages/agent-core-v2/src/features/featureRegistry.ts
@@ -1,15 +1,24 @@
 import type { ServiceClassRecipe } from '#/_base/di/fiber';
+import type { FlagId } from '#/app/flag/flagRegistry';
 
-const _featureRecipes: ServiceClassRecipe[] = [];
-
-export function registerFeature(recipe: ServiceClassRecipe): void {
-  _featureRecipes.push(recipe);
+export interface FeatureRegistration {
+  readonly recipe: ServiceClassRecipe;
+  readonly flag?: FlagId;
 }
 
-export function getFeatureRecipes(): readonly ServiceClassRecipe[] {
-  return _featureRecipes;
+const _featureRegistrations: FeatureRegistration[] = [];
+
+export function registerFeature(
+  recipe: ServiceClassRecipe,
+  options: { readonly flag?: FlagId } = {},
+): void {
+  _featureRegistrations.push({ recipe, flag: options.flag });
+}
+
+export function getFeatureRegistrations(): readonly FeatureRegistration[] {
+  return _featureRegistrations;
 }
 
 export function _clearFeatureRecipesForTests(): void {
-  _featureRecipes.length = 0;
+  _featureRegistrations.length = 0;
 }

--- a/packages/agent-core-v2/src/features/tower/towerFeature.ts
+++ b/packages/agent-core-v2/src/features/tower/towerFeature.ts
@@ -90,4 +90,4 @@ export function _setTowerFeatureAssembledForTests(value: boolean | undefined): v
   assembledOverrideForTests = value;
 }
 
-registerFeature(TowerFeature);
+registerFeature(TowerFeature, { flag: TOWER_FLAG_ID });

--- a/packages/agent-core-v2/src/workspace/workspaceInstance/workspaceInstanceManagerService.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceInstance/workspaceInstanceManagerService.ts
@@ -186,6 +186,7 @@ export class WorkspaceInstanceManager implements IWorkspaceInstanceManager {
 
   private async materialize(workspace: Workspace): Promise<WorkspaceInstance> {
     await this.environment.ready;
+    await this.config.ready;
     const runtimes = new RuntimeRegistry(workspace.id);
     const unitHost = this.unitHostFactory.create(this.instantiation, runtimes);
     const instance = new WorkspaceInstance(

--- a/packages/agent-core-v2/test/features/debugEvents/debugEvents.test.ts
+++ b/packages/agent-core-v2/test/features/debugEvents/debugEvents.test.ts
@@ -7,8 +7,10 @@ import {
   registerScopedService,
 } from '#/_base/di/scope';
 import { createScopedTestHost } from '#/_base/di/test';
+import { IConfigService } from '#/app/config/config';
 import { IFeatureManager } from '#/app/feature/featureManager';
 import { FeatureManagerService } from '#/app/feature/featureManagerService';
+import { IFlagService } from '#/app/flag/flag';
 import { LifecycleScope } from '#/app/scopes';
 import { IFeatureAssemblyService } from '#/features/featureAssembly';
 import { FeatureAssemblyService } from '#/features/featureAssemblyService';
@@ -18,7 +20,13 @@ import {
 } from '#/features/featureRegistry';
 
 import { IDebugEventsService } from '#/features/debugEvents/debugEvents';
+import { stubFlag } from '../../app/flag/stubs';
 import { DebugEventsFeature } from '#/features/debugEvents/debugEventsFeature';
+
+const featureAssemblySeeds = [
+  [IConfigService, { ready: Promise.resolve() }],
+  [IFlagService, stubFlag(false)],
+] as const;
 
 describe('DebugEventsFeature — App-scope introspection service', () => {
   beforeEach(() => {
@@ -48,7 +56,7 @@ describe('DebugEventsFeature — App-scope introspection service', () => {
       ),
     ).toBe(false);
 
-    const host = createScopedTestHost();
+    const host = createScopedTestHost(featureAssemblySeeds);
     const manager = host.app.accessor.get(IFeatureManager);
     expect(manager.units().map((unit) => unit.name)).toContain('debugEvents');
     expect(

--- a/packages/agent-core-v2/test/features/externalHooks/externalHooksFeature.test.ts
+++ b/packages/agent-core-v2/test/features/externalHooks/externalHooksFeature.test.ts
@@ -11,6 +11,7 @@ import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { IConfigService } from '#/app/config/config';
 import { IFeatureManager } from '#/app/feature/featureManager';
 import { FeatureManagerService } from '#/app/feature/featureManagerService';
+import { IFlagService } from '#/app/flag/flag';
 import { IPluginService } from '#/app/plugin/plugin';
 import { LifecycleScope } from '#/app/scopes';
 import { IFeatureAssemblyService } from '#/features/featureAssembly';
@@ -23,6 +24,7 @@ import { ISessionExternalHooksService } from '#/features/externalHooks/session/s
 import { IHostProcessService } from '#/os/interface/hostProcess';
 
 import { stubBootstrap } from '../../app/bootstrap/stubs';
+import { stubFlag } from '../../app/flag/stubs';
 
 function collectionViewOf<T>(scope: Scope, token: CollectionToken<T>): CollectionView<T> {
   return (scope.instantiation as InstantiationService).fiberHost.collectionView(token);
@@ -59,6 +61,7 @@ describe('ExternalHooksFeature — assembly (src/features/externalHooks)', () =>
         { _serviceBrand: undefined, enabledHooks: async () => [], onDidReload: Event.None },
       ],
       [IHostProcessService, { _serviceBrand: undefined }],
+      [IFlagService, stubFlag(false)],
     ]);
     const manager = host.app.accessor.get(IFeatureManager);
     expect(manager.units().map((unit) => unit.name)).toContain('externalHooks');

--- a/packages/agent-core-v2/test/features/feature.test.ts
+++ b/packages/agent-core-v2/test/features/feature.test.ts
@@ -17,9 +17,11 @@ import {
 import { Service } from '#/_base/di/service';
 import { createScopedTestHost } from '#/_base/di/test';
 import { AgentProfileContribution } from '#/app/agentProfileCatalog/agentProfileContribution';
+import { IConfigService } from '#/app/config/config';
 import { ConfigSectionContribution } from '#/app/config/configSectionContributions';
 import { IFeatureManager } from '#/app/feature/featureManager';
 import { FeatureManagerService } from '#/app/feature/featureManagerService';
+import { IFlagService } from '#/app/flag/flag';
 import { LifecycleScope } from '#/app/scopes';
 import { AgentToolContribution } from '#/agent/toolRegistry/toolContribution';
 import { Feature } from '#/features/feature';
@@ -37,6 +39,13 @@ import {
   registerFeature,
 } from '#/features/featureRegistry';
 import type { AgentTool, ToolExecution } from '#/tool/toolContract';
+
+import { stubFlag } from '../app/flag/stubs';
+
+const featureAssemblySeeds = [
+  [IConfigService, { ready: Promise.resolve() }],
+  [IFlagService, stubFlag(false)],
+] as const;
 
 interface IGreeter {
   readonly _serviceBrand: undefined;
@@ -115,7 +124,7 @@ describe('Feature — built-in capability assembly (src/features)', () => {
     }
     registerFeature(TestFeature);
 
-    const host = createScopedTestHost();
+    const host = createScopedTestHost(featureAssemblySeeds);
     const manager = host.app.accessor.get(IFeatureManager);
     expect(manager.units()).toHaveLength(1);
     expect(manager.units()[0]!.name).toBe('test-feature');
@@ -185,7 +194,7 @@ describe('Feature — built-in capability assembly (src/features)', () => {
     }
     registerFeature(DomainFeature);
 
-    const host = createScopedTestHost();
+    const host = createScopedTestHost(featureAssemblySeeds);
     const manager = host.app.accessor.get(IFeatureManager);
     const views = [
       collectionViewOf(host.app, SessionModelContribution),
@@ -225,7 +234,7 @@ describe('Feature — built-in capability assembly (src/features)', () => {
     }
     registerFeature(FirstFeature);
 
-    const host = createScopedTestHost();
+    const host = createScopedTestHost(featureAssemblySeeds);
     const manager = host.app.accessor.get(IFeatureManager);
     const agent = host.child(LifecycleScope.Agent, 'agent-1');
     const original = agent.accessor.get(IGreeter);
@@ -261,8 +270,8 @@ describe('Feature — built-in capability assembly (src/features)', () => {
     }
     registerFeature(SharedFeature);
 
-    const first = createScopedTestHost();
-    const second = createScopedTestHost();
+    const first = createScopedTestHost(featureAssemblySeeds);
+    const second = createScopedTestHost(featureAssemblySeeds);
     const firstManager = first.app.accessor.get(IFeatureManager);
     const secondManager = second.app.accessor.get(IFeatureManager);
     const firstAgent = first.child(LifecycleScope.Agent, 'agent-1');
@@ -301,7 +310,7 @@ describe('Feature — built-in capability assembly (src/features)', () => {
     }
     registerFeature(SoloFeature);
 
-    const host = createScopedTestHost();
+    const host = createScopedTestHost(featureAssemblySeeds);
     const agent = host.child(LifecycleScope.Agent, 'agent-1');
     expect(agent.accessor.get(IGreeter).greet()).toBe('hi');
     host.dispose();

--- a/packages/agent-core-v2/test/features/goal/goalFeature.test.ts
+++ b/packages/agent-core-v2/test/features/goal/goalFeature.test.ts
@@ -31,6 +31,13 @@ import { GoalFeature } from '#/features/goal/goalFeature';
 import { ISessionUsageService } from '#/session/usage/sessionUsage';
 import { IEventDispatcher } from '#/state/eventDispatcher';
 
+import { stubFlag } from '../../app/flag/stubs';
+
+const featureAssemblySeeds = [
+  [IConfigService, { ready: Promise.resolve() }],
+  [IFlagService, stubFlag(false)],
+] as const;
+
 describe('GoalFeature', () => {
   beforeEach(() => {
     _clearScopedRegistryForTests();
@@ -53,14 +60,14 @@ describe('GoalFeature', () => {
   });
 
   it('assembles a named, introspectable goal unit', () => {
-    const host = createScopedTestHost();
+    const host = createScopedTestHost(featureAssemblySeeds);
     const manager = host.app.accessor.get(IFeatureManager);
     expect(manager.units().map((unit) => unit.name)).toContain('goal');
     host.dispose();
   });
 
   it('retracts the goal runtime contribution with the Feature', async () => {
-    const host = createScopedTestHost();
+    const host = createScopedTestHost(featureAssemblySeeds);
     const manager = host.app.accessor.get(IFeatureManager);
 
     await manager.unprovideUnit('goal');

--- a/packages/agent-core-v2/test/features/sessionInit/sessionInitFeature.test.ts
+++ b/packages/agent-core-v2/test/features/sessionInit/sessionInitFeature.test.ts
@@ -7,8 +7,10 @@ import {
 } from '#/_base/di/scope';
 import { createScopedTestHost, stubPair } from '#/_base/di/test';
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
+import { IConfigService } from '#/app/config/config';
 import { IFeatureManager } from '#/app/feature/featureManager';
 import { FeatureManagerService } from '#/app/feature/featureManagerService';
+import { IFlagService } from '#/app/flag/flag';
 import { LifecycleScope } from '#/app/scopes';
 import { SessionInitFeature } from '#/features/sessionInit/sessionInitFeature';
 import { ISessionInitService } from '#/features/sessionInit/sessionInit';
@@ -23,6 +25,13 @@ import {
 import { IAgentLifecycleService } from '#/session/agentLifecycle/agentLifecycle';
 import { ISessionContext } from '#/session/sessionContext/sessionContext';
 import { ISessionSubagentService } from '#/session/subagent/subagent';
+
+import { stubFlag } from '../../app/flag/stubs';
+
+const featureAssemblySeeds = [
+  [IConfigService, { ready: Promise.resolve() }],
+  [IFlagService, stubFlag(false)],
+] as const;
 
 describe('SessionInitFeature', () => {
   beforeEach(() => {
@@ -46,7 +55,7 @@ describe('SessionInitFeature', () => {
   });
 
   it('withdraws and restores the Session service with the Feature', async () => {
-    const host = createScopedTestHost();
+    const host = createScopedTestHost(featureAssemblySeeds);
     const session = host.child(LifecycleScope.Session, 'session-1', [
       stubPair(IAgentLifecycleService, {} as IAgentLifecycleService),
       stubPair(ISessionSubagentService, {} as ISessionSubagentService),

--- a/packages/agent-core-v2/test/features/tower/towerFeature.test.ts
+++ b/packages/agent-core-v2/test/features/tower/towerFeature.test.ts
@@ -50,6 +50,10 @@ function collectionViewOf<T>(scope: Scope, token: CollectionToken<T>): Collectio
   return (scope.instantiation as InstantiationService).fiberHost.collectionView(token);
 }
 
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe('TowerFeature — experimental flag gating', () => {
   beforeEach(() => {
     _clearScopedRegistryForTests();
@@ -68,13 +72,17 @@ describe('TowerFeature — experimental flag gating', () => {
       ScopeActivation.OnScopeCreated,
       'features',
     );
-    registerFeature(TowerFeature);
+    registerFeature(TowerFeature, { flag: TOWER_FLAG_ID });
   });
 
-  it('assembles an empty unit when the tower flag is off', () => {
-    const host = createScopedTestHost([[IFlagService, stubFlag(false)]]);
+  it('does not assemble when the tower flag is off', async () => {
+    const host = createScopedTestHost([
+      [IFlagService, stubFlag(false)],
+      [IConfigService, { ready: Promise.resolve() }],
+    ]);
+    await host.app.accessor.get(IFeatureAssemblyService).ready;
     const manager = host.app.accessor.get(IFeatureManager);
-    expect(manager.units().map((unit) => unit.name)).toEqual(['tower']);
+    expect(manager.units()).toHaveLength(0);
     expect(manager.contributedServices()).toHaveLength(0);
     expect(collectionViewOf(host.app, AgentProfileContribution).items).toHaveLength(0);
     const agent = host.child(LifecycleScope.Agent, 'agent-1');
@@ -82,10 +90,12 @@ describe('TowerFeature — experimental flag gating', () => {
     host.dispose();
   });
 
-  it('contributes tools, profile, and rate-limit service when the tower flag is on', () => {
+  it('contributes tools, profile, and rate-limit service when the tower flag is on', async () => {
     const host = createScopedTestHost([
       [IFlagService, stubFlag((id) => id === TOWER_FLAG_ID)],
+      [IConfigService, { ready: Promise.resolve() }],
     ]);
+    await host.app.accessor.get(IFeatureAssemblyService).ready;
     const manager = host.app.accessor.get(IFeatureManager);
     expect(
       manager
@@ -121,13 +131,90 @@ describe('TowerFeature — experimental flag gating', () => {
 
   it('clears the assembly marker when the feature unit unloads', async () => {
     const flags = stubFlag((id) => id === TOWER_FLAG_ID);
-    const host = createScopedTestHost([[IFlagService, flags]]);
+    const host = createScopedTestHost([
+      [IFlagService, flags],
+      [IConfigService, { ready: Promise.resolve() }],
+    ]);
+    await host.app.accessor.get(IFeatureAssemblyService).ready;
     const manager = host.app.accessor.get(IFeatureManager);
     expect(isTowerFeatureAssembled(flags)).toBe(true);
 
     await manager.unprovideUnit('tower');
 
     expect(isTowerFeatureAssembled(flags)).toBe(false);
+    host.dispose();
+  });
+
+  it('defers gated assembly until config ready resolves', async () => {
+    let resolveConfigReady!: () => void;
+    const configReady = new Promise<void>((resolve) => {
+      resolveConfigReady = resolve;
+    });
+    const host = createScopedTestHost([
+      [IFlagService, stubFlag((id) => id === TOWER_FLAG_ID)],
+      [IConfigService, { ready: configReady }],
+    ]);
+    const assembly = host.app.accessor.get(IFeatureAssemblyService);
+    const manager = host.app.accessor.get(IFeatureManager);
+    await flushMicrotasks();
+    expect(manager.units()).toHaveLength(0);
+    expect(manager.contributedServices()).toHaveLength(0);
+    expect(collectionViewOf(host.app, AgentProfileContribution).items).toHaveLength(0);
+    const pendingAgent = host.child(LifecycleScope.Agent, 'agent-pending');
+    expect(collectionViewOf(pendingAgent, AgentToolContribution).items).toHaveLength(0);
+
+    resolveConfigReady();
+    await assembly.ready;
+
+    expect(manager.units().map((unit) => unit.name)).toContain('tower');
+    expect(
+      manager
+        .contributedServices()
+        .filter(
+          (entry) => entry.scope === LifecycleScope.App && entry.id === ITowerRateLimitService,
+        ),
+    ).toHaveLength(1);
+    const profiles = collectionViewOf(host.app, AgentProfileContribution).items;
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0]!.sourceId).toBe('feature:tower');
+    const agent = host.child(LifecycleScope.Agent, 'agent-1');
+    expect(collectionViewOf(agent, AgentToolContribution).items).toHaveLength(11);
+    host.dispose();
+  });
+
+  it('does not assemble when the flag turns on after ready', async () => {
+    let towerEnabled = false;
+    const host = createScopedTestHost([
+      [IFlagService, stubFlag((id) => id === TOWER_FLAG_ID && towerEnabled)],
+      [IConfigService, { ready: Promise.resolve() }],
+    ]);
+    await host.app.accessor.get(IFeatureAssemblyService).ready;
+    const manager = host.app.accessor.get(IFeatureManager);
+    expect(manager.units()).toHaveLength(0);
+
+    towerEnabled = true;
+    await flushMicrotasks();
+
+    expect(manager.units()).toHaveLength(0);
+    expect(collectionViewOf(host.app, AgentProfileContribution).items).toHaveLength(0);
+    host.dispose();
+  });
+
+  it('does not unload when the flag turns off after ready', async () => {
+    let towerEnabled = true;
+    const host = createScopedTestHost([
+      [IFlagService, stubFlag((id) => id === TOWER_FLAG_ID && towerEnabled)],
+      [IConfigService, { ready: Promise.resolve() }],
+    ]);
+    await host.app.accessor.get(IFeatureAssemblyService).ready;
+    const manager = host.app.accessor.get(IFeatureManager);
+    expect(manager.units()).toHaveLength(1);
+
+    towerEnabled = false;
+    await flushMicrotasks();
+
+    expect(manager.units()).toHaveLength(1);
+    expect(collectionViewOf(host.app, AgentProfileContribution).items).toHaveLength(1);
     host.dispose();
   });
 });

--- a/packages/agent-core-v2/test/workspace/workspaceInstance/workspaceInstanceManager.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceInstance/workspaceInstanceManager.test.ts
@@ -142,6 +142,7 @@ function manager(
     ...Array.from({ length: 22 }, () => undefined),
     new TestRuntimeUnitHostFactory(),
   ];
+  args[5] = { ready: Promise.resolve() };
   args[18] = { entries: () => [] };
   const value = Reflect.construct(WorkspaceInstanceManager, args) as WorkspaceInstanceManager;
   const providers = (value as unknown as { providers: Map<string, RuntimeProviderFactory> }).providers;

--- a/packages/kap-server/test/meta.test.ts
+++ b/packages/kap-server/test/meta.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { IFeatureManager } from '@moonshot-ai/agent-core-v2/app/feature/featureManager';
-import { getFeatureRecipes } from '@moonshot-ai/agent-core-v2/features/featureRegistry';
+import { getFeatureRegistrations } from '@moonshot-ai/agent-core-v2/features/featureRegistry';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { type RunningServer, startServer } from '../src/start';
@@ -164,7 +164,13 @@ describe('/api/v1/meta features', () => {
     meta: Record<string, unknown>;
   }
 
+  beforeEach(() => {
+    vi.stubEnv('KIMI_CODE_EXPERIMENTAL_FLAG', '0');
+    vi.stubEnv('KIMI_CODE_EXPERIMENTAL_TOWER', '0');
+  });
+
   afterEach(async () => {
+    vi.unstubAllEnvs();
     if (server !== undefined) {
       await server.close();
       server = undefined;
@@ -199,8 +205,9 @@ describe('/api/v1/meta features', () => {
   it('lists every registered built-in feature as Active with an empty meta', async () => {
     const base = await boot();
     const features = await getMetaFeatures(base);
-    const expected = getFeatureRecipes()
-      .map((recipe) => recipe.name)
+    const expected = getFeatureRegistrations()
+      .filter((registration) => registration.flag === undefined)
+      .map((registration) => registration.recipe.name)
       .sort();
     expect(features.map((feature) => feature.name).sort()).toEqual(expected);
     for (const feature of features) {

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -1096,6 +1096,30 @@ key = "${titleOAuthRef.key}"
     }
   });
 
+  it('enables tower mode from config.toml [experimental] without env vars', async () => {
+    vi.stubEnv('KIMI_CODE_EXPERIMENTAL_FLAG', '0');
+    vi.stubEnv('KIMI_CODE_EXPERIMENTAL_TOWER', undefined);
+    const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-'));
+    tempDirs.push(homeDir);
+    await writeFile(join(homeDir, 'config.toml'), '[experimental]\ntower = true\n', 'utf-8');
+    const workDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-work-'));
+    tempDirs.push(workDir);
+    const client = new SDKRpcClientV2({ homeDir, identity: TEST_IDENTITY });
+    try {
+      await client.createSession({ id: 'ses_tower_config', workDir });
+
+      await expect(client.setTowerMode({ sessionId: 'ses_tower_config', enabled: true }))
+        .resolves.toBeUndefined();
+      expect((await client.getStatus({ sessionId: 'ses_tower_config' })).towerMode).toBe(true);
+
+      await client.setTowerMode({ sessionId: 'ses_tower_config', enabled: false });
+      expect((await client.getStatus({ sessionId: 'ses_tower_config' })).towerMode).toBe(false);
+    } finally {
+      vi.unstubAllEnvs();
+      await client.close();
+    }
+  });
+
   it('exposes Session.setTowerMode and getStatus().towerMode on the v2 harness', async () => {
     vi.stubEnv('KIMI_CODE_EXPERIMENTAL_TOWER', '1');
     const { harness } = await makeHarness();


### PR DESCRIPTION
## Related Issue

No tracking issue — internal fix from a user feedback report (v0.39.1): tower mode cannot be enabled via `[experimental] tower = true` in config.toml or the `/experiments` toggle; only `KIMI_CODE_EXPERIMENTAL_TOWER=1` at process launch works.

## Problem

`ConfigService` loads config.toml asynchronously (`this.ready` in its constructor), but `FeatureAssemblyService` assembles all features synchronously during the eager App-scope bootstrap batch. At that moment the flag snapshot is still empty, so `flags.enabled("tower")` reads false and the tower feature is never assembled — and features are never re-assembled at runtime. `/tower on` then always fails with `SESSION_TOWER_MODE_INVALID` ("the tower feature is unavailable in this process") even though `/experiments` shows the flag ON.

## What changed

- `registerFeature(recipe, { flag })`: a feature registration can now declare a gating flag.
- `FeatureAssemblyService` provides unflagged features synchronously as before, and assembles flag-gated features in a deferred pass once `IConfigService.ready` resolves. Config load fires `onDidChangeConfiguration` synchronously before `ready` resolves, so `FlagService` already reflects config values when the deferred pass evaluates `flags.enabled(flag)`. `IFeatureAssemblyService.ready` exposes the deferred pass to consumers.
- `towerFeature` is wired through the new option, which fixes config.toml / `/experiments` enablement.
- `WorkspaceInstanceManager.materialize` now also awaits `config.ready` (session materialization already did), so first-session creation cannot race the deferred assembly.

Known limitation (pre-existing, unchanged by this PR): flipping a flag at runtime does not re-assemble features; a config.toml change to a gating flag takes effect on next process start.

Tests: gated/ungated assembly ordering in feature tests, a node-sdk positive test with a preset config.toml (`[experimental] tower = true` → `setTowerMode` succeeds — the previously broken path), and env-hardening of the kap-server meta test.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (no tracking issue; problem described above from a user feedback report).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (changeset included: `@moonshot-ai/kimi-code` patch)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (the fix makes already-documented behavior work; contributor-facing readiness conventions land separately)
