### PR TITLE
fix(kap-server): stop exiting the process on uncaughtException

### DIFF
--- a/packages/kap-server/src/services/pinoLoggerService.ts
+++ b/packages/kap-server/src/services/pinoLoggerService.ts
@@ -1,4 +1,4 @@
-import { pino, type Logger, type LoggerOptions } from 'pino';
+import { pino, type DestinationStream, type Logger, type LoggerOptions } from 'pino';
 
 export type ServerLogger = Logger;
 
@@ -6,6 +6,7 @@ export type ServerLogLevel = 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'tr
 
 export interface CreateLoggerOptions {
   level: ServerLogLevel;
+  stream?: DestinationStream;
 }
 
 export function createServerLogger(opts: CreateLoggerOptions): ServerLogger {
@@ -14,5 +15,5 @@ export function createServerLogger(opts: CreateLoggerOptions): ServerLogger {
     base: { name: 'kimi-server-v2' },
     timestamp: pino.stdTimeFunctions.isoTime,
   };
-  return pino(base);
+  return opts.stream === undefined ? pino(base) : pino(base, opts.stream);
 }

--- a/packages/kap-server/src/start.ts
+++ b/packages/kap-server/src/start.ts
@@ -171,11 +171,10 @@ export async function startServer(opts: ServerStartOptions): Promise<RunningServ
     );
   };
   const onUncaughtException = (err: unknown): void => {
-    logger.fatal(
+    logger.error(
       { err: err instanceof Error ? err : new Error(String(err)) },
       'uncaughtException',
     );
-    process.exit(1);
   };
   const authFailureLimiter =
     exposureClass === 'loopback' ? undefined : createAuthFailureLimiter({ logger });

--- a/packages/kap-server/test/boot.test.ts
+++ b/packages/kap-server/test/boot.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { createServer, type Server } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { Writable } from 'node:stream';
 
 import { pino } from 'pino';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -233,26 +234,56 @@ describe('server-v2 boot', () => {
     expect(await listLiveServerInstances(home)).toEqual([]);
   });
 
-  it('installs process-level rejection handlers while running and removes them on close', async () => {
+  it('logs process-level exceptions without exiting and removes the handlers on close', async () => {
     home = await mkdtemp(join(tmpdir(), 'kimi-server-v2-'));
-    const rejectionBefore = process.listenerCount('unhandledRejection');
-    const exceptionBefore = process.listenerCount('uncaughtException');
+    const lines: string[] = [];
+    const stream = new Writable({
+      write(chunk, _encoding, callback) {
+        lines.push(String(chunk));
+        callback();
+      },
+    });
+    const rejectionBefore = process.listeners('unhandledRejection');
+    const exceptionBefore = process.listeners('uncaughtException');
     server = await startServer({
       hostIdentity: TEST_HOST_IDENTITY,
       host: '127.0.0.1',
       port: 0,
       homeDir: home,
-      logLevel: 'silent',
+      logger: pino({ level: 'error' }, stream),
     });
 
-    expect(process.listenerCount('unhandledRejection')).toBe(rejectionBefore + 1);
-    expect(process.listenerCount('uncaughtException')).toBe(exceptionBefore + 1);
+    expect(process.listenerCount('unhandledRejection')).toBe(rejectionBefore.length + 1);
+    expect(process.listenerCount('uncaughtException')).toBe(exceptionBefore.length + 1);
+
+    const onUncaughtException = process
+      .listeners('uncaughtException')
+      .find((listener) => !exceptionBefore.includes(listener)) as
+      | ((error: Error) => void)
+      | undefined;
+    const onUnhandledRejection = process
+      .listeners('unhandledRejection')
+      .find((listener) => !rejectionBefore.includes(listener)) as
+      | ((reason: unknown) => void)
+      | undefined;
+    expect(onUncaughtException).toBeDefined();
+    expect(onUnhandledRejection).toBeDefined();
+
+    onUncaughtException?.(new Error('synthetic uncaught'));
+    onUnhandledRejection?.(new Error('synthetic rejection'));
+
+    const output = lines.join('');
+    expect(output).toContain('"msg":"uncaughtException"');
+    expect(output).toContain('"msg":"unhandledRejection"');
+
+    const healthz = await fetch(`http://127.0.0.1:${server.port}/api/v1/healthz`);
+    expect(healthz.status).toBe(200);
 
     await server.close();
     server = undefined;
 
-    expect(process.listenerCount('unhandledRejection')).toBe(rejectionBefore);
-    expect(process.listenerCount('uncaughtException')).toBe(exceptionBefore);
+    expect(process.listenerCount('unhandledRejection')).toBe(rejectionBefore.length);
+    expect(process.listenerCount('uncaughtException')).toBe(exceptionBefore.length);
   });
 
   it('does not leave process handlers installed when startup fails', async () => {


### PR DESCRIPTION
## Related Issue

No tracking issue — internal regression analysis, see Problem.

## Problem

`startServer` unconditionally installs a process-level `uncaughtException` handler that logs at fatal level and calls `process.exit(1)` (introduced in #3206 to isolate sessions in the standalone multi-session daemon). Two problems with that design:

- In a multi-session server, one session's stray exception kills the whole process and every other healthy session with it. A supervisor can restart the process but cannot restore the other sessions' connections and in-flight work.
- When the server is embedded in a host process (the desktop app's Electron main process), the same handler kills the entire app for any uncaught exception — including known-benign ones the host's own crash guard already swallows. Node runs every `uncaughtException` listener in registration order, so the host guard's early return cannot prevent the later `exit(1)`, and the death bypasses the host's error dialog and crash telemetry.

The process-level global state the server holds (instance registry, token store, auth limiter, connection registry) is either on disk or rebuildable, so the "unknown corrupted global state" premise behind fail-fast does not hold here. Keeping the process alive is safe and strictly better for the unaffected sessions; a session that fails surfaces its error through the engine's existing turn-failure semantics.

## What changed

- `packages/kap-server/src/start.ts`: the `uncaughtException` handler no longer calls `process.exit(1)`, and the log level drops from `fatal` to `error` since the process keeps running. The `unhandledRejection` handler (already log-only) and the handler install/remove lifecycle are unchanged. Crash telemetry keeps working: the CLI's `uncaughtExceptionMonitor` still reports, as does the desktop shell's own guard — except now the process survives to report.
- `packages/kap-server/src/services/pinoLoggerService.ts`: `createServerLogger` gains an optional `stream`, letting an embedding host route server logs into its own log channel (the desktop app uses this to land server error records in its log file instead of losing them to stdout).
- `packages/kap-server/test/boot.test.ts`: the process-handler test now proves the handlers log without terminating the process — the server still answers `healthz` after they fire — and that they are still removed on close.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (no tracking issue; internal regression analysis, see Problem).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
