### PR TITLE
fix(kimi-code): queue submissions until the slash-command catalog is ready

### DIFF
--- a/.changeset/dispatch-dynamic-commands-ready.md
+++ b/.changeset/dispatch-dynamic-commands-ready.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix slash commands typed right after startup being sent to the model as plain text instead of activating the skill.

--- a/.changeset/dispatch-dynamic-commands-ready.md
+++ b/.changeset/dispatch-dynamic-commands-ready.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Fix slash commands typed right after startup being sent to the model as plain text instead of activating the skill.

--- a/apps/kimi-code/src/tui/commands/dispatch.ts
+++ b/apps/kimi-code/src/tui/commands/dispatch.ts
@@ -213,6 +213,7 @@ export interface SlashCommandHost {
   ): void;
   readonly skillCommandMap: Map<string, string>;
   readonly pluginCommandMap: Map<string, string>;
+  dynamicCommandsReady?: Promise<void>;
 
   // Controller refs
   readonly streamingUI: StreamingUIController;
@@ -226,6 +227,13 @@ export interface SlashCommandHost {
 // ---------------------------------------------------------------------------
 
 export function dispatchInput(host: SlashCommandHost, text: string): void {
+  const pending = host.dynamicCommandsReady;
+  if (pending !== undefined) {
+    void pending.then(() => {
+      dispatchInput(host, text);
+    });
+    return;
+  }
   if (parseSlashInput(text) !== null) {
     // A leading skill command combined with further inline skill tokens
     // (`/skill:a args /skill:b`) is one grouped submission on the v2 engine.

--- a/apps/kimi-code/src/tui/constant/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/constant/kimi-tui.ts
@@ -15,6 +15,10 @@ export const TOWER_STATUS_PROMPT =
 export const TOWER_TEARDOWN_PROMPT =
   'Tear down the tower: call TowerTeardown and report what it did. It refuses to destroy dirty worktrees unless forced.';
 export const EXIT_CONFIRM_WINDOW_MS = 1500;
+// Fallback for the dynamic (skill/plugin) slash-command readiness gate: if the
+// catalog load never settles (wedged IPC), the gate clears after this long so
+// input stops queueing — a wedged load must not swallow submissions forever.
+export const DYNAMIC_COMMANDS_READY_TIMEOUT_MS = 10_000;
 // Time window for treating two consecutive Esc presses as a double-Esc, which
 // opens the undo selector. Kept short (double-click feel) so two deliberate
 // presses far apart don't accidentally trigger undo.

--- a/apps/kimi-code/src/tui/controllers/auth-flow.ts
+++ b/apps/kimi-code/src/tui/controllers/auth-flow.ts
@@ -10,8 +10,6 @@ import {
 
 import { createKimiCodeUserAgent } from '#/cli/version';
 
-import type { SkillListSession } from '../commands';
-
 import { OAUTH_LOGIN_REQUIRED_STARTUP_NOTICE } from '../constant/kimi-tui';
 import {
   refreshAllProviderModels,
@@ -45,8 +43,7 @@ export interface AuthFlowHost {
   readonly sessionEventHandler: SessionEventHandler;
   fetchSessions(): Promise<void>;
   updateTerminalTitle(): void;
-  refreshSkillCommands(session?: SkillListSession): Promise<void>;
-  refreshPluginCommands(session?: Session): Promise<void>;
+  refreshDynamicCommands(session?: Session): Promise<void>;
 }
 
 export class AuthFlowController {
@@ -129,8 +126,7 @@ export class AuthFlowController {
     host.sessionEventHandler.startSubscription();
     void host.fetchSessions();
     host.updateTerminalTitle();
-    void host.refreshSkillCommands(host.session);
-    void host.refreshPluginCommands(host.session);
+    void host.refreshDynamicCommands(host.session);
   }
 
   async refreshConfigAfterLogin(): Promise<void> {

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -154,6 +154,7 @@ import {
 } from './types';
 import { hasDispose, isExpandable } from './utils/component-capabilities';
 import { isDeadTerminalError } from './utils/dead-terminal';
+import { createDynamicCommandsGate } from './utils/dynamic-commands-gate';
 import { formatErrorMessage } from './utils/event-payload';
 import { pickForegroundTasks } from './utils/foreground-task';
 import { ImageAttachmentStore, type ImageAttachment } from './utils/image-attachment-store';
@@ -320,6 +321,7 @@ export class KimiTUI {
   readonly skillCommandMap = new Map<string, string>();
   private pluginCommands: readonly KimiSlashCommand[] = [];
   readonly pluginCommandMap = new Map<string, string>();
+  dynamicCommandsReady?: Promise<void>;
   private readonly imageStore = new ImageAttachmentStore();
   // Detected lazily in startBackgroundFdAutocomplete() — detection spawns
   // `fd --version`, which must not happen before the workspace trust gate:
@@ -515,6 +517,20 @@ export class KimiTUI {
 
   refreshSlashCommandAutocomplete(): void {
     this.setupAutocomplete();
+  }
+
+  refreshDynamicCommands(session?: Session): Promise<void> {
+    const ready = createDynamicCommandsGate(
+      Promise.all([this.refreshSkillCommands(session), this.refreshPluginCommands(session)]),
+      (warning) => {
+        this.showStatus(warning, 'warning');
+      },
+    );
+    this.dynamicCommandsReady = ready;
+    void ready.finally(() => {
+      if (this.dynamicCommandsReady === ready) this.dynamicCommandsReady = undefined;
+    });
+    return ready;
   }
 
   async refreshSkillCommands(session?: SkillListSession): Promise<void> {
@@ -817,8 +833,7 @@ export class KimiTUI {
     if (this.session !== undefined) {
       this.updateTerminalTitle();
     }
-    void this.refreshSkillCommands(this.session);
-    void this.refreshPluginCommands(this.session);
+    void this.refreshDynamicCommands(this.session);
   }
 
   private async showSessionWarnings(session: Session): Promise<void> {

--- a/apps/kimi-code/src/tui/utils/dynamic-commands-gate.ts
+++ b/apps/kimi-code/src/tui/utils/dynamic-commands-gate.ts
@@ -1,0 +1,42 @@
+/**
+ * Readiness gate for the dynamic (skill/plugin) slash-command catalog. While
+ * the gate promise is pending, `dispatchInput` defers every submission so a
+ * slash command typed right after startup still resolves against the loaded
+ * catalog instead of falling through to the model as plain text.
+ *
+ * The gate resolves when the catalog load settles — success or failure, the
+ * gate is infallible by construction so queued drains can never be dropped by
+ * a rejection — or when the fallback timeout fires, whichever comes first. On
+ * timeout `onTimeout` receives the user-facing warning and the gate clears
+ * anyway: a wedged load (e.g. stuck IPC) must not queue input forever. A load
+ * that settles after the timeout still applies its results; the gate only
+ * bounds how long input dispatch waits.
+ */
+
+import { DYNAMIC_COMMANDS_READY_TIMEOUT_MS } from '#/tui/constant/kimi-tui';
+
+export function createDynamicCommandsGate(
+  load: Promise<unknown>,
+  onTimeout: (warning: string) => void,
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      settle();
+      onTimeout(
+        'Skill and plugin catalogs are still loading — slash commands may be incomplete for a moment.',
+      );
+    }, DYNAMIC_COMMANDS_READY_TIMEOUT_MS);
+    // Never hold the process open for the fallback: quitting while a catalog
+    // load is wedged must not wait out the timer.
+    timer.unref();
+    function settle(): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      // oxlint-disable-next-line promise/no-multiple-resolved -- `settled` guards the single resolve; the rule cannot see it
+      resolve();
+    }
+    void load.then(settle, settle);
+  });
+}

--- a/apps/kimi-code/test/tui/commands/goal.test.ts
+++ b/apps/kimi-code/test/tui/commands/goal.test.ts
@@ -130,6 +130,18 @@ function makeHost(
   return { host, session };
 }
 
+// Mirror of the KimiTUI.refreshDynamicCommands wiring: arm the gate and clear
+// it once it settles, so deferred submissions re-dispatch against the loaded
+// maps instead of queueing again.
+function armDynamicCommandsGate(host: SlashCommandHost, ready: Promise<void>): void {
+  Object.assign(host, { dynamicCommandsReady: ready });
+  void ready.finally(() => {
+    if (host.dynamicCommandsReady === ready) {
+      Object.assign(host, { dynamicCommandsReady: undefined });
+    }
+  });
+}
+
 interface TestPicker {
   handleInput(data: string): void;
   render(width: number): string[];
@@ -805,6 +817,91 @@ describe('dispatchInput /goal integration', () => {
     });
     expect(host.sendNormalUserInput).toHaveBeenCalledWith('Ship feature X');
     expect(host.sendNormalUserInput).not.toHaveBeenCalledWith('/goal Ship feature X');
+  });
+
+  it('waits for dynamic commands readiness before resolving the input', async () => {
+    const { host } = makeHost();
+    host.skillCommandMap.set('mcp-config', 'mcp-config');
+    Object.assign(host, { sendSkillActivation: vi.fn() });
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+    armDynamicCommandsGate(host, ready);
+
+    dispatchInput(host, '/mcp-config enable context7');
+
+    expect(host.sendSkillActivation).not.toHaveBeenCalled();
+    expect(host.sendNormalUserInput).not.toHaveBeenCalled();
+
+    resolveReady();
+    await vi.waitFor(() => {
+      expect(host.sendSkillActivation).toHaveBeenCalledWith(
+        expect.anything(),
+        'mcp-config',
+        'enable context7',
+      );
+    });
+    expect(host.sendNormalUserInput).not.toHaveBeenCalled();
+  });
+
+  it('drains multiple queued submissions in submission order', async () => {
+    const { host } = makeHost();
+    host.skillCommandMap.set('skill-a', 'skill-a');
+    host.skillCommandMap.set('skill-b', 'skill-b');
+    const dispatched: string[] = [];
+    Object.assign(host, {
+      sendSkillActivation: vi.fn((_session: unknown, skillName: string) => {
+        dispatched.push(skillName);
+      }),
+    });
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+    armDynamicCommandsGate(host, ready);
+
+    dispatchInput(host, '/skill-a first');
+    dispatchInput(host, '/skill-b second');
+
+    expect(host.sendSkillActivation).not.toHaveBeenCalled();
+
+    resolveReady();
+    // The drains were queued before this await, so both have run once the
+    // gate promise resumes here (the skill path is synchronous with a session).
+    await ready;
+
+    expect(dispatched).toEqual(['skill-a', 'skill-b']);
+  });
+
+  it('queues plain text behind the gate and keeps its order relative to a slash submission', async () => {
+    const { host } = makeHost();
+    host.skillCommandMap.set('skill-a', 'skill-a');
+    const dispatched: string[] = [];
+    Object.assign(host, {
+      sendNormalUserInput: vi.fn((text: string) => {
+        dispatched.push(`text:${text}`);
+      }),
+      sendSkillActivation: vi.fn((_session: unknown, skillName: string) => {
+        dispatched.push(`skill:${skillName}`);
+      }),
+    });
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+    armDynamicCommandsGate(host, ready);
+
+    dispatchInput(host, 'plain prompt one');
+    dispatchInput(host, '/skill-a second');
+
+    expect(host.sendNormalUserInput).not.toHaveBeenCalled();
+    expect(host.sendSkillActivation).not.toHaveBeenCalled();
+
+    resolveReady();
+    await ready;
+
+    expect(dispatched).toEqual(['text:plain prompt one', 'skill:skill-a']);
   });
 
   it('restores the input when /goal is rejected by the busy gate while streaming', async () => {

--- a/apps/kimi-code/test/tui/utils/dynamic-commands-gate.test.ts
+++ b/apps/kimi-code/test/tui/utils/dynamic-commands-gate.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DYNAMIC_COMMANDS_READY_TIMEOUT_MS } from '#/tui/constant/kimi-tui';
+import { createDynamicCommandsGate } from '#/tui/utils/dynamic-commands-gate';
+
+describe('createDynamicCommandsGate', () => {
+  it('clears the gate with a warning when the catalog load does not settle in time', async () => {
+    vi.useFakeTimers();
+    try {
+      const onTimeout = vi.fn();
+      let resolveLoad!: () => void;
+      const load = new Promise<void>((resolve) => {
+        resolveLoad = resolve;
+      });
+      const ready = createDynamicCommandsGate(load, onTimeout);
+
+      await vi.advanceTimersByTimeAsync(DYNAMIC_COMMANDS_READY_TIMEOUT_MS);
+
+      expect(onTimeout).toHaveBeenCalledWith(
+        'Skill and plugin catalogs are still loading — slash commands may be incomplete for a moment.',
+      );
+      await ready;
+
+      // A load that settles after the timeout still resolves quietly — the
+      // warning fires once.
+      resolveLoad();
+      await ready;
+      expect(onTimeout).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resolves without warning when the load settles before the timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const onTimeout = vi.fn();
+      let resolveLoad!: () => void;
+      const load = new Promise<void>((resolve) => {
+        resolveLoad = resolve;
+      });
+      const ready = createDynamicCommandsGate(load, onTimeout);
+
+      resolveLoad();
+      await ready;
+      await vi.advanceTimersByTimeAsync(DYNAMIC_COMMANDS_READY_TIMEOUT_MS * 2);
+
+      expect(onTimeout).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resolves even when the load rejects, so queued drains are never dropped', async () => {
+    const ready = createDynamicCommandsGate(Promise.reject(new Error('wedged IPC')), vi.fn());
+    await expect(ready).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Related Issue

No tracking issue — internal fix from a CI/harness race analysis: slash commands submitted right after TUI startup could be mis-dispatched as plain user prompts when the async skill/plugin catalog had not finished loading.

## Problem

At TUI startup, `refreshSkillCommands` / `refreshPluginCommands` load the dynamic command catalog asynchronously (nothing blocks the UI), while `dispatchInput` reads `skillCommandMap` synchronously. A submission arriving before the catalog settles (a ~230ms window in the harness, unbounded under CPU saturation) is treated as unknown slash text and sent to the model as a plain user prompt — the skill activation is silently lost. Fast typists hit the same race.

## What changed

- `dispatchInput` defers every submission while `dynamicCommandsReady` is pending; queued drains re-dispatch in submission order once the gate clears, so global input ordering is preserved. The ready path is byte-identical to before.
- `KimiTUI.refreshDynamicCommands` arms the gate over the combined skill+plugin refresh via `createDynamicCommandsGate`: the gate is infallible (load success or failure both resolve it, so queued input can never be dropped by a rejection) and carries a 10s fallback — on timeout the gate clears and a warning is shown (`Skill and plugin catalogs are still loading — slash commands may be incomplete for a moment.`), so a wedged catalog load (e.g. stuck IPC) can never block input forever. A load that settles after the timeout still applies its results.
- Both startup paths (`finishStartup`, post-login bootstrap in `auth-flow`) arm the gate through `refreshDynamicCommands`; mid-session refreshes keep calling the individual methods since the maps are already populated.
- Tests: dispatch-level integration in `goal.test.ts` (defers while pending, FIFO drain order, plain-text ordering relative to slash submissions) and gate unit tests in `dynamic-commands-gate.test.ts` (timeout warning fires once, settle-before-timeout stays quiet, load rejection still resolves the gate).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (no tracking issue; problem described above from a harness/CI race analysis).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (changeset included: `@moonshot-ai/kimi-code` patch)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (internal timing fix, no user-facing behavior change beyond the fix itself)
