### PR TITLE
fix(agent-core-v2): track session index mirror give-up event once per failure episode

### DIFF
--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexMirrorService.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexMirrorService.ts
@@ -37,6 +37,7 @@ export class SessionIndexMirror extends Disposable implements ISessionIndexMirro
   private readonly timer = this._register(new IntervalTimer({ unref: true }));
   private flushing: Promise<void> | undefined;
   private consecutiveFailures = 0;
+  private giveUpTracked = false;
   private disposed = false;
   private overflowLogged = false;
 
@@ -169,6 +170,7 @@ export class SessionIndexMirror extends Disposable implements ISessionIndexMirro
         if (this.pendingMap.get(id) === summary) this.pendingMap.delete(id);
       }
       this.consecutiveFailures = 0;
+      this.giveUpTracked = false;
     } catch (error) {
       this.consecutiveFailures += 1;
       this.log.warn('failed to flush session index mirror chunk', {
@@ -180,7 +182,8 @@ export class SessionIndexMirror extends Disposable implements ISessionIndexMirro
         this.log.warn('session index mirror giving up until the next record; reconciliation will heal', {
           pending: this.pendingMap.size,
         });
-        if (this.consecutiveFailures === MAX_CONSECUTIVE_FAILURES) {
+        if (!this.giveUpTracked) {
+          this.giveUpTracked = true;
           this.telemetry.track2('session_index_mirror_give_up', {
             pending_count: this.pendingMap.size,
             consecutive_failures: this.consecutiveFailures,

--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexMirrorService.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexMirrorService.ts
@@ -180,10 +180,12 @@ export class SessionIndexMirror extends Disposable implements ISessionIndexMirro
         this.log.warn('session index mirror giving up until the next record; reconciliation will heal', {
           pending: this.pendingMap.size,
         });
-        this.telemetry.track2('session_index_mirror_give_up', {
-          pending_count: this.pendingMap.size,
-          consecutive_failures: this.consecutiveFailures,
-        });
+        if (this.consecutiveFailures === MAX_CONSECUTIVE_FAILURES) {
+          this.telemetry.track2('session_index_mirror_give_up', {
+            pending_count: this.pendingMap.size,
+            consecutive_failures: this.consecutiveFailures,
+          });
+        }
       }
     }
   }

--- a/packages/agent-core-v2/test/app/sessionIndex/sessionIndexMirror.test.ts
+++ b/packages/agent-core-v2/test/app/sessionIndex/sessionIndexMirror.test.ts
@@ -247,4 +247,25 @@ describe('SessionIndexMirror', () => {
     for (let i = 0; i < 6; i++) await mirror.drain();
     expect(giveUps()).toHaveLength(2);
   });
+
+  it('tracks the give-up event when unpublished flushes precede a throwing one', async () => {
+    const records: TelemetryRecord[] = [];
+    build(true, recordingTelemetry(records));
+
+    mirror.record(summary('a'));
+    for (let i = 0; i < 5; i++) await mirror.drain();
+    expect(records).toEqual([]);
+
+    await publishGeneration();
+    queryStore.batch = async () => {
+      throw new Error('injected flush failure');
+    };
+    for (let i = 0; i < 3; i++) await mirror.drain();
+    const giveUps = records.filter((record) => record.event === 'session_index_mirror_give_up');
+    expect(giveUps).toHaveLength(1);
+    expect(giveUps[0]?.properties).toMatchObject({
+      pending_count: 1,
+      consecutive_failures: 6,
+    });
+  });
 });

--- a/packages/agent-core-v2/test/app/sessionIndex/sessionIndexMirror.test.ts
+++ b/packages/agent-core-v2/test/app/sessionIndex/sessionIndexMirror.test.ts
@@ -31,6 +31,7 @@ import { IQueryStore } from '#/persistence/interface/queryStore';
 
 import { stubBootstrap } from '../bootstrap/stubs';
 import { stubFlag } from '../flag/stubs';
+import { recordingTelemetry, type TelemetryRecord } from '../telemetry/stubs';
 import { stubLog } from '../../_base/log/stubs';
 
 const WORKSPACE = 'wd_test';
@@ -84,12 +85,15 @@ describe('SessionIndexMirror', () => {
     await queryStore.setCheckpoint(SESSION_INDEX_MANIFEST, { seq: GENERATION });
   }
 
-  function build(flagEnabled = true): ISessionIndexMirror {
+  function build(
+    flagEnabled = true,
+    telemetry: ITelemetryService = noopTelemetryService,
+  ): ISessionIndexMirror {
     const host = createScopedTestHost([
       stubPair(IBootstrapService, stubBootstrap(homeDir)),
       stubPair(ILogService, stubLog()),
       stubPair(IFlagService, stubFlag(flagEnabled)),
-      stubPair(ITelemetryService, noopTelemetryService),
+      stubPair(ITelemetryService, telemetry),
     ]);
     disposeHost = () => {
       host.dispose();
@@ -210,5 +214,37 @@ describe('SessionIndexMirror', () => {
     expect(await queryStore.get(sessionCollection(GENERATION), 'a')).toMatchObject({
       id: 'a',
     });
+  });
+
+  it('tracks the give-up event once per consecutive failure episode', async () => {
+    const records: TelemetryRecord[] = [];
+    build(true, recordingTelemetry(records));
+    await publishGeneration();
+
+    const realBatch = queryStore.batch.bind(queryStore);
+    queryStore.batch = async () => {
+      throw new Error('injected flush failure');
+    };
+    const giveUps = (): TelemetryRecord[] =>
+      records.filter((record) => record.event === 'session_index_mirror_give_up');
+
+    mirror.record(summary('a'));
+    for (let i = 0; i < 8; i++) await mirror.drain();
+    expect(giveUps()).toHaveLength(1);
+    expect(giveUps()[0]?.properties).toMatchObject({
+      pending_count: 1,
+      consecutive_failures: 5,
+    });
+
+    queryStore.batch = realBatch;
+    await mirror.drain();
+    expect(mirror.pending()).toEqual([]);
+
+    queryStore.batch = async () => {
+      throw new Error('injected flush failure');
+    };
+    mirror.record(summary('a', { updatedAt: 9 }));
+    for (let i = 0; i < 6; i++) await mirror.drain();
+    expect(giveUps()).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Related Issue

N/A — internal telemetry fix reported via the data platform (no tracking issue).

## Problem

The `session_index_mirror_give_up` telemetry event was designed as a low-frequency signal: the session index mirror stops retrying after 5 consecutive write failures and reports once. In production it stormed instead — on 09-02 the event fired 662k times from only 5 hot sessions (max 359k from a single session, with `consecutive_failures` counting past 340k).

Root cause: once the consecutive failure count crossed the threshold, **every** subsequent failed flush re-emitted the event, and every incoming `record()` re-armed the 100ms flush timer, so an active session with a persistently failing mirror emitted the event at up to 10/s for hours.

## What changed

`SessionIndexMirror.flushChunk()` now emits `session_index_mirror_give_up` only when the consecutive failure count exactly crosses `MAX_CONSECUTIVE_FAILURES` — once per failure episode. The counter still resets on the next successful flush, so a later episode reports again. No other behavior changes: the warn logs, the retry gating, and the event schema are untouched.

Adds a test covering both directions: 8 consecutive failed flushes produce exactly one event (with `consecutive_failures: 5`), and after a successful flush a new failure episode produces a second event.

Follow-ups intentionally left out of this PR: real post-give-up backoff (the warn logs still repeat on every failed flush), the read-path re-`record()` amplifier in `getFromReadModel`, and `remove()` not maintaining workspace counters.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
