### PR TITLE
fix(kimi-code): honor KIMI_DISABLE_TELEMETRY and restore crash telemetry in v2 print mode

### DIFF
--- a/.changeset/print-mode-telemetry-disable-env.md
+++ b/.changeset/print-mode-telemetry-disable-env.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix print mode (`kimi -p`) ignoring the `KIMI_DISABLE_TELEMETRY` environment variable.

--- a/apps/kimi-code/src/cli/v2/run-v2-print.ts
+++ b/apps/kimi-code/src/cli/v2/run-v2-print.ts
@@ -56,7 +56,18 @@ import {
   type PrintBackgroundMode,
   type Scope,
 } from '@moonshot-ai/agent-core-v2';
-import { createKimiDefaultHeaders, createKimiDeviceId } from '@moonshot-ai/kimi-code-oauth';
+import {
+  createKimiDefaultHeaders,
+  createKimiDeviceId,
+  KIMI_CODE_PROVIDER_NAME,
+} from '@moonshot-ai/kimi-code-oauth';
+import {
+  initializeTelemetry,
+  setCrashPhase,
+  setTelemetryContext,
+  shouldEnableTelemetry,
+  shutdownTelemetry,
+} from '@moonshot-ai/kimi-telemetry';
 import type { GoalUpdated } from '@moonshot-ai/agent-core-v2/features/goal/goalOps';
 import type { TurnEnded } from '@moonshot-ai/agent-core-v2/agent/loop/turnOps';
 import type {
@@ -78,6 +89,7 @@ import {
   CLI_USER_AGENT_PRODUCT,
   PROMPT_CLEANUP_TIMEOUT_MS,
 } from '#/constant/app';
+import { currentKimiProfile } from '#/utils/region';
 
 import {
   formatGoalSummaryText,
@@ -169,12 +181,13 @@ export async function runV2Print(
   // user left unset are filled, in the memory layer.
   await applyPrintModeConfigDefaults(configService);
   const defaultModel = configService.get<string>('defaultModel') ?? undefined;
-  let telemetryEnabled = true;
+  let configTelemetryEnabled = true;
   try {
-    telemetryEnabled = configService.get('telemetry') !== false;
+    configTelemetryEnabled = configService.get('telemetry') !== false;
   } catch {
-    telemetryEnabled = true;
+    configTelemetryEnabled = true;
   }
+  const telemetryEnabled = shouldEnableTelemetry({ enabled: configTelemetryEnabled });
   for (const diagnostic of configService.diagnostics()) {
     if (diagnostic.severity === 'warning') {
       stderr.write(`Warning: ${diagnostic.message}\n`);
@@ -188,12 +201,14 @@ export async function runV2Print(
   const cleanup = async (): Promise<void> => {
     const pending = (cleanupPromise ??= (async () => {
       removeTerminationCleanup?.();
+      setCrashPhase('shutdown');
       try {
         await restorePermission();
       } finally {
         if (telemetryService !== undefined) {
           await raceWithTimeout(telemetryService.shutdown(), CLI_SHUTDOWN_TIMEOUT_MS);
         }
+        await shutdownTelemetry({ timeoutMs: CLI_SHUTDOWN_TIMEOUT_MS }).catch(() => {});
         app.dispose();
       }
     })());
@@ -206,7 +221,9 @@ export async function runV2Print(
     // `session_load_failed` fire inside create()/resume(), so an appender wired
     // up only after resolveNativeSession() would drop them to the null appender.
     // The model below is the best known up front; a resumed session's real
-    // model is reconciled via setContext once resolved.
+    // model is reconciled via setContext once resolved. The v1 pipeline is
+    // initialized here too: the process-wide crash handlers report through its
+    // default client, so its sink must be attached before the run can crash.
     telemetryService = app.accessor.get(ITelemetryService);
     if (telemetryEnabled) {
       telemetryService.addAppender(
@@ -218,12 +235,27 @@ export async function runV2Print(
           getAccessToken: async () => (await auth.getCachedAccessToken()) ?? null,
         }),
       );
+      // No `first_launch` on the v1 client: the v2 side already tracks it via
+      // `telemetryService.track2` below, so tracking here would double-send.
+      initializeTelemetry({
+        homeDir,
+        deviceId,
+        appName: CLI_USER_AGENT_PRODUCT,
+        version,
+        uiMode: PROMPT_UI_MODE,
+        model: opts.model ?? defaultModel,
+        endpoint: () => currentKimiProfile().telemetryEndpoint,
+        getAccessToken: async () =>
+          (await auth.getCachedAccessToken(KIMI_CODE_PROVIDER_NAME)) ?? null,
+      });
     }
 
     const resolved = await resolveNativeSession(app, opts, workDir, defaultModel, stderr);
     restorePermission = resolved.restorePermission;
 
     telemetryService.setContext({ session_id: resolved.session.id, model: resolved.telemetryModel });
+    setTelemetryContext({ sessionId: resolved.session.id });
+    setCrashPhase('runtime');
     if (firstLaunch) {
       telemetryService.track2('first_launch');
     }

--- a/apps/kimi-code/src/cli/v2/run-v2-print.ts
+++ b/apps/kimi-code/src/cli/v2/run-v2-print.ts
@@ -65,6 +65,7 @@ import {
   initializeTelemetry,
   setCrashPhase,
   setTelemetryContext,
+  setTelemetryModel,
   shouldEnableTelemetry,
   shutdownTelemetry,
 } from '@moonshot-ai/kimi-telemetry';
@@ -221,9 +222,10 @@ export async function runV2Print(
     // `session_load_failed` fire inside create()/resume(), so an appender wired
     // up only after resolveNativeSession() would drop them to the null appender.
     // The model below is the best known up front; a resumed session's real
-    // model is reconciled via setContext once resolved. The v1 pipeline is
-    // initialized here too: the process-wide crash handlers report through its
-    // default client, so its sink must be attached before the run can crash.
+    // model is reconciled once resolved (v2 via setContext, v1 via
+    // setTelemetryModel). The v1 pipeline is initialized here too: the
+    // process-wide crash handlers report through its default client, so its
+    // sink must be attached before the run can crash.
     telemetryService = app.accessor.get(ITelemetryService);
     if (telemetryEnabled) {
       telemetryService.addAppender(
@@ -255,6 +257,7 @@ export async function runV2Print(
 
     telemetryService.setContext({ session_id: resolved.session.id, model: resolved.telemetryModel });
     setTelemetryContext({ sessionId: resolved.session.id });
+    setTelemetryModel(resolved.telemetryModel);
     setCrashPhase('runtime');
     if (firstLaunch) {
       telemetryService.track2('first_launch');

--- a/apps/kimi-code/test/cli/v2-run-print.test.ts
+++ b/apps/kimi-code/test/cli/v2-run-print.test.ts
@@ -41,6 +41,7 @@ const mocks = vi.hoisted(() => ({
   initializeTelemetry: vi.fn(),
   setCrashPhase: vi.fn(),
   setTelemetryContext: vi.fn(),
+  setTelemetryModel: vi.fn(),
   shutdownTelemetry: vi.fn(async () => {}),
 }));
 
@@ -82,6 +83,7 @@ vi.mock('@moonshot-ai/kimi-telemetry', async (importOriginal) => {
     initializeTelemetry: mocks.initializeTelemetry,
     setCrashPhase: mocks.setCrashPhase,
     setTelemetryContext: mocks.setTelemetryContext,
+    setTelemetryModel: mocks.setTelemetryModel,
     shutdownTelemetry: mocks.shutdownTelemetry,
     track: vi.fn(),
     withTelemetryContext: vi.fn(() => ({ track: vi.fn() })),
@@ -570,12 +572,45 @@ describe('runV2Print', () => {
       getAccessToken: expect.any(Function),
     });
     // The resolved session id is synced onto the v1 client so crash events and
-    // system metrics carry it.
+    // system metrics carry it; the sink model is reconciled too (same value
+    // here, since the fresh session uses the configured default).
     expect(mocks.setTelemetryContext).toHaveBeenCalledWith({ sessionId: 'ses_v2' });
+    expect(mocks.setTelemetryModel).toHaveBeenCalledWith('k2');
     expect(mocks.setCrashPhase).toHaveBeenCalledWith('runtime');
     expect(mocks.setCrashPhase).toHaveBeenCalledWith('shutdown');
     expect(mocks.shutdownTelemetry).toHaveBeenCalledWith({
       timeoutMs: CLI_SHUTDOWN_TIMEOUT_MS,
     });
+  });
+
+  it('reconciles the v1 sink model with the resumed session model', async () => {
+    const stdout = writer();
+    const stderr = writer();
+    const { app, appServices, agentServices } = makeFakeHarness();
+
+    // The resumed session's stored model differs from the configured default.
+    const profile = agentServices.get(IAgentProfileService) as { getModel: () => string };
+    profile.getModel = () => 'resumed-model';
+    const index = appServices.get(ISessionIndex) as { get: ReturnType<typeof vi.fn> };
+    index.get.mockResolvedValue({ id: 'ses_1', cwd: process.cwd() });
+
+    mocks.bootstrap.mockReturnValue({ app });
+    mocks.ensureMainAgent.mockResolvedValue({ agentId: 'main', generation: 1 });
+
+    await runV2Print(opts({ session: 'ses_1' }) as never, '1.2.3-test', { stdout, stderr });
+
+    // The v1 pipeline was initialized up front with the best-known model, so
+    // crash events during session resolution still reach a sink...
+    expect(mocks.initializeTelemetry).toHaveBeenCalledTimes(1);
+    expect(mocks.initializeTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'k2' }),
+    );
+    // ...and the sink's model was reconciled to the resumed session's real
+    // model only after the session resolved.
+    expect(mocks.setTelemetryModel).toHaveBeenCalledWith('resumed-model');
+    const initOrder = mocks.initializeTelemetry.mock.invocationCallOrder[0];
+    const reconcileOrder = mocks.setTelemetryModel.mock.invocationCallOrder[0];
+    expect(initOrder).toBeDefined();
+    expect(reconcileOrder).toBeGreaterThan(initOrder!);
   });
 });

--- a/apps/kimi-code/test/cli/v2-run-print.test.ts
+++ b/apps/kimi-code/test/cli/v2-run-print.test.ts
@@ -23,9 +23,12 @@ import {
   ISessionManager,
   ITelemetryService,
   makeAgentScopeContext,
+  resolveKimiHome,
   type BootstrapInput,
   type Event2,
 } from '@moonshot-ai/agent-core-v2';
+
+import { CLI_SHUTDOWN_TIMEOUT_MS, CLI_USER_AGENT_PRODUCT } from '#/constant/app';
 
 import { runV2Print } from '../../src/cli/v2/run-v2-print';
 
@@ -35,6 +38,10 @@ const mocks = vi.hoisted(() => ({
   createKimiDefaultHeaders: vi.fn(() => ({})),
   resolveKimiHome: vi.fn((homeDir?: string) => homeDir ?? '/tmp/kimi-code-test-home'),
   createKimiDeviceId: vi.fn(() => 'device-1'),
+  initializeTelemetry: vi.fn(),
+  setCrashPhase: vi.fn(),
+  setTelemetryContext: vi.fn(),
+  shutdownTelemetry: vi.fn(async () => {}),
 }));
 
 vi.mock('@moonshot-ai/agent-core-v2', async (importOriginal) => {
@@ -65,14 +72,21 @@ vi.mock('@moonshot-ai/kimi-code-sdk', async (importOriginal) => {
   };
 });
 
-vi.mock('@moonshot-ai/kimi-telemetry', () => ({
-  initializeTelemetry: vi.fn(),
-  setCrashPhase: vi.fn(),
-  shutdownTelemetry: vi.fn(),
-  track: vi.fn(),
-  setTelemetryContext: vi.fn(),
-  withTelemetryContext: vi.fn(() => ({ track: vi.fn() })),
-}));
+vi.mock('@moonshot-ai/kimi-telemetry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@moonshot-ai/kimi-telemetry')>();
+  return {
+    // Keep the real `shouldEnableTelemetry` so the tests exercise the actual
+    // KIMI_DISABLE_TELEMETRY semantics; only the side-effecting entry points
+    // are stubbed.
+    ...actual,
+    initializeTelemetry: mocks.initializeTelemetry,
+    setCrashPhase: mocks.setCrashPhase,
+    setTelemetryContext: mocks.setTelemetryContext,
+    shutdownTelemetry: mocks.shutdownTelemetry,
+    track: vi.fn(),
+    withTelemetryContext: vi.fn(() => ({ track: vi.fn() })),
+  };
+});
 
 interface FakeScope {
   readonly id: string;
@@ -265,6 +279,9 @@ describe('runV2Print', () => {
   beforeEach(() => {
     vi.stubEnv('KIMI_CODE_EXPERIMENTAL_FLAG', '1');
     vi.stubEnv('KIMI_MODEL_OUTPUT_FORMAT', '');
+    // Pin the telemetry kill-switch to "unset" so the host environment cannot
+    // flip the default telemetry-on path these tests exercise.
+    vi.stubEnv('KIMI_DISABLE_TELEMETRY', '');
   });
 
   afterEach(() => {
@@ -504,5 +521,61 @@ describe('runV2Print', () => {
     };
     expect(profile.bind).not.toHaveBeenCalled();
     expect(profile.setModel).toHaveBeenCalledWith('new-model');
+  });
+
+  it('honors KIMI_DISABLE_TELEMETRY: no cloud appender and no v1 pipeline', async () => {
+    vi.stubEnv('KIMI_DISABLE_TELEMETRY', '1');
+    const stdout = writer();
+    const stderr = writer();
+    const { app, appServices } = makeFakeHarness();
+
+    mocks.bootstrap.mockReturnValue({ app });
+    mocks.ensureMainAgent.mockResolvedValue({ agentId: 'main', generation: 1 });
+
+    await runV2Print(opts() as never, '1.2.3-test', { stdout, stderr });
+
+    const telemetry = appServices.get(ITelemetryService) as {
+      addAppender: ReturnType<typeof vi.fn>;
+    };
+    expect(telemetry.addAppender).not.toHaveBeenCalled();
+    expect(mocks.initializeTelemetry).not.toHaveBeenCalled();
+    // The run itself is unaffected: the prompt still renders and cleanup runs.
+    expect(stdout.text()).toContain('hello world');
+    expect(app.dispose).toHaveBeenCalled();
+  });
+
+  it('initializes the v1 telemetry pipeline alongside the cloud appender', async () => {
+    const stdout = writer();
+    const stderr = writer();
+    const { app, appServices } = makeFakeHarness();
+
+    mocks.bootstrap.mockReturnValue({ app });
+    mocks.ensureMainAgent.mockResolvedValue({ agentId: 'main', generation: 1 });
+
+    await runV2Print(opts() as never, '1.2.3-test', { stdout, stderr });
+
+    const telemetry = appServices.get(ITelemetryService) as {
+      addAppender: ReturnType<typeof vi.fn>;
+    };
+    expect(telemetry.addAppender).toHaveBeenCalledTimes(1);
+    expect(mocks.initializeTelemetry).toHaveBeenCalledTimes(1);
+    expect(mocks.initializeTelemetry).toHaveBeenCalledWith({
+      homeDir: resolveKimiHome(),
+      deviceId: 'device-1',
+      appName: CLI_USER_AGENT_PRODUCT,
+      version: '1.2.3-test',
+      uiMode: 'print',
+      model: 'k2',
+      endpoint: expect.any(Function),
+      getAccessToken: expect.any(Function),
+    });
+    // The resolved session id is synced onto the v1 client so crash events and
+    // system metrics carry it.
+    expect(mocks.setTelemetryContext).toHaveBeenCalledWith({ sessionId: 'ses_v2' });
+    expect(mocks.setCrashPhase).toHaveBeenCalledWith('runtime');
+    expect(mocks.setCrashPhase).toHaveBeenCalledWith('shutdown');
+    expect(mocks.shutdownTelemetry).toHaveBeenCalledWith({
+      timeoutMs: CLI_SHUTDOWN_TIMEOUT_MS,
+    });
   });
 });

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,5 +1,6 @@
 import {
   flushSync,
+  getSink,
   setContext,
   shutdown,
   track as trackEvent,
@@ -14,6 +15,17 @@ export function track(event: string, properties: TelemetryPropertiesType = {}): 
 
 export function setTelemetryContext(patch: TelemetryContextIds): void {
   setContext(patch);
+}
+
+/**
+ * Reconcile the attached sink's model after the real session model is known
+ * (e.g. a resumed session whose stored model differs from the configured
+ * default). Applies to events accepted after the call; a no-op when undefined
+ * or when no sink is attached (telemetry disabled or not yet initialized).
+ */
+export function setTelemetryModel(model: string | undefined): void {
+  if (model === undefined) return;
+  getSink()?.setModel(model);
 }
 
 export function withTelemetryContext(patch: TelemetryContextIds): TelemetryClient {

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -30,7 +30,7 @@ export async function shutdownTelemetry(
   await shutdown(options);
 }
 
-export { initializeTelemetry } from './bootstrap';
+export { initializeTelemetry, shouldEnableTelemetry } from './bootstrap';
 export type { TelemetryBootstrapOptions } from './bootstrap';
 
 export { installCrashHandlers, setCrashPhase } from './crash';

--- a/packages/telemetry/src/sink.ts
+++ b/packages/telemetry/src/sink.ts
@@ -55,6 +55,10 @@ export class EventSink {
     }
   }
 
+  setModel(model: string): void {
+    setPrimitive(this.context, 'model', model);
+  }
+
   startPeriodicFlush(): void {
     if (this.flushTimer !== null) return;
     this.flushTimer = setInterval(() => {

--- a/packages/telemetry/test/telemetry.test.ts
+++ b/packages/telemetry/test/telemetry.test.ts
@@ -7,7 +7,13 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { flushTelemetrySync, initializeTelemetry, shutdownTelemetry, track } from '../src';
+import {
+  flushTelemetrySync,
+  initializeTelemetry,
+  setTelemetryModel,
+  shutdownTelemetry,
+  track,
+} from '../src';
 import { isTelemetryDisabledByEnv } from '../src/bootstrap';
 import { TelemetryClient, resetDefaultTelemetryClientForTests } from '../src/client';
 import { installCrashHandlersForClient, setCrashPhase, uninstallCrashHandlers } from '../src/crash';
@@ -403,6 +409,27 @@ describe('EventSink', () => {
     await sink.retryDiskEvents();
 
     expect(transport.retryCount).toBe(1);
+  });
+
+  it('applies a reconciled model only to events accepted after setModel', () => {
+    const transport = new RecordingTransport();
+    const sink = makeSink(transport);
+    const event = (id: string): TelemetryEvent => ({
+      event_id: id,
+      device_id: 'dev',
+      session_id: 'ses',
+      event: 'test',
+      timestamp: 1,
+      properties: {},
+    });
+
+    sink.accept(event('e1'));
+    sink.setModel('reconciled-model');
+    sink.accept(event('e2'));
+    sink.flushSync();
+
+    expect(transport.saved[0]?.[0]?.context).toMatchObject({ model: 'kimi-k2' });
+    expect(transport.saved[0]?.[1]?.context).toMatchObject({ model: 'reconciled-model' });
   });
 });
 
@@ -888,6 +915,36 @@ describe('telemetry bootstrap', () => {
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(fetchImpl.mock.calls[0]?.[0]).toBe('https://mock.test/events');
+  });
+
+  it('reconciles the singleton sink model for subsequently tracked events', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', fetchImpl);
+
+    initializeTelemetry({
+      homeDir: await tempHome(),
+      deviceId: 'dev',
+      appName: 'kimi-code-cli',
+      version: '1.2.3',
+      model: 'model-a',
+    });
+    track('first');
+    setTelemetryModel('model-b');
+    track('second');
+    // An unresolved (undefined) model leaves the sink untouched.
+    setTelemetryModel(undefined);
+    track('third');
+    await shutdownTelemetry();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const init = requestInitFrom(fetchImpl);
+    const payload = JSON.parse(init.body as string) as {
+      events: Array<{ event: string; context_model?: string }>;
+    };
+    const byEvent = new Map(payload.events.map((event) => [event.event, event]));
+    expect(byEvent.get('kfc_first')?.context_model).toBe('model-a');
+    expect(byEvent.get('kfc_second')?.context_model).toBe('model-b');
+    expect(byEvent.get('kfc_third')?.context_model).toBe('model-b');
   });
 
   it('flushes the singleton synchronously to disk fallback', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue — found during an internal telemetry code audit.

## Problem

The default `kimi -p` path (v2 print runner) had two telemetry gaps:

1. It ignored the `KIMI_DISABLE_TELEMETRY` environment variable: `run-v2-print.ts` only consulted the `telemetry` config key, while the v1 print path and kap-server also honor the env var — three entry points, two behaviors.
2. Crash telemetry was silently lost: `main.ts` installs the process-wide crash handlers on the v1 default telemetry client, but the v2 print path never initializes that client, so no sink was ever attached. `crash` events sat in the in-memory queue and were dropped when the process exited. `system_metrics` coverage was missing for the same reason.

## What changed

- The v2 print runner now computes the telemetry switch with the shared `shouldEnableTelemetry` helper (config `telemetry` key **and** `KIMI_DISABLE_TELEMETRY`), exported from the `@moonshot-ai/kimi-telemetry` entry.
- When telemetry is enabled, the v2 print runner also initializes the v1 telemetry pipeline with the same parameters as `initializeCliTelemetry`, so the process-wide crash handlers and the system-metrics collector work in v2 print mode. `first_launch` is deliberately tracked only on the v2 side to avoid double-sending; crash phase transitions (`runtime` / `shutdown`) and the v1 pipeline shutdown during cleanup now mirror the v1 print path.
- Tests: the env-var case asserts neither the cloud appender nor the v1 pipeline is initialized; the default case asserts the v1 init parameters, session context sync, crash phases, and shutdown.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
