### PR TITLE
fix(telemetry): deduplicate session_started and model switch events

### DIFF
--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -804,9 +804,9 @@ export async function applyExperimentalFeatureChanges(
     host.refreshSlashCommandAutocomplete();
     host.restoreEditor();
     if (host.session !== undefined) {
-      await host.session.reloadSession();
+      const reloadedSession = await host.harness.reloadSession({ id: host.session.id });
       await host.reloadCurrentSessionView(
-        host.session,
+        reloadedSession,
         'Experimental features updated. Session reloaded.',
       );
     } else {

--- a/apps/kimi-code/src/tui/commands/provider.ts
+++ b/apps/kimi-code/src/tui/commands/provider.ts
@@ -306,23 +306,33 @@ export async function setDefaultModel(
     effort,
     model === undefined ? undefined : effectiveModelForHost(host, model),
   );
-  const hadSession = host.session !== undefined;
+  if (host.session === undefined && host.engineV2) {
+    // A first prompt may still be inside lazy creation: wait it out so the
+    // pick lands on the new session instead of racing its assembly (same
+    // coordination as the /model path).
+    await host.waitForLazyCreation();
+  }
   await host.harness.setConfig({
     defaultModel: alias,
     thinking,
   });
-  await host.authFlow.refreshConfigAfterLogin();
+  // Whether activation reached an already-live session (the engine tracks
+  // model_switch from setModel there). Recorded at activation time rather
+  // than snapshotted at entry: a lazy session can come live while the config
+  // writes above are pending, while a session created BY activation (v1)
+  // does not count — creation binds the model without an engine event.
+  let activatedLiveSession = await host.authFlow.refreshConfigAfterLogin();
   // refreshConfigAfterLogin reactivates from the persisted config, so a pick
   // the gate keeps session-only never reaches the runtime — apply it after
   // the refresh, or the persisted value would clobber it.
   if (thinking.effort === undefined && effort !== 'off' && effort !== 'on') {
-    await host.authFlow.activateModelAfterLogin(alias, effort);
+    activatedLiveSession =
+      (await host.authFlow.activateModelAfterLogin(alias, effort)) || activatedLiveSession;
   }
-  // With a live session the engine already tracks model_switch from setModel
-  // (via activateModelAfterLogin); without one the engine never sees the pick
-  // (v2 defers creation to the first prompt, v1 binds the model on creation
-  // without an event), so the TUI stays the sole producer for that path.
-  if (!hadSession) {
+  // Without a live session the engine never sees the pick (v2 defers creation
+  // to the first prompt, v1 binds the model on creation without an event), so
+  // the TUI stays the sole producer for that path.
+  if (!activatedLiveSession) {
     host.track('model_switch', { model: alias });
   }
   host.showStatus(`Default model set to ${alias} with thinking ${effort}.`);

--- a/apps/kimi-code/src/tui/commands/provider.ts
+++ b/apps/kimi-code/src/tui/commands/provider.ts
@@ -306,6 +306,7 @@ export async function setDefaultModel(
     effort,
     model === undefined ? undefined : effectiveModelForHost(host, model),
   );
+  const hadSession = host.session !== undefined;
   await host.harness.setConfig({
     defaultModel: alias,
     thinking,
@@ -317,7 +318,13 @@ export async function setDefaultModel(
   if (thinking.effort === undefined && effort !== 'off' && effort !== 'on') {
     await host.authFlow.activateModelAfterLogin(alias, effort);
   }
-  host.track('model_switch', { model: alias });
+  // With a live session the engine already tracks model_switch from setModel
+  // (via activateModelAfterLogin); without one the engine never sees the pick
+  // (v2 defers creation to the first prompt, v1 binds the model on creation
+  // without an event), so the TUI stays the sole producer for that path.
+  if (!hadSession) {
+    host.track('model_switch', { model: alias });
+  }
   host.showStatus(`Default model set to ${alias} with thinking ${effort}.`);
 }
 

--- a/apps/kimi-code/src/tui/commands/provider.ts
+++ b/apps/kimi-code/src/tui/commands/provider.ts
@@ -316,23 +316,23 @@ export async function setDefaultModel(
     defaultModel: alias,
     thinking,
   });
-  // Whether activation reached an already-live session (the engine tracks
-  // model_switch from setModel there). Recorded at activation time rather
-  // than snapshotted at entry: a lazy session can come live while the config
-  // writes above are pending, while a session created BY activation (v1)
-  // does not count — creation binds the model without an engine event.
-  let activatedLiveSession = await host.authFlow.refreshConfigAfterLogin();
+  // Whether activation made the engine emit model_switch (it reached a live
+  // session AND changed the bound alias — both engines track only an actual
+  // change). Recorded at activation time rather than snapshotted at entry: a
+  // lazy session can come live while the config writes above are pending; a
+  // session created BY activation (v1) or a same-alias rebind does not count
+  // — both bind the model without an engine event.
+  let engineTrackedSwitch = await host.authFlow.refreshConfigAfterLogin();
   // refreshConfigAfterLogin reactivates from the persisted config, so a pick
   // the gate keeps session-only never reaches the runtime — apply it after
   // the refresh, or the persisted value would clobber it.
   if (thinking.effort === undefined && effort !== 'off' && effort !== 'on') {
-    activatedLiveSession =
-      (await host.authFlow.activateModelAfterLogin(alias, effort)) || activatedLiveSession;
+    engineTrackedSwitch =
+      (await host.authFlow.activateModelAfterLogin(alias, effort)) || engineTrackedSwitch;
   }
-  // Without a live session the engine never sees the pick (v2 defers creation
-  // to the first prompt, v1 binds the model on creation without an event), so
-  // the TUI stays the sole producer for that path.
-  if (!activatedLiveSession) {
+  // When the engine never emitted (no live session, or the alias was already
+  // bound), the TUI stays the sole producer for the pick.
+  if (!engineTrackedSwitch) {
     host.track('model_switch', { model: alias });
   }
   host.showStatus(`Default model set to ${alias} with thinking ${effort}.`);

--- a/apps/kimi-code/src/tui/commands/reload.ts
+++ b/apps/kimi-code/src/tui/commands/reload.ts
@@ -21,8 +21,11 @@ export async function handleReloadCommand(host: SlashCommandHost): Promise<void>
   const session = host.session;
 
   if (session !== undefined) {
-    await session.reloadSession({ forcePluginSessionStartReminder: true });
-    await host.reloadCurrentSessionView(session, 'Session reloaded.');
+    const reloadedSession = await host.harness.reloadSession({
+      id: session.id,
+      forcePluginSessionStartReminder: true,
+    });
+    await host.reloadCurrentSessionView(reloadedSession, 'Session reloaded.');
   }
 
   const config = await host.harness.getConfig({ reload: true });

--- a/apps/kimi-code/src/tui/controllers/auth-flow.ts
+++ b/apps/kimi-code/src/tui/controllers/auth-flow.ts
@@ -75,14 +75,22 @@ export class AuthFlowController {
     this.host.setStartupReady();
   }
 
-  async activateModelAfterLogin(model: string, effort?: string): Promise<void> {
+  /**
+   * Apply a model pick to the runtime. Returns whether the pick reached an
+   * already-live session: the engine tracks `model_switch` from `setModel`
+   * there, while the session-less paths produce no engine event (v2 defers
+   * creation to the first prompt; v1 binds the model at creation without
+   * one), so callers mirroring the engine's telemetry must stay the producer
+   * for exactly the `false` case.
+   */
+  async activateModelAfterLogin(model: string, effort?: string): Promise<boolean> {
     const { host } = this;
     if (host.session !== undefined) {
       await host.session.setModel(model);
       if (effort !== undefined) {
         await host.session.setThinking(effort);
       }
-      return;
+      return true;
     }
 
     if (host.engineV2) {
@@ -96,7 +104,7 @@ export class AuthFlowController {
         patch.lazySessionThinking = effort as ThinkingEffort;
       }
       host.setAppState(patch);
-      return;
+      return false;
     }
 
     const options: MutableCreateSessionOptions = {
@@ -131,9 +139,15 @@ export class AuthFlowController {
     host.updateTerminalTitle();
     void host.refreshSkillCommands(host.session);
     void host.refreshPluginCommands(host.session);
+    return false;
   }
 
-  async refreshConfigAfterLogin(): Promise<void> {
+  /**
+   * Re-read config and reactivate the persisted model after login or a
+   * config-refreshing command. Returns whatever the activation reports (see
+   * {@link activateModelAfterLogin}); `false` when no activation ran.
+   */
+  async refreshConfigAfterLogin(): Promise<boolean> {
     const { host } = this;
     const config = await host.harness.getConfig({ reload: true });
     const availableModels = config.models ?? {};
@@ -148,16 +162,19 @@ export class AuthFlowController {
         await host.hydrateLazyConfigDefaults();
       }
       host.setAppState({ availableModels, availableProviders });
-      return;
+      return false;
     }
 
-    await this.activateModelAfterLogin(defaultModel, thinkingEffortFromConfig(config.thinking));
+    const activated = await this.activateModelAfterLogin(
+      defaultModel,
+      thinkingEffortFromConfig(config.thinking),
+    );
     if (host.session === undefined && host.engineV2) {
       // Session-less v2: also hydrate permission/plan defaults from the
       // refreshed config, same as startup.
       await host.hydrateLazyConfigDefaults();
       host.setAppState({ availableModels, availableProviders });
-      return;
+      return activated;
     }
     const appStatePatch: Partial<AppState> = {
       availableModels,
@@ -166,6 +183,7 @@ export class AuthFlowController {
       maxContextTokens: selected.maxContextSize,
     };
     host.setAppState(appStatePatch);
+    return activated;
   }
 
   async refreshConfigAfterLogout(): Promise<void> {

--- a/apps/kimi-code/src/tui/controllers/auth-flow.ts
+++ b/apps/kimi-code/src/tui/controllers/auth-flow.ts
@@ -76,21 +76,26 @@ export class AuthFlowController {
   }
 
   /**
-   * Apply a model pick to the runtime. Returns whether the pick reached an
-   * already-live session: the engine tracks `model_switch` from `setModel`
-   * there, while the session-less paths produce no engine event (v2 defers
-   * creation to the first prompt; v1 binds the model at creation without
-   * one), so callers mirroring the engine's telemetry must stay the producer
-   * for exactly the `false` case.
+   * Apply a model pick to the runtime. Returns whether the activation made
+   * the engine emit `model_switch` — it reached an already-live session AND
+   * changed the bound alias (both engines track the event only on an actual
+   * alias change). `false` when no live session existed (v2 defers creation
+   * to the first prompt; v1 binds the model at creation without an event) or
+   * the alias was already bound, so callers mirroring the engine's telemetry
+   * must stay the producer for exactly those paths. Thinking-effort changes
+   * are orthogonal: the engine's `thinking_toggle` fires from `setThinking`
+   * regardless of this flag.
    */
   async activateModelAfterLogin(model: string, effort?: string): Promise<boolean> {
     const { host } = this;
     if (host.session !== undefined) {
-      await host.session.setModel(model);
+      const session = host.session;
+      const modelChanged = (await session.getStatus()).model !== model;
+      await session.setModel(model);
       if (effort !== undefined) {
-        await host.session.setThinking(effort);
+        await session.setThinking(effort);
       }
-      return true;
+      return modelChanged;
     }
 
     if (host.engineV2) {

--- a/apps/kimi-code/test/tui/commands/experiments.test.ts
+++ b/apps/kimi-code/test/tui/commands/experiments.test.ts
@@ -42,6 +42,7 @@ function makeHost() {
       getExperimentalFeatures: vi.fn(async () => [
         feature({ enabled: false, source: 'config', configValue: false }),
       ]),
+      reloadSession: vi.fn(async () => session),
     },
     session,
     refreshSlashCommandAutocomplete: vi.fn(),
@@ -56,6 +57,7 @@ function makeHost() {
     harness: {
       setConfig: ReturnType<typeof vi.fn>;
       getExperimentalFeatures: ReturnType<typeof vi.fn>;
+      reloadSession: ReturnType<typeof vi.fn>;
     };
     refreshSlashCommandAutocomplete: ReturnType<typeof vi.fn>;
     reloadCurrentSessionView: ReturnType<typeof vi.fn>;
@@ -88,7 +90,8 @@ describe('experimental feature command handlers', () => {
     expect(isExperimentalFlagEnabled('micro_compaction')).toBe(false);
     expect(host.refreshSlashCommandAutocomplete).toHaveBeenCalled();
     expect(host.restoreEditor).toHaveBeenCalled();
-    expect(host.session.reloadSession).toHaveBeenCalledOnce();
+    expect(host.harness.reloadSession).toHaveBeenCalledWith({ id: host.session.id });
+    expect(host.session.reloadSession).not.toHaveBeenCalled();
     expect(host.reloadCurrentSessionView).toHaveBeenCalledWith(
       host.session,
       'Experimental features updated. Session reloaded.',

--- a/apps/kimi-code/test/tui/commands/provider.test.ts
+++ b/apps/kimi-code/test/tui/commands/provider.test.ts
@@ -13,7 +13,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { SlashCommandHost } from '#/tui/commands';
 import { setDefaultModel } from '#/tui/commands/provider';
 
-function makeHost() {
+function makeHost(options: { withSession?: boolean } = {}) {
   const appState = {
     availableModels: {
       // Declares no efforts; the Anthropic profile inference supplies
@@ -30,6 +30,7 @@ function makeHost() {
   };
   const host = {
     state: { appState },
+    session: options.withSession === true ? ({} as SlashCommandHost['session']) : undefined,
     harness: {
       setConfig: vi.fn(async () => ({})),
     },
@@ -45,6 +46,7 @@ function makeHost() {
       refreshConfigAfterLogin: ReturnType<typeof vi.fn>;
       activateModelAfterLogin: ReturnType<typeof vi.fn>;
     };
+    track: ReturnType<typeof vi.fn>;
   };
   return { host };
 }
@@ -65,6 +67,9 @@ describe('setDefaultModel', () => {
     expect(
       host.authFlow.activateModelAfterLogin.mock.invocationCallOrder[0]!,
     ).toBeGreaterThan(host.authFlow.refreshConfigAfterLogin.mock.invocationCallOrder[0]!);
+    // Without a session the engine never sees the pick, so the TUI stays the
+    // sole model_switch producer.
+    expect(host.track).toHaveBeenCalledWith('model_switch', { model: 'opus' });
   });
 
   it('does not re-apply the effort when the pick persists', async () => {
@@ -89,5 +94,15 @@ describe('setDefaultModel', () => {
       thinking: { enabled: true },
     });
     expect(host.authFlow.activateModelAfterLogin).not.toHaveBeenCalled();
+  });
+
+  it('leaves model_switch to the engine when a session is live', async () => {
+    const { host } = makeHost({ withSession: true });
+
+    await setDefaultModel(host, 'opus', 'high');
+
+    // activateModelAfterLogin routes through session.setModel, which the
+    // engine already tracks — a TUI-side event would double-count the switch.
+    expect(host.track).not.toHaveBeenCalled();
   });
 });

--- a/apps/kimi-code/test/tui/commands/provider.test.ts
+++ b/apps/kimi-code/test/tui/commands/provider.test.ts
@@ -104,26 +104,44 @@ describe('setDefaultModel', () => {
     expect(host.authFlow.activateModelAfterLogin).not.toHaveBeenCalled();
   });
 
-  it('leaves model_switch to the engine when activation reached a live session', async () => {
+  it('leaves model_switch to the engine when activation changed the bound alias', async () => {
     const { host } = makeHost({ refreshReachedLiveSession: true });
 
     await setDefaultModel(host, 'opus', 'high');
 
-    // refreshConfigAfterLogin routed through session.setModel, which the
-    // engine already tracks — a TUI-side event would double-count the switch.
+    // refreshConfigAfterLogin routed through session.setModel with a changed
+    // alias, which the engine already tracks — a TUI-side event would
+    // double-count the switch.
     expect(host.track).not.toHaveBeenCalled();
   });
 
-  it('leaves model_switch to the engine when a lazy session came live mid-flow', async () => {
-    // The codex race: session-less at entry, but the first prompt's lazy
-    // creation completes while setConfig / the refresh are pending, so the
-    // session-only re-apply lands on the now-live session (engine emits).
+  it('leaves model_switch to the engine when a lazy session came live mid-flow and rebounded', async () => {
+    // Session-less at entry, but the first prompt's lazy creation completes
+    // while setConfig / the refresh are pending, so the session-only re-apply
+    // lands on the now-live session and actually switches its alias (engine
+    // emits).
     const { host } = makeHost({ activateReachedLiveSession: true });
 
     await setDefaultModel(host, 'opus', 'xhigh');
 
     expect(host.authFlow.activateModelAfterLogin).toHaveBeenCalledWith('opus', 'xhigh');
     expect(host.track).not.toHaveBeenCalled();
+  });
+
+  it('emits model_switch when a v1-created session only rebinds the same alias', async () => {
+    // v1 session-less + session-only effort: the refresh creates the session
+    // with the picked model (creation emits nothing), then the re-apply
+    // reaches that live session but its setModel is an alias no-op (no engine
+    // event either) — the TUI must stay the producer for the pick.
+    const { host } = makeHost({
+      refreshReachedLiveSession: false,
+      activateReachedLiveSession: false,
+    });
+
+    await setDefaultModel(host, 'opus', 'xhigh');
+
+    expect(host.authFlow.activateModelAfterLogin).toHaveBeenCalledWith('opus', 'xhigh');
+    expect(host.track).toHaveBeenCalledWith('model_switch', { model: 'opus' });
   });
 
   it('waits for an in-flight lazy creation before activating (v2)', async () => {

--- a/apps/kimi-code/test/tui/commands/provider.test.ts
+++ b/apps/kimi-code/test/tui/commands/provider.test.ts
@@ -13,7 +13,13 @@ import { describe, expect, it, vi } from 'vitest';
 import type { SlashCommandHost } from '#/tui/commands';
 import { setDefaultModel } from '#/tui/commands/provider';
 
-function makeHost(options: { withSession?: boolean } = {}) {
+function makeHost(
+  options: {
+    refreshReachedLiveSession?: boolean;
+    activateReachedLiveSession?: boolean;
+    engineV2?: boolean;
+  } = {},
+) {
   const appState = {
     availableModels: {
       // Declares no efforts; the Anthropic profile inference supplies
@@ -30,13 +36,14 @@ function makeHost(options: { withSession?: boolean } = {}) {
   };
   const host = {
     state: { appState },
-    session: options.withSession === true ? ({} as SlashCommandHost['session']) : undefined,
+    engineV2: options.engineV2 === true,
+    waitForLazyCreation: vi.fn(async () => {}),
     harness: {
       setConfig: vi.fn(async () => ({})),
     },
     authFlow: {
-      refreshConfigAfterLogin: vi.fn(async () => {}),
-      activateModelAfterLogin: vi.fn(async () => {}),
+      refreshConfigAfterLogin: vi.fn(async () => options.refreshReachedLiveSession === true),
+      activateModelAfterLogin: vi.fn(async () => options.activateReachedLiveSession === true),
     },
     track: vi.fn(),
     showStatus: vi.fn(),
@@ -46,6 +53,7 @@ function makeHost(options: { withSession?: boolean } = {}) {
       refreshConfigAfterLogin: ReturnType<typeof vi.fn>;
       activateModelAfterLogin: ReturnType<typeof vi.fn>;
     };
+    waitForLazyCreation: ReturnType<typeof vi.fn>;
     track: ReturnType<typeof vi.fn>;
   };
   return { host };
@@ -96,13 +104,36 @@ describe('setDefaultModel', () => {
     expect(host.authFlow.activateModelAfterLogin).not.toHaveBeenCalled();
   });
 
-  it('leaves model_switch to the engine when a session is live', async () => {
-    const { host } = makeHost({ withSession: true });
+  it('leaves model_switch to the engine when activation reached a live session', async () => {
+    const { host } = makeHost({ refreshReachedLiveSession: true });
 
     await setDefaultModel(host, 'opus', 'high');
 
-    // activateModelAfterLogin routes through session.setModel, which the
+    // refreshConfigAfterLogin routed through session.setModel, which the
     // engine already tracks — a TUI-side event would double-count the switch.
     expect(host.track).not.toHaveBeenCalled();
+  });
+
+  it('leaves model_switch to the engine when a lazy session came live mid-flow', async () => {
+    // The codex race: session-less at entry, but the first prompt's lazy
+    // creation completes while setConfig / the refresh are pending, so the
+    // session-only re-apply lands on the now-live session (engine emits).
+    const { host } = makeHost({ activateReachedLiveSession: true });
+
+    await setDefaultModel(host, 'opus', 'xhigh');
+
+    expect(host.authFlow.activateModelAfterLogin).toHaveBeenCalledWith('opus', 'xhigh');
+    expect(host.track).not.toHaveBeenCalled();
+  });
+
+  it('waits for an in-flight lazy creation before activating (v2)', async () => {
+    const { host } = makeHost({ engineV2: true });
+
+    await setDefaultModel(host, 'opus', 'high');
+
+    expect(host.waitForLazyCreation).toHaveBeenCalled();
+    expect(
+      host.waitForLazyCreation.mock.invocationCallOrder[0]!,
+    ).toBeLessThan(host.harness.setConfig.mock.invocationCallOrder[0]!);
   });
 });

--- a/apps/kimi-code/test/tui/commands/reload.test.ts
+++ b/apps/kimi-code/test/tui/commands/reload.test.ts
@@ -78,9 +78,11 @@ auto_install = false
 
     await handleReloadCommand(host);
 
-    expect(session.reloadSession).toHaveBeenCalledWith({
+    expect(host.harness.reloadSession).toHaveBeenCalledWith({
+      id: session.id,
       forcePluginSessionStartReminder: true,
     });
+    expect(session.reloadSession).not.toHaveBeenCalled();
     expect(host.reloadCurrentSessionView).toHaveBeenCalledWith(
       session,
       'Session reloaded.',
@@ -205,6 +207,7 @@ function makeHost({
     state,
     session,
     harness: {
+      reloadSession: vi.fn(async () => session),
       getConfig: vi.fn(async () => ({
         models: {
           fresh: { provider: 'test', model: 'fresh-model', maxContextSize: 1000 },
@@ -227,6 +230,7 @@ function makeHost({
     showStatus: vi.fn(),
   } as unknown as SlashCommandHost & {
     readonly harness: {
+      readonly reloadSession: ReturnType<typeof vi.fn>;
       readonly getConfig: ReturnType<typeof vi.fn>;
       readonly getExperimentalFeatures: ReturnType<typeof vi.fn>;
     };

--- a/apps/kimi-code/test/tui/controllers/auth-flow.test.ts
+++ b/apps/kimi-code/test/tui/controllers/auth-flow.test.ts
@@ -10,6 +10,7 @@ function makeHost(
     engineV2?: boolean;
     withSession?: boolean;
     defaultModel?: string;
+    boundModel?: string;
   } = {},
 ) {
   const appState = {
@@ -23,6 +24,7 @@ function makeHost(
     options.withSession === true
       ? {
           id: 'ses-live',
+          getStatus: vi.fn(async () => ({ model: options.boundModel ?? 'old-model' })),
           setModel: vi.fn(async () => ({ model: 'k2', providerName: 'managed' })),
           setThinking: vi.fn(async () => {}),
         }
@@ -66,39 +68,53 @@ function makeHost(
 }
 
 describe('activateModelAfterLogin', () => {
-  it('applies through setModel and reports a live session when one exists', async () => {
+  it('reports an engine-tracked switch when the pick changes the bound alias', async () => {
     const { host, session } = makeHost({ withSession: true });
     const authFlow = new AuthFlowController(host);
 
-    const reachedLiveSession = await authFlow.activateModelAfterLogin('k2', 'high');
+    const engineTrackedSwitch = await authFlow.activateModelAfterLogin('k2', 'high');
 
-    expect(reachedLiveSession).toBe(true);
+    expect(engineTrackedSwitch).toBe(true);
     expect(session!.setModel).toHaveBeenCalledWith('k2');
     expect(session!.setThinking).toHaveBeenCalledWith('high');
   });
 
-  it('only patches app state and reports no live session on the session-less v2 path', async () => {
+  it('reports no engine switch when the live session already binds the alias', async () => {
+    const { host, session } = makeHost({ withSession: true, boundModel: 'k2' });
+    const authFlow = new AuthFlowController(host);
+
+    // setModel is an alias no-op here, so neither engine emits model_switch —
+    // callers must stay the producer. The effort still goes through
+    // setThinking, whose thinking_toggle is the engine's own event.
+    const engineTrackedSwitch = await authFlow.activateModelAfterLogin('k2', 'high');
+
+    expect(engineTrackedSwitch).toBe(false);
+    expect(session!.setModel).toHaveBeenCalledWith('k2');
+    expect(session!.setThinking).toHaveBeenCalledWith('high');
+  });
+
+  it('only patches app state and reports no engine switch on the session-less v2 path', async () => {
     const { host, appState } = makeHost({ engineV2: true });
     const authFlow = new AuthFlowController(host);
 
-    const reachedLiveSession = await authFlow.activateModelAfterLogin('k2', 'high');
+    const engineTrackedSwitch = await authFlow.activateModelAfterLogin('k2', 'high');
 
-    expect(reachedLiveSession).toBe(false);
+    expect(engineTrackedSwitch).toBe(false);
     expect(host.harness.createSession).not.toHaveBeenCalled();
     expect(appState.model).toBe('k2');
     expect(appState).toMatchObject({ lazySessionThinking: 'high' });
   });
 
-  it('creates the session on the session-less v1 path and still reports no live session', async () => {
+  it('creates the session on the session-less v1 path and still reports no engine switch', async () => {
     const { host } = makeHost();
     const authFlow = new AuthFlowController(host);
 
     // The v1 creation binds the model without an engine model_switch event,
-    // so callers must treat this path as "no live session reached" even
-    // though host.session is defined afterwards.
-    const reachedLiveSession = await authFlow.activateModelAfterLogin('k2', 'high');
+    // so callers must treat this path as "no engine switch" even though
+    // host.session is defined afterwards.
+    const engineTrackedSwitch = await authFlow.activateModelAfterLogin('k2', 'high');
 
-    expect(reachedLiveSession).toBe(false);
+    expect(engineTrackedSwitch).toBe(false);
     expect(host.harness.createSession).toHaveBeenCalledWith(
       expect.objectContaining({ model: 'k2', thinking: 'high' }),
     );
@@ -111,9 +127,9 @@ describe('refreshConfigAfterLogin', () => {
     const { host } = makeHost({ withSession: true });
     const authFlow = new AuthFlowController(host);
 
-    const reachedLiveSession = await authFlow.refreshConfigAfterLogin();
+    const engineTrackedSwitch = await authFlow.refreshConfigAfterLogin();
 
-    expect(reachedLiveSession).toBe(false);
+    expect(engineTrackedSwitch).toBe(false);
   });
 
   it('propagates the activation result for the persisted default model', async () => {

--- a/apps/kimi-code/test/tui/controllers/auth-flow.test.ts
+++ b/apps/kimi-code/test/tui/controllers/auth-flow.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  AuthFlowController,
+  type AuthFlowHost,
+} from '#/tui/controllers/auth-flow';
+
+function makeHost(
+  options: {
+    engineV2?: boolean;
+    withSession?: boolean;
+    defaultModel?: string;
+  } = {},
+) {
+  const appState = {
+    workDir: '/tmp/work',
+    additionalDirs: [] as string[],
+    planMode: false,
+    model: 'old-model',
+    thinkingEffort: 'off',
+  };
+  const session =
+    options.withSession === true
+      ? {
+          id: 'ses-live',
+          setModel: vi.fn(async () => ({ model: 'k2', providerName: 'managed' })),
+          setThinking: vi.fn(async () => {}),
+        }
+      : undefined;
+  const host = {
+    state: { appState },
+    session,
+    engineV2: options.engineV2 === true,
+    harness: {
+      createSession: vi.fn(async () => ({ id: 'ses-new', summary: { title: null } })),
+      getConfig: vi.fn(async () => ({
+        defaultModel: options.defaultModel,
+        models: { k2: { provider: 'managed:kimi-code', model: 'kimi-k2', maxContextSize: 200_000 } },
+        providers: {},
+      })),
+    },
+    options: { startup: {} },
+    setAppState: vi.fn((patch: Record<string, unknown>) => Object.assign(appState, patch)),
+    setStartupReady: vi.fn(),
+    resetSessionRuntime: vi.fn(),
+    setSession: vi.fn(async (next: unknown) => {
+      (host as { session: unknown }).session = next;
+    }),
+    syncRuntimeState: vi.fn(async () => {}),
+    appendStartupNotice: vi.fn(),
+    hydrateLazyConfigDefaults: vi.fn(async () => {}),
+    sessionEventHandler: { startSubscription: vi.fn() },
+    fetchSessions: vi.fn(async () => {}),
+    updateTerminalTitle: vi.fn(),
+    refreshSkillCommands: vi.fn(async () => {}),
+    refreshPluginCommands: vi.fn(async () => {}),
+  } as unknown as AuthFlowHost & {
+    session: unknown;
+    harness: {
+      createSession: ReturnType<typeof vi.fn>;
+      getConfig: ReturnType<typeof vi.fn>;
+    };
+    setAppState: ReturnType<typeof vi.fn>;
+  };
+  return { host, appState, session };
+}
+
+describe('activateModelAfterLogin', () => {
+  it('applies through setModel and reports a live session when one exists', async () => {
+    const { host, session } = makeHost({ withSession: true });
+    const authFlow = new AuthFlowController(host);
+
+    const reachedLiveSession = await authFlow.activateModelAfterLogin('k2', 'high');
+
+    expect(reachedLiveSession).toBe(true);
+    expect(session!.setModel).toHaveBeenCalledWith('k2');
+    expect(session!.setThinking).toHaveBeenCalledWith('high');
+  });
+
+  it('only patches app state and reports no live session on the session-less v2 path', async () => {
+    const { host, appState } = makeHost({ engineV2: true });
+    const authFlow = new AuthFlowController(host);
+
+    const reachedLiveSession = await authFlow.activateModelAfterLogin('k2', 'high');
+
+    expect(reachedLiveSession).toBe(false);
+    expect(host.harness.createSession).not.toHaveBeenCalled();
+    expect(appState.model).toBe('k2');
+    expect(appState).toMatchObject({ lazySessionThinking: 'high' });
+  });
+
+  it('creates the session on the session-less v1 path and still reports no live session', async () => {
+    const { host } = makeHost();
+    const authFlow = new AuthFlowController(host);
+
+    // The v1 creation binds the model without an engine model_switch event,
+    // so callers must treat this path as "no live session reached" even
+    // though host.session is defined afterwards.
+    const reachedLiveSession = await authFlow.activateModelAfterLogin('k2', 'high');
+
+    expect(reachedLiveSession).toBe(false);
+    expect(host.harness.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'k2', thinking: 'high' }),
+    );
+    expect(host.session).toMatchObject({ id: 'ses-new' });
+  });
+});
+
+describe('refreshConfigAfterLogin', () => {
+  it('reports false without activating when no default model is configured', async () => {
+    const { host } = makeHost({ withSession: true });
+    const authFlow = new AuthFlowController(host);
+
+    const reachedLiveSession = await authFlow.refreshConfigAfterLogin();
+
+    expect(reachedLiveSession).toBe(false);
+  });
+
+  it('propagates the activation result for the persisted default model', async () => {
+    const live = makeHost({ withSession: true, defaultModel: 'k2' });
+    const reachedLive = await new AuthFlowController(live.host).refreshConfigAfterLogin();
+    expect(reachedLive).toBe(true);
+    expect(live.session!.setModel).toHaveBeenCalledWith('k2');
+
+    const lazy = makeHost({ engineV2: true, defaultModel: 'k2' });
+    const reachedLazy = await new AuthFlowController(lazy.host).refreshConfigAfterLogin();
+    expect(reachedLazy).toBe(false);
+    expect(lazy.host.harness.createSession).not.toHaveBeenCalled();
+  });
+});

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -301,6 +301,7 @@ function makeHarness(session = makeSession(), overrides: Record<string, unknown>
     createSession: vi.fn(async () => session),
     resumeSession: vi.fn(async () => session),
     forkSession: vi.fn(async () => session),
+    reloadSession: vi.fn(async () => session),
     listSessions: vi.fn(async () => []),
     exportSession: vi.fn(async () => ({
       zipPath: '/tmp/fake-session.zip',
@@ -2113,11 +2114,15 @@ command = "vim"
     driver.handleUserInput('/reload');
 
     await vi.waitFor(() => {
-      expect(session.reloadSession).toHaveBeenCalledOnce();
+      expect(harness.reloadSession).toHaveBeenCalledWith({
+        id: session.id,
+        forcePluginSessionStartReminder: true,
+      });
     });
     await vi.waitFor(() => {
       expect(driver.state.appState.theme).toBe('light');
     });
+    expect(session.reloadSession).not.toHaveBeenCalled();
     expect(harness.track).toHaveBeenCalledWith('input_command', { command: 'reload' });
     const transcript = stripSgr(renderTranscript(driver));
     expect(transcript).toContain('hello before reload');

--- a/packages/node-sdk/src/kimi-harness.ts
+++ b/packages/node-sdk/src/kimi-harness.ts
@@ -650,8 +650,8 @@ export class KimiHarness {
       // caller-supplied sessionStartedProperties that happen to share a key.
       // `client_id` is always null here: a single-process host has no
       // per-connection client id (that concept only exists for daemon clients,
-      // see core-impl.ts). Kept as an explicit key so both producers share the
-      // same session_started schema.
+      // see core-impl.ts). Kept as an explicit key so this row carries the
+      // same client-attribution shape as the daemon-client producer there.
       client_id: null,
       client_name: this.identity?.productName ?? null,
       client_version: this.identity?.version ?? null,

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -544,25 +544,39 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
    * the host keeps owning the client's lifecycle (flush / shutdown stay with
    * the host, matching the v1 core's arrangement).
    *
-   * The engine's own `session_started` is dropped here: `KimiHarness` emits
-   * that event for every session it opens (create / resume / reload / fork)
-   * with the richer client-attribution schema, so forwarding the engine's
-   * `{resumed, experimental_flags}` copy double-counted every open. Hosts
-   * without a harness (run-v2-print, kap-server) wire their own appenders and
-   * still get the engine's row.
+   * The engine's own `session_started` is forwarded unless
+   * {@link suppressEngineSessionStarted} was called — see its doc for why the
+   * harness-assembled client drops that row.
    */
   private installEngineTelemetry(client: TelemetryClient | undefined): void {
     if (client === undefined) return;
     const telemetry = this.app.accessor.get(ITelemetryService);
     telemetry.addAppender({
       track: (record) => {
-        if (record.event === 'session_started') return;
+        if (this.engineSessionStartedSuppressed && record.event === 'session_started') return;
         client.track(record.event, record.properties);
       },
     });
     void this.configReady.then(() => {
       telemetry.setEnabled(this.engineAccessor.get(IConfigService).get('telemetry') !== false);
     });
+  }
+
+  private engineSessionStartedSuppressed = false;
+
+  /**
+   * Drop the engine's own `session_started` from telemetry forwarding. Called
+   * by `createKimiHarnessV2` at assembly time: the harness emits that event
+   * for every session it opens (create / resume / reload / fork) with the
+   * richer client-attribution schema, so the engine's
+   * `{resumed, experimental_flags}` copy would double-count every open.
+   * Direct `SDKRpcClientV2` consumers never call this and keep the engine row
+   * — it is their only `session_started` producer. Hosts without a harness
+   * (run-v2-print, kap-server) wire their own appenders and are unaffected
+   * either way.
+   */
+  suppressEngineSessionStarted(): void {
+    this.engineSessionStartedSuppressed = true;
   }
 
   /**
@@ -2717,6 +2731,11 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
 
 export function createKimiHarnessV2(options: KimiHarnessOptions): KimiHarness {
   const rpc = new SDKRpcClientV2(options);
+  // The harness below emits session_started for every session it opens with
+  // the richer client-attribution schema; drop the engine's thinner copy from
+  // forwarding so each open is counted once. Direct SDKRpcClientV2 consumers
+  // keep the engine row.
+  rpc.suppressEngineSessionStarted();
   return new KimiHarness(rpc, {
     identity: rpc.identity,
     uiMode: options.uiMode,

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -543,12 +543,20 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
    * section gates engine events the same way the v2 print runner gates them;
    * the host keeps owning the client's lifecycle (flush / shutdown stay with
    * the host, matching the v1 core's arrangement).
+   *
+   * The engine's own `session_started` is dropped here: `KimiHarness` emits
+   * that event for every session it opens (create / resume / reload / fork)
+   * with the richer client-attribution schema, so forwarding the engine's
+   * `{resumed, experimental_flags}` copy double-counted every open. Hosts
+   * without a harness (run-v2-print, kap-server) wire their own appenders and
+   * still get the engine's row.
    */
   private installEngineTelemetry(client: TelemetryClient | undefined): void {
     if (client === undefined) return;
     const telemetry = this.app.accessor.get(ITelemetryService);
     telemetry.addAppender({
       track: (record) => {
+        if (record.event === 'session_started') return;
         client.track(record.event, record.properties);
       },
     });

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -1358,7 +1358,7 @@ describe('SDKRpcClientV2 engine telemetry', () => {
     }
   });
 
-  it('reports the same enabled experimental flags on every session_started row', async () => {
+  it('emits session_started once per open, with the harness schema and enabled experimental flags', async () => {
     const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-tel-flags-'));
     tempDirs.push(homeDir);
     const workDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-tel-flags-work-'));
@@ -1372,16 +1372,34 @@ describe('SDKRpcClientV2 engine telemetry', () => {
     });
     try {
       const session = await harness.createSession({ workDir });
+      // The harness row is the sole producer: the forwarding appender drops
+      // the engine's own session_started, or every open would double-count.
       const started = records.filter((record) => record.event === 'session_started');
-      expect(started.length).toBeGreaterThanOrEqual(2);
+      expect(started).toHaveLength(1);
+      expect(started[0]).toMatchObject({
+        sessionId: session.id,
+        properties: {
+          client_name: 'kimi-code-cli',
+          client_version: '0.0.0-test',
+          ui_mode: 'shell',
+          resumed: false,
+        },
+      });
       for (const record of started) {
         const flags = String(record.properties?.['experimental_flags'] ?? '').split(',');
         expect(flags).toContain('subagent_fork');
         expect(flags).toContain('wait_for');
       }
-      const distinct = new Set(started.map((record) => record.properties?.['experimental_flags']));
-      expect(distinct.size).toBe(1);
       await session.close();
+      await harness.resumeSession({ id: session.id });
+      const afterResume = records.filter((record) => record.event === 'session_started');
+      expect(afterResume).toHaveLength(2);
+      expect(afterResume[1]).toMatchObject({
+        sessionId: session.id,
+        properties: { resumed: true },
+      });
+      const distinct = new Set(afterResume.map((record) => record.properties?.['experimental_flags']));
+      expect(distinct.size).toBe(1);
     } finally {
       await harness.close();
     }

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -1404,6 +1404,34 @@ describe('SDKRpcClientV2 engine telemetry', () => {
       await harness.close();
     }
   });
+
+  it('keeps forwarding the engine session_started to a direct SDKRpcClientV2 consumer', async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-tel-direct-'));
+    tempDirs.push(homeDir);
+    const workDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-tel-direct-work-'));
+    tempDirs.push(workDir);
+    const records: TelemetryRecord[] = [];
+    const client = new SDKRpcClientV2({
+      homeDir,
+      identity: TEST_IDENTITY,
+      telemetry: recordingTelemetry(records),
+    });
+    try {
+      // No harness wraps this client, so nothing else emits session_started —
+      // the engine's own row must survive forwarding.
+      const summary = await client.createSession({ workDir });
+      const started = records.filter((record) => record.event === 'session_started');
+      expect(started).toHaveLength(1);
+      expect(started[0]).toMatchObject({ properties: { resumed: false } });
+      await client.closeSession({ sessionId: summary.id });
+      await client.resumeSession({ id: summary.id });
+      const afterResume = records.filter((record) => record.event === 'session_started');
+      expect(afterResume).toHaveLength(2);
+      expect(afterResume[1]).toMatchObject({ properties: { resumed: true } });
+    } finally {
+      await client.close();
+    }
+  });
 });
 
 describe('removeProviderFromConfig', () => {


### PR DESCRIPTION
## Related Issue

No linked issue — found during an internal telemetry code audit.

## Problem

Two telemetry events were double-counted:

1. `session_started` in v2 SDK mode: the v2 engine emits `{resumed, experimental_flags}` and the node-sdk harness emits a richer row (`client_id` / `client_name` / `client_version` / `ui_mode` / `resumed` / host properties). Engine events are forwarded into the same sink as the harness events, so every session open produced two rows with conflicting schemas.
2. `model_switch` when switching the default model with a live session: both the engine (v1 and v2) and the TUI emitted it. The TUI also emitted it even when the alias did not actually change — a phantom event.

## What changed

- The v2 SDK engine-telemetry forwarder (`installEngineTelemetry`) drops the engine's `session_started`. The harness stays the producer for SDK hosts (its schema is a superset), and the engine stays the producer for harness-less hosts (the v2 print runner and kap-server wire their own appenders and are unaffected). The stale harness comment claiming both producers share one schema is corrected.
- `setDefaultModel` in the TUI now tracks `model_switch` only when there is no live session — the one path the engine cannot see (v2 defers session creation to the first prompt; v1 binds the model on creation without an event). With a live session the engine is the sole producer, and an unchanged alias no longer produces a phantom event.
- Kept, deliberately: the `model_switch` / `thinking_toggle` tracks in `commands/config.ts` only fire on the no-session path, where the engine never sees the change — removing them would lose those events.
- Behavior note: reload paths (`/reload`, config reload) in v2 mode no longer produce `session_started`. This aligns v2 with v1, where reload never emitted it (the dedicated `session_reload` event covers it).
- Tests: the SDK forwarder test now asserts exactly one `session_started` per open (create → 1, close + resume → 2 with `resumed: true`); the provider command test covers the live-session vs no-session split.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
