### PR TITLE
fix(agent-core-v2): tolerate stray files in the sessions directory during index scans

### DIFF
--- a/.changeset/stray-files-session-index.md
+++ b/.changeset/stray-files-session-index.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix sessions not loading in the resume picker when stray files sit inside the sessions directory.

--- a/packages/agent-core-v2/src/persistence/backends/node-fs/fileStorageService.ts
+++ b/packages/agent-core-v2/src/persistence/backends/node-fs/fileStorageService.ts
@@ -20,8 +20,9 @@ const WATCH_DEBOUNCE_MS = 150;
 const TORN_READ_RETRIES = 3;
 const TORN_READ_RETRY_DELAY_MS = 15;
 
-function isEnoent(error: unknown): boolean {
-  return (error as NodeJS.ErrnoException).code === 'ENOENT';
+function isMissingEntry(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === 'ENOENT' || code === 'ENOTDIR';
 }
 
 export class FileStorageService implements IFileSystemStorageService {
@@ -42,7 +43,7 @@ export class FileStorageService implements IFileSystemStorageService {
       try {
         bytes = await readFile(filePath);
       } catch (error) {
-        if (isEnoent(error)) return undefined;
+        if (isMissingEntry(error)) return undefined;
         throw toStorageIoError(error, { path: filePath, op: 'read' });
       }
       if (attempt >= TORN_READ_RETRIES) return bytes;
@@ -72,7 +73,7 @@ export class FileStorageService implements IFileSystemStorageService {
         yield chunk as Uint8Array;
       }
     } catch (error) {
-      if (isEnoent(error)) return;
+      if (isMissingEntry(error)) return;
       throw toStorageIoError(error, { path: filePath, op: 'read' });
     }
   }
@@ -144,7 +145,7 @@ export class FileStorageService implements IFileSystemStorageService {
     try {
       entries = await readdir(this.scopePath(scope));
     } catch (error) {
-      if (isEnoent(error)) return [];
+      if (isMissingEntry(error)) return [];
       throw toStorageIoError(error, { path: this.scopePath(scope), op: 'list' });
     }
     return prefix === undefined ? entries : entries.filter((entry) => entry.startsWith(prefix));
@@ -155,7 +156,7 @@ export class FileStorageService implements IFileSystemStorageService {
     try {
       await unlink(filePath);
     } catch (error) {
-      if (isEnoent(error)) return;
+      if (isMissingEntry(error)) return;
       throw toStorageIoError(error, { path: filePath, op: 'delete' });
     }
   }
@@ -165,7 +166,7 @@ export class FileStorageService implements IFileSystemStorageService {
     try {
       return (await stat(filePath)).size;
     } catch (error) {
-      if (isEnoent(error)) return undefined;
+      if (isMissingEntry(error)) return undefined;
       throw toStorageIoError(error, { path: filePath, op: 'stat' });
     }
   }
@@ -175,7 +176,7 @@ export class FileStorageService implements IFileSystemStorageService {
     try {
       return (await stat(filePath)).mtimeMs;
     } catch (error) {
-      if (isEnoent(error)) return undefined;
+      if (isMissingEntry(error)) return undefined;
       throw toStorageIoError(error, { path: filePath, op: 'stat' });
     }
   }
@@ -263,7 +264,7 @@ export class FileStorageService implements IFileSystemStorageService {
       await syncDir(dir);
       this.syncedDirs.add(dir);
     } catch (error) {
-      if (!isEnoent(error)) throw error;
+      if (!isMissingEntry(error)) throw error;
     }
   }
 }

--- a/packages/agent-core-v2/test/persistence/backends/node-fs/fileStorageService.test.ts
+++ b/packages/agent-core-v2/test/persistence/backends/node-fs/fileStorageService.test.ts
@@ -62,6 +62,16 @@ describe('FileStorageService — error translation', () => {
     await expect(svc.delete('scope', 'missing.json')).resolves.toBeUndefined();
   });
 
+  it('treats a regular file in place of a scope directory as missing', async () => {
+    const svc = new FileStorageService(dir);
+    await writeFile(join(dir, 'junk'), 'x');
+    expect(await svc.read('junk', 'state.json')).toBeUndefined();
+    expect(await svc.size('junk', 'state.json')).toBeUndefined();
+    expect(await svc.mtime('junk', 'state.json')).toBeUndefined();
+    expect(await svc.list('junk')).toEqual([]);
+    await expect(svc.delete('junk', 'state.json')).resolves.toBeUndefined();
+  });
+
   it.skipIf(isWin)('translates non-ENOENT failures into StorageError(io_failed)', async () => {
     const svc = new FileStorageService(dir);
     await mkdir(join(dir, 'scope', 'adir'), { recursive: true });


### PR DESCRIPTION
## Related Issue

Resolve #3500

(Filed with this PR; awaiting a maintainer's `/approve`.)

## Problem

On 0.40.x the resume picker (`kimi -r`, `/sessions`) and `kimi session list` list **no sessions at all** when any workspace bucket directory under `~/.kimi-code/sessions/` contains a stray regular file — macOS Finder's `.DS_Store` is the common trigger. The scan added in #3422 stats `<entry>/state.json` for every entry of every bucket directory; for a regular-file entry that fails with `ENOTDIR`, which the node-fs storage translated to `StorageError(io_failed)` ("storage stat failed: unrecognized I/O error"), rejecting the whole scan. Projection, startup freshness checks, periodic reconciliation, and the authoritative fallback read all fail, so fresh processes cannot list any session. Long-running servers degrade into a per-entry-tolerant branch and keep working, which makes the failure look like frontends see different session sets.

## What changed

- **node-fs storage**: `isEnoent` is now `isMissingEntry` and also matches `ENOTDIR`. A regular file in place of a scope directory means the probed key cannot exist, so `read`, `readStream`, `list`, `delete`, `size`, and `mtime` report it as missing instead of throwing. This fits the existing storage contract ("undefined = missing"), heals every session-index scan path through one seam, and matches the in-memory backend, where probing a path below a value already resolves to missing.
- Alternative considered: per-entry catches inside the session-index scans. Rejected — it patches only the session domain while other storage consumers stay fragile, and swallowing arbitrary stat errors there could mask real corruption; the storage layer is where `ENOENT` semantics already live.
- **Test**: regression case covering a regular file in place of a scope directory for all probe operations.
- **Changeset**: patch entry for `@moonshot-ai/kimi-code`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.