### PR TITLE
fix(tree-sitter-bash): recognize heredocs in character-level balanced scanning

### DIFF
--- a/packages/agent-core-v2/src/agent/agentsMdReminder/agentsMdReminderService.ts
+++ b/packages/agent-core-v2/src/agent/agentsMdReminder/agentsMdReminderService.ts
@@ -40,7 +40,7 @@ import { extractBashTargetDirs } from './bashTargets';
 
 const AGENTS_MD_BASENAMES: ReadonlySet<string> = new Set<string>(AGENTS_MD_PLAIN_NAMES);
 
-const BASH_PARSE_OPTIONS = { timeoutMs: 20, maxNodes: 10_000 } as const;
+const BASH_PARSE_OPTIONS = { timeoutMs: 500, maxNodes: 10_000 } as const;
 
 const DISCOVERY_REMINDER_VARIANT = 'agents_md';
 

--- a/packages/agent-core-v2/src/agent/permissionPolicy/policies/dangerous-command-ask.ts
+++ b/packages/agent-core-v2/src/agent/permissionPolicy/policies/dangerous-command-ask.ts
@@ -12,7 +12,7 @@ import type {
   PermissionPolicyResult,
 } from '#/agent/permissionPolicy/types';
 
-const PARSE_OPTIONS = { timeoutMs: 20, maxNodes: 10_000 } as const;
+const PARSE_OPTIONS = { timeoutMs: 500, maxNodes: 10_000 } as const;
 
 const MAX_NESTED_SHELL_DEPTH = 4;
 

--- a/packages/agent-core-v2/test/agent/permissionPolicy/permissionPolicyService.test.ts
+++ b/packages/agent-core-v2/test/agent/permissionPolicy/permissionPolicyService.test.ts
@@ -357,6 +357,18 @@ describe('AgentPermissionPolicyService chain', () => {
     },
   );
 
+  it('approves a heredoc command containing a single quote in yolo mode', async () => {
+    mode = 'yolo';
+
+    await expect(evaluate({
+      toolName: 'Bash',
+      args: { command: 'gh --body "$(cat <<\'EOF\'\nit\'s\nEOF\n)"', timeout: 60 },
+    })).resolves.toMatchObject({
+      policyName: 'yolo-mode-approve',
+      result: { kind: 'approve' },
+    });
+  });
+
   it.each(['$CMD --force', 'bash -c "echo $HOME"', 'env $FLAGS'])(
     'denies unanalyzable command `%s` in auto mode',
     async (command) => {

--- a/packages/tree-sitter-bash/src/lexer.ts
+++ b/packages/tree-sitter-bash/src/lexer.ts
@@ -261,10 +261,12 @@ const CASE_ENABLING_WORDS: ReadonlySet<string> = new Set(['if', 'then', 'elif', 
  * body must not affect the paren count. `((` opens an arithmetic region,
  * skipped as one balanced unit so a left-shift `<<` is not mistaken for a
  * heredoc operator. Comments (`#` at the start of a word, judged by the
- * preceding character) are skipped to end of line, `${ ... }` / `$[ ... ]`
- * expansions and word-glued `[ ... ]` subscripts are skipped as balanced
- * units, so a `<<` inside any of these non-redirection contexts is
- * likewise not mistaken for a heredoc operator.
+ * preceding character after looking through `\`+newline continuations)
+ * are skipped to end of line, `${ ... }` / `$[ ... ]` expansions,
+ * word-glued `[ ... ]` subscripts, and `[[ ... ]]` conditional regions
+ * are skipped as balanced units, so a `<<` inside any of these
+ * non-redirection contexts is likewise not mistaken for a heredoc
+ * operator.
  */
 export function scanBalancedStatements(
   source: string,
@@ -332,7 +334,9 @@ export function scanBalancedStatements(
       continue;
     }
     if (ch === '#') {
-      const prev = j > i ? source[j - 1] : undefined;
+      let p = j - 1;
+      while (p - 1 >= i && source[p] === '\n' && source[p - 1] === '\\') p -= 2;
+      const prev = p >= i ? source[p] : undefined;
       if (prev === undefined || isBlank(prev) || prev === '\n' || prev === ';' || prev === '&' || prev === '|' || prev === '(') {
         while (j < end && source[j] !== '\n') j++;
         continue;
@@ -341,6 +345,11 @@ export function scanBalancedStatements(
     if (ch === '$' && (source[j + 1] === '{' || source[j + 1] === '[')) {
       const open = source[j + 1]!;
       j = scanBalanced(source, budget, j + 1, end, open, open === '{' ? '}' : ']', depth + 1).end;
+      previous = 'word';
+      continue;
+    }
+    if (ch === '[' && source[j + 1] === '[' && previous !== 'word') {
+      j = scanBalanced(source, budget, j, end, '[', ']', depth + 1).end;
       previous = 'word';
       continue;
     }

--- a/packages/tree-sitter-bash/src/lexer.ts
+++ b/packages/tree-sitter-bash/src/lexer.ts
@@ -261,10 +261,10 @@ const CASE_ENABLING_WORDS: ReadonlySet<string> = new Set(['if', 'then', 'elif', 
  * body must not affect the paren count. `((` opens an arithmetic region,
  * skipped as one balanced unit so a left-shift `<<` is not mistaken for a
  * heredoc operator. Comments (`#` at the start of a word, judged by the
- * preceding character) are skipped to end of line, and `${ ... }` /
- * `$[ ... ]` expansions are skipped as balanced units, so a `<<` inside
- * any of these non-redirection contexts is likewise not mistaken for a
- * heredoc operator.
+ * preceding character) are skipped to end of line, `${ ... }` / `$[ ... ]`
+ * expansions and word-glued `[ ... ]` subscripts are skipped as balanced
+ * units, so a `<<` inside any of these non-redirection contexts is
+ * likewise not mistaken for a heredoc operator.
  */
 export function scanBalancedStatements(
   source: string,
@@ -341,6 +341,11 @@ export function scanBalancedStatements(
     if (ch === '$' && (source[j + 1] === '{' || source[j + 1] === '[')) {
       const open = source[j + 1]!;
       j = scanBalanced(source, budget, j + 1, end, open, open === '{' ? '}' : ']', depth + 1).end;
+      previous = 'word';
+      continue;
+    }
+    if (ch === '[' && j > i && isWordChar(source[j - 1])) {
+      j = scanBalanced(source, budget, j, end, '[', ']', depth + 1).end;
       previous = 'word';
       continue;
     }

--- a/packages/tree-sitter-bash/src/lexer.ts
+++ b/packages/tree-sitter-bash/src/lexer.ts
@@ -254,6 +254,13 @@ const CASE_ENABLING_WORDS: ReadonlySet<string> = new Set(['if', 'then', 'elif', 
  * keywords in CASE_ENABLING_WORDS — so `echo case` does not confuse the
  * scan. `esac` pops the innermost open case regardless of position (the
  * reference scanner emits the esac token even in argument position).
+ *
+ * Heredoc-aware: a `<<` / `<<-` operator queues its delimiter word, and the
+ * body lines of every pending heredoc are skipped wholesale right after
+ * the next newline — quotes, parens and substitutions inside a heredoc
+ * body must not affect the paren count. `((` opens an arithmetic region,
+ * skipped as one balanced unit so a left-shift `<<` is not mistaken for a
+ * heredoc operator.
  */
 export function scanBalancedStatements(
   source: string,
@@ -266,6 +273,8 @@ export function scanBalancedStatements(
   let nesting = 0;
   /** Paren depths at which each open case_statement started. */
   const caseDepths: number[] = [];
+  /** Heredoc delimiters queued since the last newline. */
+  const pendingHeredocs: { delimiter: string; stripTabs: boolean }[] = [];
   let j = i;
   /** What preceded the current position: 'start' | 'sep' | 'keyword' | 'word'. */
   let previous: 'start' | 'sep' | 'keyword' | 'word' = 'start';
@@ -299,7 +308,16 @@ export function scanBalancedStatements(
       j++;
       continue;
     }
-    if (ch === '\n' || ch === ';' || ch === '&' || ch === '|') {
+    if (ch === '\n') {
+      j++;
+      if (pendingHeredocs.length > 0) {
+        j = skipHeredocBodies(source, budget, j, end, pendingHeredocs);
+        pendingHeredocs.length = 0;
+      }
+      previous = 'sep';
+      continue;
+    }
+    if (ch === ';' || ch === '&' || ch === '|') {
       previous = 'sep';
       j++;
       continue;
@@ -309,7 +327,25 @@ export function scanBalancedStatements(
       j++;
       continue;
     }
+    if (ch === '<') {
+      const heredoc = scanHeredocDelimiter(source, j, end);
+      if (heredoc !== null) {
+        pendingHeredocs.push(heredoc);
+        j = heredoc.end;
+      } else {
+        j++;
+      }
+      previous = 'word';
+      continue;
+    }
     if (ch === '(') {
+      if (source[j + 1] === '(') {
+        const arith = scanBalanced(source, budget, j, end, '(', ')', depth + 1);
+        if (j === i) return { end: arith.end, balanced: arith.balanced };
+        j = arith.end;
+        previous = 'word';
+        continue;
+      }
       nesting++;
       previous = 'sep';
       j++;
@@ -349,6 +385,127 @@ export function scanBalancedStatements(
     j++;
   }
   return { end, balanced: false };
+}
+
+/** Parse a heredoc operator (`<<` / `<<-`) and its delimiter word, starting
+ *  at `i` (which points at the first `<`). Returns the delimiter with quotes
+ *  and backslashes removed (mirroring the parser's extractHeredocSpec),
+ *  whether `<<-` strips leading tabs, and the index just past the delimiter
+ *  word — or null when this `<` does not open a heredoc with a non-empty
+ *  delimiter (`<<<` herestring, another redirect, or malformed input). */
+function scanHeredocDelimiter(
+  source: string,
+  i: number,
+  end: number,
+): { delimiter: string; stripTabs: boolean; end: number } | null {
+  if (source[i + 1] !== '<') return null;
+  let j = i + 2;
+  if (source[j] === '<') return null;
+  let stripTabs = false;
+  if (source[j] === '-') {
+    stripTabs = true;
+    j++;
+  }
+  while (j < end && (source[j] === ' ' || source[j] === '\t' || source[j] === '\r')) j++;
+  let raw = '';
+  while (j < end) {
+    const ch = source[j]!;
+    if (ch === ' ' || ch === '\t' || ch === '\r' || ch === '\n') break;
+    if (ch === '&' || ch === '|' || ch === ';' || ch === '(' || ch === ')' || ch === '<' || ch === '>') break;
+    if (ch === '\\') {
+      if (j + 1 >= end || source[j + 1] === '\n') return null;
+      raw += ch + source[j + 1];
+      j += 2;
+      continue;
+    }
+    if (ch === "'") {
+      const close = source.indexOf("'", j + 1);
+      if (close === -1 || close >= end) return null;
+      raw += source.slice(j, close + 1);
+      j = close + 1;
+      continue;
+    }
+    if (ch === '"') {
+      let k = j + 1;
+      for (;;) {
+        if (k >= end) return null;
+        if (source[k] === '\\') {
+          k += 2;
+          continue;
+        }
+        if (source[k] === '"') break;
+        k++;
+      }
+      raw += source.slice(j, k + 1);
+      j = k + 1;
+      continue;
+    }
+    raw += ch;
+    j++;
+  }
+  let delimiter = '';
+  for (let k = 0; k < raw.length; k++) {
+    const ch = raw[k]!;
+    if (ch === '\\' && k + 1 < raw.length) {
+      delimiter += raw[k + 1];
+      k++;
+    } else if (ch !== '"' && ch !== "'") {
+      delimiter += ch;
+    }
+  }
+  if (delimiter.length === 0) return null;
+  return { delimiter, stripTabs, end: j };
+}
+
+/** Skip the body lines of each queued heredoc, starting at `i` (just past
+ *  the newline that ended the command line). Bodies are consumed in queue
+ *  order, each up to its delimiter line (`<<-` allows leading tabs before
+ *  the marker), mirroring readHeredocBody; a delimiter directly followed
+ *  by `)` also closes the body — the paren belongs to the enclosing
+ *  substitution and is left for the paren scan. A body whose delimiter
+ *  never appears swallows the rest of the range. */
+function skipHeredocBodies(
+  source: string,
+  budget: ParseBudget,
+  i: number,
+  end: number,
+  specs: readonly { delimiter: string; stripTabs: boolean }[],
+): number {
+  let j = i;
+  for (const spec of specs) {
+    let lineStart = j;
+    let closed = false;
+    while (lineStart < end) {
+      budget.progress();
+      let marker = lineStart;
+      if (spec.stripTabs) {
+        while (marker < end && source[marker] === '\t') marker++;
+      }
+      if (source.startsWith(spec.delimiter, marker)) {
+        const after = marker + spec.delimiter.length;
+        if (after >= end) {
+          j = end;
+          closed = true;
+          break;
+        }
+        if (source[after] === '\n') {
+          j = after + 1;
+          closed = true;
+          break;
+        }
+        if (source[after] === ')') {
+          j = after;
+          closed = true;
+          break;
+        }
+      }
+      const newline = source.indexOf('\n', lineStart);
+      if (newline === -1 || newline >= end) break;
+      lineStart = newline + 1;
+    }
+    if (!closed) return end;
+  }
+  return j;
 }
 
 /** Skip a $-construct starting at `i` (which points at the `$`). Handles

--- a/packages/tree-sitter-bash/src/lexer.ts
+++ b/packages/tree-sitter-bash/src/lexer.ts
@@ -359,7 +359,7 @@ export function scanBalancedStatements(
       continue;
     }
     if (ch === '<') {
-      const heredoc = scanHeredocDelimiter(source, j, end);
+      const heredoc = scanHeredocDelimiter(source, budget, j, end, depth);
       if (heredoc !== null) {
         pendingHeredocs.push(heredoc);
         j = heredoc.end;
@@ -423,11 +423,15 @@ export function scanBalancedStatements(
  *  and backslashes removed (mirroring the parser's extractHeredocSpec),
  *  whether `<<-` strips leading tabs, and the index just past the delimiter
  *  word — or null when this `<` does not open a heredoc with a non-empty
- *  delimiter (`<<<` herestring, another redirect, or malformed input). */
+ *  delimiter (`<<<` herestring, another redirect, or malformed input).
+ *  Substitution syntax inside the delimiter word (`$( )`, `${ }`, `$[ ]`,
+ *  backticks) is scanned wholesale as part of the word. */
 function scanHeredocDelimiter(
   source: string,
+  budget: ParseBudget,
   i: number,
   end: number,
+  depth: number,
 ): { delimiter: string; stripTabs: boolean; end: number } | null {
   if (source[i + 1] !== '<') return null;
   let j = i + 2;
@@ -443,6 +447,24 @@ function scanHeredocDelimiter(
     const ch = source[j]!;
     if (ch === ' ' || ch === '\t' || ch === '\r' || ch === '\n') break;
     if (ch === '&' || ch === '|' || ch === ';' || ch === '(' || ch === ')' || ch === '<' || ch === '>') break;
+    if (ch === '$' && (source[j + 1] === '(' || source[j + 1] === '{' || source[j + 1] === '[')) {
+      const open = source[j + 1]!;
+      const region =
+        open === '('
+          ? scanBalancedStatements(source, budget, j + 1, end, depth + 1)
+          : scanBalanced(source, budget, j + 1, end, open, open === '{' ? '}' : ']', depth + 1);
+      if (!region.balanced) return null;
+      raw += source.slice(j, region.end);
+      j = region.end;
+      continue;
+    }
+    if (ch === '`') {
+      const backtickEnd = skipBacktick(source, budget, j, end);
+      if (backtickEnd >= end) return null;
+      raw += source.slice(j, backtickEnd);
+      j = backtickEnd;
+      continue;
+    }
     if (ch === '\\') {
       if (j + 1 >= end || source[j + 1] === '\n') return null;
       raw += ch + source[j + 1];

--- a/packages/tree-sitter-bash/src/lexer.ts
+++ b/packages/tree-sitter-bash/src/lexer.ts
@@ -260,6 +260,10 @@ const CASE_ENABLING_WORDS: ReadonlySet<string> = new Set(['if', 'then', 'elif', 
  * the next newline — quotes, parens and substitutions inside a heredoc
  * body must not affect the paren count. `((` opens an arithmetic region,
  * skipped as one balanced unit so a left-shift `<<` is not mistaken for a
+ * heredoc operator. Comments (`#` at the start of a word, judged by the
+ * preceding character) are skipped to end of line, and `${ ... }` /
+ * `$[ ... ]` expansions are skipped as balanced units, so a `<<` inside
+ * any of these non-redirection contexts is likewise not mistaken for a
  * heredoc operator.
  */
 export function scanBalancedStatements(
@@ -325,6 +329,19 @@ export function scanBalancedStatements(
     if (ch === '{') {
       previous = 'sep';
       j++;
+      continue;
+    }
+    if (ch === '#') {
+      const prev = j > i ? source[j - 1] : undefined;
+      if (prev === undefined || isBlank(prev) || prev === '\n' || prev === ';' || prev === '&' || prev === '|' || prev === '(') {
+        while (j < end && source[j] !== '\n') j++;
+        continue;
+      }
+    }
+    if (ch === '$' && (source[j + 1] === '{' || source[j + 1] === '[')) {
+      const open = source[j + 1]!;
+      j = scanBalanced(source, budget, j + 1, end, open, open === '{' ? '}' : ']', depth + 1).end;
+      previous = 'word';
       continue;
     }
     if (ch === '<') {

--- a/packages/tree-sitter-bash/test/fixtures/differential/heredoc.txt
+++ b/packages/tree-sitter-bash/test/fixtures/differential/heredoc.txt
@@ -633,4 +633,8 @@ echo "$(cat <<-'EOF'
 ===
 @match: echo $(echo $((x << 2)))
 echo $(echo $((x << 2)))
+echo $(echo $[x << 2]
+)
+echo $(printf x # <<EOF
+)
 ===

--- a/packages/tree-sitter-bash/test/fixtures/differential/heredoc.txt
+++ b/packages/tree-sitter-bash/test/fixtures/differential/heredoc.txt
@@ -637,4 +637,6 @@ echo $(echo $[x << 2]
 )
 echo $(printf x # <<EOF
 )
+echo $( [[ x == @(<<EOF) ]]
+)
 ===

--- a/packages/tree-sitter-bash/test/fixtures/differential/heredoc.txt
+++ b/packages/tree-sitter-bash/test/fixtures/differential/heredoc.txt
@@ -595,3 +595,42 @@ program [0,18] "<<EOF cat\nbody\nEOF"
         heredoc_content [10,15] "body\n"
       heredoc_end [15,18] "EOF"
 ===
+@match: gh --body "$(cat <<'EOF'
+gh --body "$(cat <<'EOF'
+it's
+EOF
+)"
+===
+@match: echo $(cat <<'EOF'
+echo $(cat <<'EOF'
+it's
+EOF
+)
+===
+@match: echo $(cat <<'EOF'
+echo $(cat <<'EOF'
+) paren
+EOF
+)
+===
+@match: cat <(cat <<'EOF'
+cat <(cat <<'EOF'
+it's
+EOF
+)
+===
+@match: echo "$(cat <<'EOF'
+echo "$(cat <<'EOF'
+$(broken
+EOF
+)"
+===
+@match: echo "$(cat <<-'EOF'
+echo "$(cat <<-'EOF'
+	it's
+	EOF
+)"
+===
+@match: echo $(echo $((x << 2)))
+echo $(echo $((x << 2)))
+===

--- a/packages/tree-sitter-bash/test/parser-compound.test.ts
+++ b/packages/tree-sitter-bash/test/parser-compound.test.ts
@@ -819,7 +819,7 @@ describe('heredocs in substitutions', () => {
     );
   });
 
-  it('still treats << inside comments and arithmetic as no heredoc operator', () => {
+  it('still treats << inside comments, arithmetic, and subscripts as no heredoc operator', () => {
     expectTree(
       'echo $(echo $((x << 2)))',
       `(program (command (command_name (word "echo")) (command_substitution "$(" (command (command_name (word "echo")) (arithmetic_expansion "$((" (binary_expression (variable_name "x") "<<" (number "2")) "))")) ")")))`,
@@ -831,6 +831,10 @@ describe('heredocs in substitutions', () => {
     expectTree(
       'echo $(printf x # <<EOF\n)',
       `(program (command (command_name (word "echo")) (command_substitution "$(" (command (command_name (word "printf")) (word "x")) (comment "# <<EOF") ")")))`,
+    );
+    expectTree(
+      'echo $(a[x<<2]=3\n)',
+      `(program (command (command_name (word "echo")) (command_substitution "$(" (variable_assignment (subscript (variable_name "a") "[" (word "x<<2") "]") "=" (number "3")) ")")))`,
     );
   });
 });

--- a/packages/tree-sitter-bash/test/parser-compound.test.ts
+++ b/packages/tree-sitter-bash/test/parser-compound.test.ts
@@ -819,7 +819,7 @@ describe('heredocs in substitutions', () => {
     );
   });
 
-  it('still treats << inside comments, arithmetic, and subscripts as no heredoc operator', () => {
+  it('still treats << inside comments, arithmetic, subscripts, and conditionals as no heredoc operator', () => {
     expectTree(
       'echo $(echo $((x << 2)))',
       `(program (command (command_name (word "echo")) (command_substitution "$(" (command (command_name (word "echo")) (arithmetic_expansion "$((" (binary_expression (variable_name "x") "<<" (number "2")) "))")) ")")))`,
@@ -835,6 +835,14 @@ describe('heredocs in substitutions', () => {
     expectTree(
       'echo $(a[x<<2]=3\n)',
       `(program (command (command_name (word "echo")) (command_substitution "$(" (variable_assignment (subscript (variable_name "a") "[" (word "x<<2") "]") "=" (number "3")) ")")))`,
+    );
+    expectTree(
+      'echo $( [[ x == @(<<EOF) ]]\n)',
+      `(program (command (command_name (word "echo")) (command_substitution "$(" (test_command "[[" (binary_expression (word "x") "==" (extglob_pattern "@(<<EOF)")) "]]") ")")))`,
+    );
+    expectTree(
+      'echo $(printf foo\\\n#bar)',
+      `(program (command (command_name (word "echo")) (command_substitution "$(" (command (command_name (word "printf")) (word "foo")) (comment "#bar") ")")))`,
     );
   });
 });

--- a/packages/tree-sitter-bash/test/parser-compound.test.ts
+++ b/packages/tree-sitter-bash/test/parser-compound.test.ts
@@ -819,7 +819,7 @@ describe('heredocs in substitutions', () => {
     );
   });
 
-  it('still treats << inside comments, arithmetic, subscripts, and conditionals as no heredoc operator', () => {
+  it('handles tricky << contexts inside substitutions (non-redirection contexts and substitution delimiters)', () => {
     expectTree(
       'echo $(echo $((x << 2)))',
       `(program (command (command_name (word "echo")) (command_substitution "$(" (command (command_name (word "echo")) (arithmetic_expansion "$((" (binary_expression (variable_name "x") "<<" (number "2")) "))")) ")")))`,
@@ -839,6 +839,10 @@ describe('heredocs in substitutions', () => {
     expectTree(
       'echo $( [[ x == @(<<EOF) ]]\n)',
       `(program (command (command_name (word "echo")) (command_substitution "$(" (test_command "[[" (binary_expression (word "x") "==" (extglob_pattern "@(<<EOF)")) "]]") ")")))`,
+    );
+    expectTree(
+      'echo $(cat <<$(foo)\nbody\n$(foo)\n)',
+      `(program (command (command_name (word "echo")) (command_substitution "$(" (redirected_statement (command (command_name (word "cat"))) (heredoc_redirect "<<" (heredoc_start "$(foo)") (heredoc_body (heredoc_content "body\\n")) (heredoc_end "$(foo)"))) ")")))`,
     );
     expectTree(
       'echo $(printf foo\\\n#bar)',

--- a/packages/tree-sitter-bash/test/parser-compound.test.ts
+++ b/packages/tree-sitter-bash/test/parser-compound.test.ts
@@ -776,6 +776,57 @@ describe('combinations', () => {
   });
 });
 
+describe('heredocs in substitutions', () => {
+  it('parses a quoted heredoc with a single quote in its body inside "$( )"', () => {
+    expectTree(
+      'echo "$(cat <<\'EOF\'\nit\'s\nEOF\n)"',
+      `(program (command (command_name (word "echo")) (string "\\"" (command_substitution "$(" (redirected_statement (command (command_name (word "cat"))) (heredoc_redirect "<<" (heredoc_start "'EOF'") (heredoc_body "it's\\n") (heredoc_end "EOF"))) ")") "\\"")))`,
+    );
+  });
+
+  it('parses the gh pr create shape that triggered the unanalyzable verdict', () => {
+    expectTree(
+      'gh --body "$(cat <<\'EOF\'\nit\'s\nEOF\n)"',
+      `(program (command (command_name (word "gh")) (word "--body") (string "\\"" (command_substitution "$(" (redirected_statement (command (command_name (word "cat"))) (heredoc_redirect "<<" (heredoc_start "'EOF'") (heredoc_body "it's\\n") (heredoc_end "EOF"))) ")") "\\"")))`,
+    );
+  });
+
+  it('parses a quoted heredoc with a single quote in its body inside bare $( )', () => {
+    expectTree(
+      'echo $(cat <<\'EOF\'\nit\'s\nEOF\n)',
+      `(program (command (command_name (word "echo")) (command_substitution "$(" (redirected_statement (command (command_name (word "cat"))) (heredoc_redirect "<<" (heredoc_start "'EOF'") (heredoc_body "it's\\n") (heredoc_end "EOF"))) ")")))`,
+    );
+  });
+
+  it('parses a heredoc body containing a paren inside $( )', () => {
+    expectTree(
+      'echo $(cat <<EOF\n)a\nEOF\n)',
+      `(program (command (command_name (word "echo")) (command_substitution "$(" (redirected_statement (command (command_name (word "cat"))) (heredoc_redirect "<<" (heredoc_start "EOF") (heredoc_body (heredoc_content ")a\\n")) (heredoc_end "EOF"))) ")")))`,
+    );
+  });
+
+  it('parses a heredoc with a double-quoted body line inside "$( )"', () => {
+    expectTree(
+      'echo "$(cat <<\'EOF\'\nsay "hi"\nEOF\n)"',
+      `(program (command (command_name (word "echo")) (string "\\"" (command_substitution "$(" (redirected_statement (command (command_name (word "cat"))) (heredoc_redirect "<<" (heredoc_start "'EOF'") (heredoc_body "say \\"hi\\"\\n") (heredoc_end "EOF"))) ")") "\\"")))`,
+    );
+  });
+
+  it('parses a heredoc inside a process substitution', () => {
+    expectTree(
+      'cat <(cat <<\'EOF\'\nit\'s\nEOF\n)',
+      `(program (command (command_name (word "cat")) (process_substitution "<(" (redirected_statement (command (command_name (word "cat"))) (heredoc_redirect "<<" (heredoc_start "'EOF'") (heredoc_body "it's\\n") (heredoc_end "EOF"))) ")")))`,
+    );
+  });
+
+  it('still treats << inside $( ) arithmetic as left shift', () => {
+    expectTree(
+      'echo $(echo $((x << 2)))',
+      `(program (command (command_name (word "echo")) (command_substitution "$(" (command (command_name (word "echo")) (arithmetic_expansion "$((" (binary_expression (variable_name "x") "<<" (number "2")) "))")) ")")))`,
+    );
+  });
+});
+
 describe('recovery and adversarial input', () => {
   it('recovers unterminated compound commands without throwing', () => {
     for (const source of [

--- a/packages/tree-sitter-bash/test/parser-compound.test.ts
+++ b/packages/tree-sitter-bash/test/parser-compound.test.ts
@@ -819,10 +819,18 @@ describe('heredocs in substitutions', () => {
     );
   });
 
-  it('still treats << inside $( ) arithmetic as left shift', () => {
+  it('still treats << inside comments and arithmetic as no heredoc operator', () => {
     expectTree(
       'echo $(echo $((x << 2)))',
       `(program (command (command_name (word "echo")) (command_substitution "$(" (command (command_name (word "echo")) (arithmetic_expansion "$((" (binary_expression (variable_name "x") "<<" (number "2")) "))")) ")")))`,
+    );
+    expectTree(
+      'echo $(echo $[x << 2]\n)',
+      `(program (command (command_name (word "echo")) (command_substitution "$(" (command (command_name (word "echo")) (arithmetic_expansion "$[" (binary_expression (variable_name "x") "<<" (number "2")) "]")) ")")))`,
+    );
+    expectTree(
+      'echo $(printf x # <<EOF\n)',
+      `(program (command (command_name (word "echo")) (command_substitution "$(" (command (command_name (word "printf")) (word "x")) (comment "# <<EOF") ")")))`,
     );
   });
 });


### PR DESCRIPTION
## Related Issue

Resolve #3468

## Problem

A command whose heredoc body sits inside a command substitution — e.g. `gh pr create --body "$(cat <<'EOF' ... EOF)"` where the body contains a bare apostrophe such as `it's` — failed to parse: the character-level balanced-paren scanner treated heredoc body text as ordinary characters, so a stray quote, paren, or backtick produced ERROR nodes. `hasError` then made the dangerous-command permission policy judge the whole command unanalyzable, which prompts for approval even in yolo mode.

A related flake: the permission policy and the AGENTS.md reminder parse bash with a 20ms wall-clock budget. Under CPU contention, GC pauses, or cold-start JIT, an otherwise fine parse could be aborted and likewise degrade to "unanalyzable" (a spurious approval prompt, or a silently dropped reminder).

## What changed

- `packages/tree-sitter-bash`: the character-level balanced scanner is now heredoc-aware — it parses `<<` / `<<-` delimiters (excluding `<<<` herestrings) with the same unquoting rules as the token-level heredoc reader, queues pending bodies, and skips them line-wise at newlines; arithmetic `$(( ... ))` regions are skipped as a whole so a left-shift `<<` is never mistaken for a heredoc operator.
- Tests: unit cases for heredocs inside `$( )`, `"$( )"`, and `<( )` (including bodies containing `'`, `)`, `"`), differential `@match` fixtures verified byte-identical against the reference wasm parser, and a permission-policy test proving the original `gh pr create` scenario is auto-approved in yolo mode.
- `packages/agent-core-v2`: raise the bash parse wall-clock budget from 20ms to 500ms for the permission policy and AGENTS.md reminder paths. `maxNodes` stays the deterministic cap; 500ms remains a backstop against pathological parser loops.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
