### PR TITLE
fix(telemetry): drop null values from flattened event payloads

### DIFF
--- a/packages/agent-core-v2/src/app/telemetry/cloudTransport.ts
+++ b/packages/agent-core-v2/src/app/telemetry/cloudTransport.ts
@@ -282,7 +282,9 @@ export function flattenEvent(event: EnrichedCloudEvent): Record<string, CloudPri
       flattenNested(out, 'context', value);
     } else {
       assertPrimitive(key, value);
-      out[key] = value;
+      if (value !== null) {
+        out[key] = value;
+      }
     }
   }
   return out;
@@ -304,7 +306,9 @@ function flattenNested(target: Record<string, CloudPrimitive>, prefix: string, v
   if (value === null || typeof value !== 'object' || Array.isArray(value)) return;
   for (const [key, nestedValue] of Object.entries(value)) {
     assertPrimitive(`${prefix}.${key}`, nestedValue);
-    target[`${prefix}_${key}`] = nestedValue;
+    if (nestedValue !== null) {
+      target[`${prefix}_${key}`] = nestedValue;
+    }
   }
 }
 

--- a/packages/agent-core-v2/test/app/telemetry/cloudAppender.test.ts
+++ b/packages/agent-core-v2/test/app/telemetry/cloudAppender.test.ts
@@ -411,6 +411,29 @@ describe('CloudAppender', () => {
     ).toHaveLength(0);
   });
 
+  it('drops null values from the outbound payload', async () => {
+    const requests: CapturedRequest[] = [];
+    const appender = new CloudAppender(
+      baseOptions({
+        homeDir,
+        deviceId: 'dev123',
+        fetchImpl: makeFetch((req) => {
+          requests.push(req);
+          return okResponse();
+        }),
+      }),
+    );
+
+    appender.track({ event: 'evt', context: {}, properties: { empty: null, keep: 'yes' } });
+    await appender.flush();
+
+    expect(requests).toHaveLength(1);
+    const event = requests[0]?.body.events[0];
+    expect(event?.['property_keep']).toBe('yes');
+    expect(event).not.toHaveProperty('property_empty');
+    expect(event).not.toHaveProperty('session_id');
+  });
+
   it('drops non-primitive properties and reports the violation', async () => {
     const errors: unknown[] = [];
     setUnexpectedErrorHandler((err) => errors.push(err));

--- a/packages/telemetry/src/transport.ts
+++ b/packages/telemetry/src/transport.ts
@@ -265,7 +265,9 @@ export function flattenEvent(event: EnrichedTelemetryEvent): Record<string, Tele
       flattenNested(out, 'context', value);
     } else {
       assertPrimitive(key, value);
-      out[key] = value;
+      if (value !== null) {
+        out[key] = value;
+      }
     }
   }
   return out;
@@ -275,7 +277,9 @@ function flattenNested(target: Record<string, TelemetryPrimitive>, prefix: strin
   if (value === null || typeof value !== 'object' || Array.isArray(value)) return;
   for (const [key, nestedValue] of Object.entries(value)) {
     assertPrimitive(`${prefix}.${key}`, nestedValue);
-    target[`${prefix}_${key}`] = nestedValue;
+    if (nestedValue !== null) {
+      target[`${prefix}_${key}`] = nestedValue;
+    }
   }
 }
 

--- a/packages/telemetry/test/telemetry.test.ts
+++ b/packages/telemetry/test/telemetry.test.ts
@@ -498,10 +498,16 @@ describe('payload assembly', () => {
     expect(() => buildPayload([arrayProperty], 'device-1')).toThrow(/property.list/);
   });
 
-  it('passes null primitive values through and leaves the input event untouched', () => {
+  it('drops null values from the payload and leaves the input event untouched', () => {
     const event = {
       ...sampleEvent('nullable'),
+      device_id: null,
+      session_id: null,
       properties: {
+        empty: null,
+      },
+      context: {
+        version: '1.2.3',
         empty: null,
       },
     };
@@ -512,8 +518,12 @@ describe('payload assembly', () => {
 
     expect(payload.events[0]).toMatchObject({
       event: 'kfc_nullable',
-      property_empty: null,
+      context_version: '1.2.3',
     });
+    expect(payload.events[0]).not.toHaveProperty('device_id');
+    expect(payload.events[0]).not.toHaveProperty('session_id');
+    expect(payload.events[0]).not.toHaveProperty('property_empty');
+    expect(payload.events[0]).not.toHaveProperty('context_empty');
     expect(event.properties).toBe(originalProperties);
     expect(event.context).toBe(originalContext);
     expect(event.event).toBe('nullable');


### PR DESCRIPTION
## Related Issue

No linked issue — found during a telemetry data-quality investigation.

## Problem

DataFinder ingestion validation rejects a large volume of client telemetry events (`kfc_*`, posted to `telemetry-logs.kimi.com`) with "invalid event property data type" errors. The largest root cause: JSON `null` is treated as a legal primitive by both parallel telemetry pipelines and is reported as-is. `undefined` values are silently dropped by `JSON.stringify`, but `null` survives into the payload — both in flattened top-level keys (e.g. `session_id` when no session is bound) and in flattened `property_*` / `context_*` keys.

## What changed

- v1 pipeline (`packages/telemetry/src/transport.ts`): `flattenEvent` / `flattenNested` now skip keys whose value is `null` when building the outbound payload. `undefined` handling is unchanged.
- v2 pipeline (`packages/agent-core-v2/src/app/telemetry/cloudTransport.ts`): the same treatment at the line-equivalent flatten layer.
- Disk retry is unaffected: failed batches are persisted pre-flattening and re-flattened on retry, so retried events get the same null-dropping. In the v2 orchestration layer `undefined` already carries the remove-field semantics, so dropping `null` loses no meaning.
- Tests: the v1 payload-assembly test now asserts null keys (top-level `device_id` / `session_id` and nested `property_*` / `context_*`) are absent from the payload while the input event is not mutated; a new CloudAppender test asserts a null property and an unbound session id never reach the wire. `@moonshot-ai/kimi-telemetry` 74/74, agent-core-v2 telemetry suites 55/55, `check-no-comments` clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
