### PR TITLE
fix(agent-core-v2): deduplicate repeated tool call ids inside the turn machine

### DIFF
--- a/packages/agent-core-v2/docs/state-manifest.d.ts
+++ b/packages/agent-core-v2/docs/state-manifest.d.ts
@@ -1079,6 +1079,7 @@ export interface AgentStateSnapshot {
       name: string;
       arguments: string | null;
       extras?: Record<string, unknown>;
+      rawId?: string;
       _streamIndex?: string | number;
     }[];
     readonly toolCallId?: string;

--- a/packages/agent-core-v2/scripts/check-import-boundaries.mjs
+++ b/packages/agent-core-v2/scripts/check-import-boundaries.mjs
@@ -25,6 +25,7 @@ const HUMAN_VOCABULARY = new Set([
   'llm/response-format',
   'llm/media/upload',
   'llm/requester/requester',
+  'llm/toolCallIdNormalizer',
   'llm-kimi/trait',
 ]);
 

--- a/packages/agent-core-v2/src/agent/llmRequester/llmRequesterService.ts
+++ b/packages/agent-core-v2/src/agent/llmRequester/llmRequesterService.ts
@@ -571,7 +571,7 @@ export class AgentLLMRequesterService implements IAgentLLMRequesterService {
   ): StreamedMessagePart {
     if (!isToolCall(part)) return part;
     const assigned = toolCallIds.remapStreamedId(part.id, part._streamIndex);
-    return assigned === part.id ? part : { ...part, id: assigned };
+    return assigned === part.id ? part : { ...part, id: assigned, rawId: part.rawId ?? part.id };
   }
 
   private warnAboutAnthropicThinkingEffort(request: ResolvedLLMRequest): void {

--- a/packages/agent-core-v2/src/agent/llmRequester/llmRequesterService.ts
+++ b/packages/agent-core-v2/src/agent/llmRequester/llmRequesterService.ts
@@ -67,7 +67,7 @@ import type { LLMRequestTrace } from '#/llm-adapter/contract/request-trace';
 import {
   ToolCallIdNormalizer,
   type ToolCallIdResponseNormalizer,
-} from './toolCallIdNormalizer';
+} from '#human/llm/toolCallIdNormalizer';
 import {
   LlmRequest,
   llmRequestTraceKey,

--- a/packages/agent-core-v2/src/agent/loop/machine/requester.ts
+++ b/packages/agent-core-v2/src/agent/loop/machine/requester.ts
@@ -3,7 +3,6 @@ import type {
   AgentLLMRequestSource,
   IAgentLLMRequesterService,
 } from '#/agent/llmRequester/llmRequester';
-import { ToolCallIdResponseNormalizer } from '#/agent/llmRequester/toolCallIdNormalizer';
 import { unwrapErrorCause } from '#/errors';
 import { llmMessageFromError } from '#/llm-adapter/contract/errors';
 import type { LLMRequestTrace } from '#/llm-adapter/contract/request-trace';
@@ -81,17 +80,9 @@ export function createMachineRequester(
       baseSource?.type === 'turn' && decision.step !== undefined
         ? { ...baseSource, step: decision.step }
         : baseSource;
-    const toolCallIds = new ToolCallIdResponseNormalizer(new Set());
     const task = service.start(
       { source },
-      (part) => {
-        if (part.type !== 'function') {
-          control.onEvent?.({ type: 'llm.delta', part });
-          return;
-        }
-        const id = toolCallIds.remapStreamedId(part.id, part._streamIndex);
-        control.onEvent?.({ type: 'llm.delta', part: id === part.id ? part : { ...part, id } });
-      },
+      (part) => control.onEvent?.({ type: 'llm.delta', part }),
       signal,
     );
     options?.onTrace?.(task.trace);

--- a/packages/agent-core-v2/src/human/agent/turn.ts
+++ b/packages/agent-core-v2/src/human/agent/turn.ts
@@ -16,6 +16,7 @@ import {
 import type { LlmModel } from '#/llm/model';
 import type { createLlmMachine, LlmEvent } from '#/llm/requester/machine';
 import type { LlmRequestConfig } from '#/llm/requester/requester';
+import { ToolCallIdNormalizer } from '#/llm/toolCallIdNormalizer';
 import { emptyUsage, type TokenUsage } from '#/llm/usage';
 import type { ToolResult } from '#/tool/executor';
 import type { ToolOutput } from '#/tool/machine';
@@ -83,7 +84,8 @@ export function toInputMessages(history: readonly HistoryMessage[]): Message[] {
 }
 
 export interface HistoryAccumulator {
-  push(part: StreamedMessagePart): void;
+  push(part: StreamedMessagePart): StreamedMessagePart;
+  rollback(): void;
   pushUsage(usage: Partial<TokenUsage>): void;
   pushHeaders(headers: Record<string, string>): void;
   pushFinish(finish: FinishInfo): void;
@@ -91,14 +93,32 @@ export interface HistoryAccumulator {
   finish(meta?: AssistantMetaInput): AssistantEntry;
 }
 
-export function createHistoryAccumulator(meta?: AssistantMetaInput): HistoryAccumulator {
+export function createHistoryAccumulator(
+  meta?: AssistantMetaInput,
+  toolCallIds?: ToolCallIdNormalizer,
+): HistoryAccumulator {
   const inner = createMessageAccumulator();
+  const response = toolCallIds?.beginResponse();
   let usage: TokenUsage | undefined;
   let headers: Record<string, string> | undefined;
   let finish: FinishInfo | undefined;
   let messageId: string | undefined;
   return {
-    push: (part) => inner.push(part),
+    push: (part) => {
+      if (response !== undefined && part.type === 'function') {
+        const id = response.remapStreamedId(part.id, part._streamIndex);
+        if (id !== part.id) {
+          const remapped = { ...part, id, rawId: part.id };
+          inner.push(remapped);
+          return remapped;
+        }
+      }
+      inner.push(part);
+      return part;
+    },
+    rollback: () => {
+      response?.rollback();
+    },
     pushUsage: (value) => {
       usage = {
         inputOther: value.inputOther ?? usage?.inputOther ?? 0,
@@ -169,6 +189,7 @@ export interface TurnMachineContext {
   input: TurnInput;
   produced: HistoryMessage[];
   accumulator: HistoryAccumulator;
+  toolCallIds: ToolCallIdNormalizer;
   pendingToolCalls: ToolCall[];
   outcomes: Record<string, ToolOutput>;
   steps: number;
@@ -261,19 +282,25 @@ export function createTurnMachine(llmActor: ReturnType<typeof createLlmMachine>)
   }).createMachine({
     id: 'turn',
     initial: 'thinking',
-    context: ({ input }) => ({
-      input,
-      produced: [],
-      accumulator: createHistoryAccumulator(modelMeta(input.request.model)),
-      pendingToolCalls: [],
-      outcomes: {},
-      steps: 0,
-    }),
+    context: ({ input }) => {
+      const toolCallIds = new ToolCallIdNormalizer();
+      toolCallIds.seedFrom(toInputMessages(input.history));
+      return {
+        input,
+        produced: [],
+        accumulator: createHistoryAccumulator(modelMeta(input.request.model), toolCallIds),
+        toolCallIds,
+        pendingToolCalls: [],
+        outcomes: {},
+        steps: 0,
+      };
+    },
     states: {
       thinking: {
         entry: assign({
           steps: ({ context }) => context.steps + 1,
-          accumulator: ({ context }) => createHistoryAccumulator(modelMeta(context.input.request.model)),
+          accumulator: ({ context }) =>
+            createHistoryAccumulator(modelMeta(context.input.request.model), context.toolCallIds),
         }),
         invoke: {
           src: 'llmActor',
@@ -312,27 +339,33 @@ export function createTurnMachine(llmActor: ReturnType<typeof createLlmMachine>)
           },
           'llm.delta': {
             actions: [
-              'forwardToParent',
-              ({ context, event }) => {
-                context.accumulator.push(event.part);
+              ({ context, event, self }) => {
+                const part = context.accumulator.push(event.part);
+                self._parent?.send({ ...event, part });
               },
             ],
           },
           'llm.retrying': {
             actions: [
               'forwardToParent',
+              ({ context }) => {
+                context.accumulator.rollback();
+              },
               assign({
                 accumulator: ({ context }) =>
-                  createHistoryAccumulator(modelMeta(context.input.request.model)),
+                  createHistoryAccumulator(modelMeta(context.input.request.model), context.toolCallIds),
               }),
             ],
           },
           'llm.recovering': {
             actions: [
               'forwardToParent',
+              ({ context }) => {
+                context.accumulator.rollback();
+              },
               assign({
                 accumulator: ({ context }) =>
-                  createHistoryAccumulator(modelMeta(context.input.request.model)),
+                  createHistoryAccumulator(modelMeta(context.input.request.model), context.toolCallIds),
               }),
             ],
           },

--- a/packages/agent-core-v2/src/human/agent/turn.ts
+++ b/packages/agent-core-v2/src/human/agent/turn.ts
@@ -108,7 +108,7 @@ export function createHistoryAccumulator(
       if (response !== undefined && part.type === 'function') {
         const id = response.remapStreamedId(part.id, part._streamIndex);
         if (id !== part.id) {
-          const remapped = { ...part, id, rawId: part.id };
+          const remapped = { ...part, id, rawId: part.rawId ?? part.id };
           inner.push(remapped);
           return remapped;
         }

--- a/packages/agent-core-v2/src/human/llm/message.ts
+++ b/packages/agent-core-v2/src/human/llm/message.ts
@@ -41,6 +41,7 @@ export interface ToolCall {
   name: string;
   arguments: string | null;
   extras?: Record<string, unknown>;
+  rawId?: string;
   _streamIndex?: number | string;
 }
 
@@ -210,6 +211,7 @@ export function createMessageAccumulator(): MessageAccumulator {
         name: pending.name,
         arguments: pending.arguments,
         extras: pending.extras,
+        rawId: pending.rawId,
       });
       if (pending._streamIndex !== undefined) {
         toolCallIndexMap.set(pending._streamIndex, ordinal);

--- a/packages/agent-core-v2/src/human/llm/toolCallIdNormalizer.ts
+++ b/packages/agent-core-v2/src/human/llm/toolCallIdNormalizer.ts
@@ -55,7 +55,7 @@ export class ToolCallIdResponseNormalizer {
         this.occurrencesByRawId.get(call.id)?.[occurrence] ?? this.claim(call.id, occurrence);
       if (assigned === call.id) return call;
       changed = true;
-      return { ...call, id: assigned };
+      return { ...call, id: assigned, rawId: call.rawId ?? call.id };
     });
     return changed ? result : toolCalls;
   }

--- a/packages/agent-core-v2/src/human/llm/toolCallIdNormalizer.ts
+++ b/packages/agent-core-v2/src/human/llm/toolCallIdNormalizer.ts
@@ -1,15 +1,20 @@
-import type { Message } from '#/llm-adapter/contract/message';
-import type { ToolCall } from '#human/llm/message';
+import type { ToolCall } from '#/llm/message';
+
+export interface ToolCallIdSeedMessage {
+  readonly role?: string;
+  readonly toolCalls?: readonly { readonly id: string }[];
+  readonly toolCallId?: string;
+}
 
 export class ToolCallIdNormalizer {
   private readonly seen = new Set<string>();
   private seeded = false;
 
-  seedFrom(messages: readonly Message[]): void {
+  seedFrom(messages: readonly ToolCallIdSeedMessage[]): void {
     if (this.seeded) return;
     this.seeded = true;
     for (const message of messages) {
-      for (const call of message.toolCalls) this.seen.add(call.id);
+      for (const call of message.toolCalls ?? []) this.seen.add(call.id);
       if (message.toolCallId !== undefined) this.seen.add(message.toolCallId);
     }
   }

--- a/packages/agent-core-v2/src/human/test/agent/machine.test.ts
+++ b/packages/agent-core-v2/src/human/test/agent/machine.test.ts
@@ -237,6 +237,7 @@ describe('agent machine tool failure', () => {
     const dupRequester = createStubRequester([
       createAssistantMessage([], [toolCall('call-1', 'slow_tool'), toolCall('call-1', 'fast_tool')]),
       createAssistantMessage([], [toolCall('call-1', 'slow_tool')]),
+      createAssistantMessage([], [{ ...toolCall('call-1', 'slow_tool'), rawId: 'call-original' }]),
       createAssistantMessage([{ type: 'text', text: 'done' }]),
     ]);
     const dupStarted: string[] = [];
@@ -258,6 +259,15 @@ describe('agent machine tool failure', () => {
       expect(dupStarted).toEqual(['call-1:slow_tool', 'call-1__2:fast_tool', 'call-1__3:slow_tool']);
     });
     dupResolvers.get('call-1__3')?.({ content: [{ type: 'text', text: 'slow again' }] });
+    await vi.waitFor(() => {
+      expect(dupStarted).toEqual([
+        'call-1:slow_tool',
+        'call-1__2:fast_tool',
+        'call-1__3:slow_tool',
+        'call-1__4:slow_tool',
+      ]);
+    });
+    dupResolvers.get('call-1__4')?.({ content: [{ type: 'text', text: 'slow once more' }] });
     const dupMessages = await dupPromise;
 
     expect(rolesAndTexts(dupMessages)).toEqual([
@@ -267,13 +277,15 @@ describe('agent machine tool failure', () => {
       'tool:fast',
       'assistant:',
       'tool:slow again',
+      'assistant:',
+      'tool:slow once more',
       'assistant:done',
     ]);
     expect(
       dupMessages
         .filter((entry) => entry.message.role === 'tool')
         .map((entry) => entry.message.toolCallId),
-    ).toEqual(['call-1', 'call-1__2', 'call-1__3']);
+    ).toEqual(['call-1', 'call-1__2', 'call-1__3', 'call-1__4']);
     expect(
       dupMessages
         .filter((entry) => entry.message.role === 'assistant' && entry.message.toolCalls.length > 0)
@@ -281,6 +293,7 @@ describe('agent machine tool failure', () => {
     ).toEqual([
       ['call-1:', 'call-1__2:call-1'],
       ['call-1__3:call-1'],
+      ['call-1__4:call-original'],
     ]);
 
     let attempt = 0;

--- a/packages/agent-core-v2/src/human/test/agent/machine.test.ts
+++ b/packages/agent-core-v2/src/human/test/agent/machine.test.ts
@@ -100,8 +100,9 @@ function stubTools(
 async function runAgent(
   requester: LlmRequester,
   tools: readonly ToolDefinition[],
+  retry?: LlmRetryOptions,
 ): Promise<HistoryMessage[]> {
-  const actor = createActor(createTestAgentMachine(tools, requester), {
+  const actor = createActor(createTestAgentMachine(tools, requester, retry), {
     input: { request: { model } },
   });
   actor.start();
@@ -230,6 +231,101 @@ describe('agent machine tool failure', () => {
       'assistant:',
       'tool:slow',
       'tool:fast',
+      'assistant:done',
+    ]);
+
+    const dupRequester = createStubRequester([
+      createAssistantMessage([], [toolCall('call-1', 'slow_tool'), toolCall('call-1', 'fast_tool')]),
+      createAssistantMessage([], [toolCall('call-1', 'slow_tool')]),
+      createAssistantMessage([{ type: 'text', text: 'done' }]),
+    ]);
+    const dupStarted: string[] = [];
+    const dupResolvers = new Map<string, (result: ToolResult) => void>();
+    const dupTools = stubTools(({ toolCall: call }) => {
+      dupStarted.push(`${call.id}:${call.name}`);
+      return new Promise((resolve) => {
+        dupResolvers.set(call.id, resolve);
+      });
+    }, 'slow_tool', 'fast_tool');
+
+    const dupPromise = runAgent(dupRequester, dupTools);
+    await vi.waitFor(() => {
+      expect(dupStarted).toEqual(['call-1:slow_tool', 'call-1__2:fast_tool']);
+    });
+    dupResolvers.get('call-1__2')?.({ content: [{ type: 'text', text: 'fast' }] });
+    dupResolvers.get('call-1')?.({ content: [{ type: 'text', text: 'slow' }] });
+    await vi.waitFor(() => {
+      expect(dupStarted).toEqual(['call-1:slow_tool', 'call-1__2:fast_tool', 'call-1__3:slow_tool']);
+    });
+    dupResolvers.get('call-1__3')?.({ content: [{ type: 'text', text: 'slow again' }] });
+    const dupMessages = await dupPromise;
+
+    expect(rolesAndTexts(dupMessages)).toEqual([
+      'user:hi',
+      'assistant:',
+      'tool:slow',
+      'tool:fast',
+      'assistant:',
+      'tool:slow again',
+      'assistant:done',
+    ]);
+    expect(
+      dupMessages
+        .filter((entry) => entry.message.role === 'tool')
+        .map((entry) => entry.message.toolCallId),
+    ).toEqual(['call-1', 'call-1__2', 'call-1__3']);
+    expect(
+      dupMessages
+        .filter((entry) => entry.message.role === 'assistant' && entry.message.toolCalls.length > 0)
+        .map((entry) => entry.message.toolCalls.map((call) => `${call.id}:${call.rawId ?? ''}`)),
+    ).toEqual([
+      ['call-1:', 'call-1__2:call-1'],
+      ['call-1__3:call-1'],
+    ]);
+
+    let attempt = 0;
+    const rollbackRequester: LlmRequester = {
+      generate: (_config, _content, { onEvent }) => {
+        attempt += 1;
+        onEvent?.({ type: 'llm.sent' });
+        if (attempt === 1) {
+          onEvent?.({ type: 'llm.delta', part: toolCall('call-1', 'retry_tool') });
+          onEvent?.({
+            type: 'llm.failed.remote',
+            error: {
+              kind: 'status',
+              statusCode: 500,
+              message: 'server error',
+              requestId: null,
+              retryAfterMs: null,
+              headers: null,
+            },
+          });
+          return Promise.resolve();
+        }
+        if (attempt === 2) {
+          streamMessage(createAssistantMessage([], [toolCall('call-1', 'retry_tool')]), onEvent);
+        } else {
+          streamMessage(createAssistantMessage([{ type: 'text', text: 'done' }]), onEvent);
+        }
+        return Promise.resolve();
+      },
+    };
+    const rollbackStarted: string[] = [];
+    const rollbackTools = stubTools(({ toolCall: call }) => {
+      rollbackStarted.push(call.id);
+      return Promise.resolve({ content: [{ type: 'text', text: 'retried' }] });
+    }, 'retry_tool');
+
+    const rollbackMessages = await runAgent(rollbackRequester, rollbackTools, {
+      maxAttemptsPerStep: 3,
+    });
+
+    expect(rollbackStarted).toEqual(['call-1']);
+    expect(rolesAndTexts(rollbackMessages)).toEqual([
+      'user:hi',
+      'assistant:',
+      'tool:retried',
       'assistant:done',
     ]);
   });

--- a/packages/agent-core-v2/src/human/test/llm/toolCallIdNormalizer.test.ts
+++ b/packages/agent-core-v2/src/human/test/llm/toolCallIdNormalizer.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Message } from '#/llm-adapter/contract/message';
-import type { ToolCall } from '#human/llm/message';
+import type { Message, ToolCall } from '#/llm/message';
 
-import { ToolCallIdNormalizer } from '#/agent/llmRequester/toolCallIdNormalizer';
+import { ToolCallIdNormalizer } from '#/llm/toolCallIdNormalizer';
 
 function call(id: string, streamIndex?: number): ToolCall {
   return { type: 'function', id, name: 'Bash', arguments: '{}', _streamIndex: streamIndex };
@@ -65,9 +64,12 @@ describe('ToolCallIdNormalizer', () => {
 
   it('claims tool result ids from history as well', () => {
     const normalizer = new ToolCallIdNormalizer();
-    normalizer.seedFrom([
-      { role: 'tool', content: [], toolCalls: [], toolCallId: 'Bash_1' },
-    ]);
+    const history: Message[] = [
+      { role: 'user', content: [] },
+      { role: 'system', content: [] },
+      { role: 'tool', content: [], toolCallId: 'Bash_1' },
+    ];
+    normalizer.seedFrom(history);
 
     expect(normalizer.beginResponse().remapStreamedId('Bash_1', 0)).toBe('Bash_1__2');
   });

--- a/packages/agent-core-v2/test/agent/llmRequester/llmRequesterService.test.ts
+++ b/packages/agent-core-v2/test/agent/llmRequester/llmRequesterService.test.ts
@@ -1052,8 +1052,11 @@ describe('AgentLLMRequesterService tool call id normalization', () => {
     });
 
     expect(first.message.toolCalls[0]!.id).toBe('Bash_0');
-    expect(second.message.toolCalls[0]!.id).toBe('Bash_0__2');
-    expect(parts.filter(isToolCall).map((p) => p.id)).toEqual(['Bash_0', 'Bash_0__2']);
+    expect(second.message.toolCalls[0]).toMatchObject({ id: 'Bash_0__2', rawId: 'Bash_0' });
+    expect(parts.filter(isToolCall).map((p) => [p.id, p.rawId])).toEqual([
+      ['Bash_0', undefined],
+      ['Bash_0__2', 'Bash_0'],
+    ]);
   });
 
   it('rewrites duplicates within a single response', async () => {
@@ -1064,7 +1067,10 @@ describe('AgentLLMRequesterService tool call id normalization', () => {
 
     const result = await service.request();
 
-    expect(result.message.toolCalls.map((c) => c.id)).toEqual(['Bash_0', 'Bash_0__2']);
+    expect(result.message.toolCalls.map((c) => [c.id, c.rawId])).toEqual([
+      ['Bash_0', undefined],
+      ['Bash_0__2', 'Bash_0'],
+    ]);
   });
 
   it('rolls claims back when the attempt fails mid-stream', async () => {


### PR DESCRIPTION
## Related Issue

Follow-up to #3580 and #3582 (no separate issue; internal robustness design for the turn state machine).

## Problem

The turn/agent state machines assume tool call ids are unique within a response, but nothing inside the machines enforces it. Upstream (`llmRequesterService`) normalizes duplicate provider ids at its own stream boundary, yet any consumer driving the machines without that service in front (tests, future direct users) can feed a response whose tool calls share one id. Every id-keyed structure then corrupts silently: `turnTools` and the spawned tool actors overwrite each other, one call never executes, a single outcome satisfies both pending calls, and the transcript ends up with two identical tool messages for a call that never ran — a "fake success" with no error.

#3582 put a temporary guard in the v2 loop adapter's requester bridge. This PR moves the defense into the machine itself, at the point the response is assembled, and removes the adapter guard.

## What changed

- **Turn accumulator remaps ids as parts stream in** (`human/agent/turn.ts`): the turn machine holds a turn-shared `ToolCallIdNormalizer` seeded from the full input history (history-level uniqueness, same as upstream's `seedFrom`). Each step's `HistoryAccumulator` remaps every streamed `function` part id via `remapStreamedId` in `push()` and returns the remapped part, so the forwarded `llm.delta` stream and the folded message agree by construction. Failed attempts roll their claims back (`rollback()` on `llm.retrying`/`llm.recovering`), so a retry reuses the raw ids — the same shape as the upstream service normalizer. The requester machine stays stateless and untouched.
- **`ToolCall.rawId`** (`human/llm/message.ts`): `id` is now guaranteed duplicate-free (history-level); a remapped call records its original provider id in `rawId` (absent when unchanged). `rawId` is internal provenance only — closed-set lowering never serializes it onto the provider wire.
- **One normalizer implementation**: `toolCallIdNormalizer.ts` moved from `agent/llmRequester/` to `human/llm/` and is reused by both the machine and `llmRequesterService` (behavior unchanged there, rollback + warn log kept); `seedFrom` now takes a structural message type. Registered in the import-boundaries vocabulary.
- **Adapter reverted**: the #3582 bridge remap in `agent/loop/machine/requester.ts` is removed (pure pass-through) — the machine defends itself.
- State manifest regenerated for the `rawId` contract change.

Verification: negative checks (removing the push-remap or the rollback each fails the extended scenario), human suite 265/265, `test/agent` 1849/1849, monorepo typecheck, lint (no-comments / import-boundaries / oxlint), and remote full suite green (only the known `sessionExport` environment flake). No changeset: the machine path is unreleased (#3580) and the upstream normalizer already covers the released v2 path, so the change is not user-perceivable.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
