### PR TITLE
fix: send reasoning_effort when Thinking is On for OpenAI-compatible models

### DIFF
--- a/.changeset/openai-compat-thinking-on.md
+++ b/.changeset/openai-compat-thinking-on.md
@@ -1,5 +1,7 @@
 ---
-"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kosong": patch
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/agent-core-v2": patch
 ---
 
 Send reasoning_effort when Thinking is On for OpenAI-compatible models.

--- a/.changeset/openai-compat-thinking-on.md
+++ b/.changeset/openai-compat-thinking-on.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Send reasoning_effort when Thinking is On for OpenAI-compatible models.

--- a/packages/agent-core-v2/src/human/llm/thinking.ts
+++ b/packages/agent-core-v2/src/human/llm/thinking.ts
@@ -79,7 +79,7 @@ export function resolveThinkingEffort(
   const effort = options.effort;
   const meta = thinkingMetadataOf(model);
   if (effort === 'on') {
-    return { ok: true, encode: 'silent' };
+    return { ok: true, encode: 'effort', value: nonEmpty(meta?.defaultEffort) ?? 'medium' };
   }
   if (effort === 'off') {
     if (meta?.offEffort !== undefined) {

--- a/packages/agent-core-v2/src/human/test/llm/thinking.test.ts
+++ b/packages/agent-core-v2/src/human/test/llm/thinking.test.ts
@@ -221,7 +221,7 @@ describe('openai requester thinking', () => {
     expect(client.body()['reasoning_effort']).toBe('max');
   });
 
-  it('sends nothing for on without a trait', async () => {
+  it('sends reasoning_effort medium for on without a trait', async () => {
     const client = stubOpenAIClient(chatCompletionChunks());
     const requester = createOpenAIRequester(undefined, { clientFactory: client.clientFactory });
     await requester.generate(
@@ -229,8 +229,22 @@ describe('openai requester thinking', () => {
       { messages },
       { signal: new AbortController().signal },
     );
-    expect(client.body()['reasoning_effort']).toBeUndefined();
+    expect(client.body()['reasoning_effort']).toBe('medium');
     expect(client.body()['thinking']).toBeUndefined();
+  });
+
+  it('sends defaultEffort as reasoning_effort for on on a custom OpenAI-compatible model', async () => {
+    const client = stubOpenAIClient(chatCompletionChunks());
+    const requester = createOpenAIRequester(undefined, { clientFactory: client.clientFactory });
+    await requester.generate(
+      {
+        model: modelWith({ adaptiveThinking: true, defaultEffort: 'high' }),
+        thinking: { effort: 'on' },
+      },
+      { messages },
+      { signal: new AbortController().signal },
+    );
+    expect(client.body()['reasoning_effort']).toBe('high');
   });
 
   it('sends the configured offEffort when thinking is off', async () => {

--- a/packages/agent-core/src/session/provider-manager.ts
+++ b/packages/agent-core/src/session/provider-manager.ts
@@ -139,6 +139,7 @@ export class ProviderManager implements ModelProvider {
       this.options.promptCacheKey,
       effectiveAlias.supportEfforts,
       effectiveAlias.offEffort,
+      effectiveAlias.defaultEffort,
       effectiveAlias.adaptiveThinking,
       alias.betaApi,
     );
@@ -268,6 +269,7 @@ function toKosongProviderConfig(
   promptCacheKey: string | undefined,
   supportEfforts: readonly string[] | undefined,
   offEffort: string | undefined,
+  onEffort: string | undefined,
   adaptiveThinking: boolean | undefined,
   betaApi: boolean | undefined,
 ): KosongProviderConfig {
@@ -325,6 +327,7 @@ function toKosongProviderConfig(
         apiKey: providerApiKey(provider),
         reasoningKey,
         offEffort,
+        onEffort,
         // Session affinity: route every request of this session through the
         // same provider-side prompt cache (the OpenAI analog of Anthropic
         // `metadata.user_id` above). Undefined values are stripped at
@@ -370,6 +373,7 @@ function toKosongProviderConfig(
           modelBaseUrl ?? providerValue(provider.baseUrl, provider.env, 'OPENAI_BASE_URL'),
         apiKey: providerApiKey(provider),
         offEffort,
+        onEffort,
         // Session affinity: same `prompt_cache_key` intent as the `openai`
         // branch; the Responses API accepts it as a top-level request field.
         generationKwargs: { prompt_cache_key: promptCacheKey },

--- a/packages/agent-core/test/harness/runtime-provider.test.ts
+++ b/packages/agent-core/test/harness/runtime-provider.test.ts
@@ -284,6 +284,44 @@ describe('resolveRuntimeProvider maxOutputSize forwarding', () => {
     });
   });
 
+  it('forwards alias.defaultEffort as onEffort to the openai and openai_responses provider configs', () => {
+    const config = {
+      ...BASE_CONFIG,
+      providers: {
+        ...BASE_CONFIG.providers,
+        gateway: { type: 'openai', apiKey: 'sk-gateway' } as const,
+        responses: { type: 'openai_responses', apiKey: 'sk-responses' } as const,
+      },
+      models: {
+        ...BASE_CONFIG.models!,
+        'gateway/custom': {
+          provider: 'gateway',
+          model: 'deepseek-v4-flash',
+          maxContextSize: 256000,
+          capabilities: ['tool_use', 'thinking'],
+          adaptiveThinking: true,
+          defaultEffort: 'high',
+        },
+        'responses/custom': {
+          provider: 'responses',
+          model: 'deepseek-v4-flash',
+          maxContextSize: 256000,
+          adaptiveThinking: true,
+          defaultEffort: 'high',
+        },
+      },
+    } as KimiConfig;
+
+    expect(resolveRuntimeProvider({ config, model: 'gateway/custom' }).provider).toMatchObject({
+      type: 'openai',
+      onEffort: 'high',
+    });
+    expect(resolveRuntimeProvider({ config, model: 'responses/custom' }).provider).toMatchObject({
+      type: 'openai_responses',
+      onEffort: 'high',
+    });
+  });
+
   it('forwards alias.offEffort to the openai and openai_responses provider configs', () => {
     const config = {
       ...BASE_CONFIG,

--- a/packages/kosong/src/providers/openai-common.ts
+++ b/packages/kosong/src/providers/openai-common.ts
@@ -11,7 +11,7 @@ import {
 } from '#/errors';
 import { extractText } from '#/message';
 import type { ContentPart, Message } from '#/message';
-import type { FinishReason } from '#/provider';
+import type { FinishReason, ThinkingEffort } from '#/provider';
 import type { Tool } from '#/tool';
 import type { TokenUsage } from '#/usage';
 import {
@@ -302,4 +302,24 @@ export function convertToolMessageContent(
   return message.content
     .map((p) => convertContentPart(p))
     .filter((p): p is OpenAIContentPart => p !== null);
+}
+
+/**
+ * Default `reasoning_effort` for a boolean Thinking On. Chat-completions and
+ * Responses APIs have no dedicated "on" token; catalog models with
+ * `support_efforts` are remapped to a concrete effort before they reach this
+ * helper. Custom OpenAI-compatible models with only `adaptive_thinking`
+ * still arrive as `'on'` and must send an explicit value, or endpoints that
+ * think only when the field is present stay silent.
+ */
+export const DEFAULT_ON_REASONING_EFFORT = 'medium';
+
+export function encodeOpenAIReasoningEffort(
+  effort: ThinkingEffort | undefined,
+  options?: { offEffort?: string; onEffort?: string },
+): string | undefined {
+  if (effort === undefined) return undefined;
+  if (effort === 'off') return options?.offEffort;
+  if (effort === 'on') return options?.onEffort ?? DEFAULT_ON_REASONING_EFFORT;
+  return effort;
 }

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -95,7 +95,7 @@ export interface OpenAILegacyOptions {
    * shared default (`medium`) is sent so boolean Thinking On is not a
    * silent no-op on OpenAI-compatible endpoints.
    */
-  onEffort?: string | undefined;
+  onEffort?: string;
   httpClient?: unknown;
   defaultHeaders?: Record<string, string>;
   toolMessageConversion?: ToolMessageConversion | undefined;

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -18,6 +18,7 @@ import {
   convertContentPart,
   convertOpenAIError,
   convertToolMessageContent,
+  encodeOpenAIReasoningEffort,
   extractUsage,
   isFunctionToolCall,
   normalizeOpenAIFinishReason,
@@ -88,6 +89,13 @@ export interface OpenAILegacyOptions {
    * whose default is to reason.
    */
   offEffort?: string | undefined;
+  /**
+   * The effort value that encodes "thinking on" on this wire. When set,
+   * `withThinking('on')` sends it as `reasoning_effort`; otherwise the
+   * shared default (`medium`) is sent so boolean Thinking On is not a
+   * silent no-op on OpenAI-compatible endpoints.
+   */
+  onEffort?: string | undefined;
   httpClient?: unknown;
   defaultHeaders?: Record<string, string>;
   toolMessageConversion?: ToolMessageConversion | undefined;
@@ -493,6 +501,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
   private _reasoningKeyDialect: ReasoningKeyDialect;
   private _thinkingEffort: ThinkingEffort | undefined;
   private _offEffort: string | undefined;
+  private _onEffort: string | undefined;
   private _generationKwargs: OpenAILegacyGenerationKwargs;
   private _toolMessageConversion: ToolMessageConversion;
   private _client: OpenAI | undefined;
@@ -518,6 +527,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
     );
     this._thinkingEffort = undefined;
     this._offEffort = options.offEffort;
+    this._onEffort = options.onEffort;
     this._generationKwargs = {
       ...options.generationKwargs,
       ...(options.maxTokens !== undefined
@@ -574,19 +584,17 @@ export class OpenAILegacyChatProvider implements ChatProvider {
       this._generationKwargs,
     );
 
-    // Determine reasoning_effort. 'on' has no wire encoding on
-    // chat-completions APIs, so it sends no reasoning_effort field; only a
-    // concrete effort (low/medium/high/...) is passed through verbatim.
-    // 'off' sends the model's declared off value (e.g. 'none') when one is
-    // configured — models that reason by default need the explicit value to
-    // actually disable reasoning; otherwise the field is omitted as before.
+    // Determine reasoning_effort. Concrete efforts pass through verbatim.
+    // 'on' has no dedicated chat-completions token, so it is encoded as
+    // onEffort when configured, otherwise 'medium'. 'off' sends the model's
+    // declared off value (e.g. 'none') when one is configured — models that
+    // reason by default need the explicit value to actually disable reasoning;
+    // otherwise the field is omitted as before.
     const effort = this._thinkingEffort;
-    let reasoningEffort: string | undefined =
-      effort === 'off'
-        ? this._offEffort
-        : effort === undefined || effort === 'on'
-          ? undefined
-          : effort;
+    let reasoningEffort: string | undefined = encodeOpenAIReasoningEffort(effort, {
+      offEffort: this._offEffort,
+      onEffort: this._onEffort,
+    });
 
     // Auto-enable reasoning_effort when the history contains ThinkPart but reasoning
     // was not explicitly configured. This prevents server validation errors from APIs

--- a/packages/kosong/src/providers/openai-responses.ts
+++ b/packages/kosong/src/providers/openai-responses.ts
@@ -23,6 +23,7 @@ import OpenAI from 'openai';
 import { usesOpenAIResponsesDeveloperRole } from './capability-registry';
 import {
   convertOpenAIError,
+  encodeOpenAIReasoningEffort,
   isMediaPart,
   isOpenAIInsufficientQuotaCode,
   TOOL_RESULT_MEDIA_PLACEHOLDER,
@@ -361,6 +362,13 @@ export interface OpenAIResponsesOptions {
    * whose default is to reason.
    */
   offEffort?: string | undefined;
+  /**
+   * The effort value that encodes "thinking on" on this wire. When set,
+   * `withThinking('on')` sends it as `reasoning_effort`; otherwise the
+   * shared default (`medium`) is sent so boolean Thinking On is not a
+   * silent no-op on OpenAI-compatible endpoints.
+   */
+  onEffort?: string | undefined;
   httpClient?: unknown;
   defaultHeaders?: Record<string, string>;
   toolMessageConversion?: ToolMessageConversion | undefined;
@@ -1050,6 +1058,7 @@ export class OpenAIResponsesChatProvider implements ChatProvider {
   private _defaultHeaders: Record<string, string> | undefined;
   private _generationKwargs: OpenAIResponsesGenerationKwargs;
   private _offEffort: string | undefined;
+  private _onEffort: string | undefined;
   private _toolMessageConversion: ToolMessageConversion;
   private _client: OpenAI | undefined;
   private _httpClient: unknown;
@@ -1064,6 +1073,7 @@ export class OpenAIResponsesChatProvider implements ChatProvider {
     this._stream = true; // Responses API always supports streaming
     this._generationKwargs = { ...options.generationKwargs };
     this._offEffort = options.offEffort;
+    this._onEffort = options.onEffort;
     this._toolMessageConversion = options.toolMessageConversion ?? null;
     this._httpClient = options.httpClient;
     this._clientFactory = options.clientFactory;
@@ -1171,10 +1181,13 @@ export class OpenAIResponsesChatProvider implements ChatProvider {
   }
 
   withThinking(effort: ThinkingEffort): OpenAIResponsesChatProvider {
-    // 'on' sends no effort field; 'off' sends the model's declared off value
-    // (e.g. 'none') when one is configured, and omits the field otherwise.
-    const reasoningEffort =
-      effort === 'off' ? this._offEffort : effort === 'on' ? undefined : effort;
+    // 'on' is encoded as onEffort when configured, otherwise 'medium'.
+    // 'off' sends the model's declared off value (e.g. 'none') when one is
+    // configured, and omits the field otherwise.
+    const reasoningEffort = encodeOpenAIReasoningEffort(effort, {
+      offEffort: this._offEffort,
+      onEffort: this._onEffort,
+    });
     const clone = this._clone();
     clone._generationKwargs = {
       ...clone._generationKwargs,

--- a/packages/kosong/src/providers/openai-responses.ts
+++ b/packages/kosong/src/providers/openai-responses.ts
@@ -368,7 +368,7 @@ export interface OpenAIResponsesOptions {
    * shared default (`medium`) is sent so boolean Thinking On is not a
    * silent no-op on OpenAI-compatible endpoints.
    */
-  onEffort?: string | undefined;
+  onEffort?: string;
   httpClient?: unknown;
   defaultHeaders?: Record<string, string>;
   toolMessageConversion?: ToolMessageConversion | undefined;

--- a/packages/kosong/test/openai-legacy.test.ts
+++ b/packages/kosong/test/openai-legacy.test.ts
@@ -28,6 +28,7 @@ function createProvider(
     reasoningKey: string;
     model: string;
     offEffort: string;
+    onEffort: string;
   }>,
 ): OpenAILegacyChatProvider {
   return new OpenAILegacyChatProvider({
@@ -36,6 +37,7 @@ function createProvider(
     stream: options?.stream ?? false,
     reasoningKey: options?.reasoningKey,
     offEffort: options?.offEffort,
+    onEffort: options?.onEffort,
   });
 }
 
@@ -1268,14 +1270,28 @@ describe('OpenAILegacyChatProvider', () => {
       expect(provider.thinkingEffort).toBe('off');
     });
 
-    it('.withThinking("on") sends no reasoning_effort without ThinkPart history and reports "on"', async () => {
+    it('.withThinking("on") sends reasoning_effort medium without ThinkPart history and reports "on"', async () => {
       const provider = createProvider().withThinking('on');
       const history: Message[] = [
         { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
       ];
       const body = await captureRequestBody(provider, '', [], history);
 
-      expect(body['reasoning_effort']).toBeUndefined();
+      expect(body['reasoning_effort']).toBe('medium');
+      expect(provider.thinkingEffort).toBe('on');
+    });
+
+    it('.withThinking("on") sends the configured onEffort for a custom OpenAI-compatible model', async () => {
+      const provider = createProvider({
+        model: 'deepseek-v4-flash',
+        onEffort: 'high',
+      }).withThinking('on');
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['reasoning_effort']).toBe('high');
       expect(provider.thinkingEffort).toBe('on');
     });
 

--- a/packages/kosong/test/openai-responses.test.ts
+++ b/packages/kosong/test/openai-responses.test.ts
@@ -1059,6 +1059,31 @@ describe('OpenAIResponsesChatProvider', () => {
       expect(provider.thinkingEffort).toBe('off');
     });
 
+    it('with_thinking("on") sends reasoning effort medium by default', async () => {
+      const provider = createProvider().withThinking('on');
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['reasoning']).toEqual({ effort: 'medium', summary: 'auto' });
+      expect(body['include']).toEqual(['reasoning.encrypted_content']);
+    });
+
+    it('with_thinking("on") sends the configured onEffort for a custom OpenAI-compatible model', async () => {
+      const provider = new OpenAIResponsesChatProvider({
+        model: 'deepseek-v4-flash',
+        apiKey: 'test-key',
+        onEffort: 'high',
+      }).withThinking('on');
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['reasoning']).toEqual({ effort: 'high', summary: 'auto' });
+    });
+
     it('with_thinking("low") sends reasoning with effort=low', async () => {
       const provider = createProvider().withThinking('low');
       const history: Message[] = [


### PR DESCRIPTION
## Related Issue

Resolve #3448

## Problem

See linked issue.

For manually configured OpenAI-compatible models, turning Thinking On (or `adaptive_thinking = true`) did not put any reasoning fields on the wire. Catalog models with `support_efforts` map On to a concrete effort tier; custom models only set the adaptive flag, so the encoder omitted `reasoning_effort` and Thinking On was silently ineffective for endpoints that require an explicit parameter.

## What changed

When Thinking is On for OpenAI chat-completions / Responses:

- send `reasoning_effort`
- default to `medium` (same default used elsewhere for ThinkPart auto-inject)
- prefer the model’s configured `default_effort` when present

Shared across v1 (kosong / CLI) and v2 (kap-server / Web) encoding paths, with focused regression tests and a patch changeset for `@moonshot-ai/kosong`, `@moonshot-ai/agent-core`, and `@moonshot-ai/agent-core-v2`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Maintainer note: `#3448` is awaiting `/approve` per CONTRIBUTING; happy to adjust scope on request.