### PR TITLE
fix(cli): warn in kimi -p when workspace trust skips project MCP servers

### DIFF
--- a/.changeset/warn-trust-gated-mcp-in-print-mode.md
+++ b/.changeset/warn-trust-gated-mcp-in-print-mode.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Print a warning in `kimi -p` when project-level MCP servers are skipped because the folder is not trusted.

--- a/apps/kimi-code/src/cli/v2/run-v2-print.ts
+++ b/apps/kimi-code/src/cli/v2/run-v2-print.ts
@@ -61,7 +61,10 @@ import {
   type PrintBackgroundMode,
   type Scope,
 } from '@moonshot-ai/agent-core-v2';
-import { loadMcpServers } from '@moonshot-ai/agent-core-v2/app/mcpConfig/configLoader';
+import {
+  loadMcpServersDetailed,
+  resolveMcpJsonPaths,
+} from '@moonshot-ai/agent-core-v2/app/mcpConfig/configLoader';
 import {
   createKimiDefaultHeaders,
   createKimiDeviceId,
@@ -494,9 +497,9 @@ export interface TrustGatedMcpServer {
 
 /**
  * Project-level MCP servers the workspace-trust gate leaves out in this
- * folder: what the config loader sees with project files included vs skipped
- * (mirrors the SDK's `getWorkspaceTrustInfo`). Empty when the folder is
- * trusted or nothing project-level is declared.
+ * folder, identified by the origin of each entry in the final merged config
+ * (mirrors the SDK's `getWorkspaceTrustInfo`). Empty when the folder is trusted
+ * or nothing project-level is declared.
  */
 export async function listTrustGatedMcpServers(
   app: Scope,
@@ -508,12 +511,13 @@ export async function listTrustGatedMcpServers(
     .getOrCreate({ root: workDir });
   if (await workspace.program.trust.get()) return [];
   const fs = app.accessor.get(IHostFileSystem);
-  const [withProject, userOnly] = await Promise.all([
-    loadMcpServers({ fs, cwd: workDir, homeDir, includeProject: true }),
-    loadMcpServers({ fs, cwd: workDir, homeDir, includeProject: false }),
+  const [paths, loaded] = await Promise.all([
+    resolveMcpJsonPaths({ fs, cwd: workDir, homeDir }),
+    loadMcpServersDetailed({ fs, cwd: workDir, homeDir, includeProject: true }),
   ]);
-  return Object.entries(withProject)
-    .filter(([name]) => !(name in userOnly))
+  const projectPaths = new Set([paths.projectRoot, paths.project]);
+  return Object.entries(loaded.servers)
+    .filter(([name]) => projectPaths.has(loaded.origins[name] ?? ''))
     .map(([name, config]) => ({ name, target: describeMcpTarget(config) }))
     .toSorted((a, b) => a.name.localeCompare(b.name));
 }

--- a/apps/kimi-code/src/cli/v2/run-v2-print.ts
+++ b/apps/kimi-code/src/cli/v2/run-v2-print.ts
@@ -32,10 +32,12 @@ import {
   IConfigService,
   IEventBus,
   IEventDispatcher,
+  IHostFileSystem,
   IOAuthToolkit,
   ISessionIndex,
   ISessionManager,
   ITelemetryService,
+  IWorkspaceInstanceManager,
   PRINT_MAX_TURNS_DEFAULT,
   PRINT_WAIT_CEILING_S_DEFAULT,
   applyPrintModeConfigDefaults,
@@ -55,9 +57,11 @@ import {
   type IAgentScopeHandle,
   type ISessionScopeHandle,
   type LoopRunResult,
+  type McpServerConfig,
   type PrintBackgroundMode,
   type Scope,
 } from '@moonshot-ai/agent-core-v2';
+import { loadMcpServers } from '@moonshot-ai/agent-core-v2/app/mcpConfig/configLoader';
 import {
   createKimiDefaultHeaders,
   createKimiDeviceId,
@@ -272,6 +276,15 @@ export async function runV2Print(
       });
     }
 
+    // Print mode has no trust prompt, so the engine's workspace-trust gate
+    // would silently drop project-level MCP servers — say so on stderr.
+    try {
+      const gated = await listTrustGatedMcpServers(app, workDir, homeDir);
+      if (gated.length > 0) stderr.write(formatTrustGatedMcpWarning(gated));
+    } catch {
+      // Best-effort: a broken mcp.json or trust store must not fail the run.
+    }
+
     const resolved = await resolveNativeSession(app, opts, workDir, defaultModel, stderr);
     restorePermission = resolved.restorePermission;
     quiesceAgents = async () => {
@@ -472,6 +485,54 @@ async function resolveNativeSession(
     telemetryModel: model,
     goalModel: model,
   };
+}
+
+export interface TrustGatedMcpServer {
+  readonly name: string;
+  readonly target: string;
+}
+
+/**
+ * Project-level MCP servers the workspace-trust gate leaves out in this
+ * folder: what the config loader sees with project files included vs skipped
+ * (mirrors the SDK's `getWorkspaceTrustInfo`). Empty when the folder is
+ * trusted or nothing project-level is declared.
+ */
+export async function listTrustGatedMcpServers(
+  app: Scope,
+  workDir: string,
+  homeDir: string,
+): Promise<readonly TrustGatedMcpServer[]> {
+  const workspace = await app.accessor
+    .get(IWorkspaceInstanceManager)
+    .getOrCreate({ root: workDir });
+  if (await workspace.program.trust.get()) return [];
+  const fs = app.accessor.get(IHostFileSystem);
+  const [withProject, userOnly] = await Promise.all([
+    loadMcpServers({ fs, cwd: workDir, homeDir, includeProject: true }),
+    loadMcpServers({ fs, cwd: workDir, homeDir, includeProject: false }),
+  ]);
+  return Object.entries(withProject)
+    .filter(([name]) => !(name in userOnly))
+    .map(([name, config]) => ({ name, target: describeMcpTarget(config) }))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+}
+
+export function formatTrustGatedMcpWarning(servers: readonly TrustGatedMcpServer[]): string {
+  const noun = servers.length === 1 ? 'server' : 'servers';
+  const list = servers.map((server) => `${server.name} (${server.target})`).join(', ');
+  return (
+    `Warning: this folder is not trusted; skipped ${servers.length} project-level MCP ${noun}: ${list}.\n` +
+    '  Run `kimi` here and choose "Trust this folder" to enable them.\n\n'
+  );
+}
+
+function describeMcpTarget(config: McpServerConfig): string {
+  if (config.transport === 'stdio') {
+    const args = config.args === undefined ? '' : ` ${config.args.join(' ')}`;
+    return `stdio: ${config.command}${args}`;
+  }
+  return `${config.transport}: ${config.url}`;
 }
 
 async function runNativeTurn(

--- a/apps/kimi-code/test/cli/run-v2-print.test.ts
+++ b/apps/kimi-code/test/cli/run-v2-print.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   applyPrintBackgroundPolicy,
   createPrintTurnEndings,
+  formatTrustGatedMcpWarning,
   PrintSteeredTurnFailedError,
   type PrintTurnEnding,
   type PrintTurnEndings,
@@ -500,5 +501,22 @@ describe('createPrintTurnEndings', () => {
     expect(early).toBe('waiting');
     endings.push(ending(7));
     await expect(pending).resolves.toMatchObject({ turnId: 7 });
+  });
+});
+
+describe('formatTrustGatedMcpWarning', () => {
+  it('singularizes the noun for one skipped server', () => {
+    const text = formatTrustGatedMcpWarning([{ name: 'fs', target: 'stdio: node server.js' }]);
+    expect(text).toContain('skipped 1 project-level MCP server: fs (stdio: node server.js).');
+    expect(text).toContain('"Trust this folder"');
+  });
+
+  it('pluralizes and joins multiple skipped servers', () => {
+    const text = formatTrustGatedMcpWarning([
+      { name: 'api', target: 'http: https://example.com/mcp' },
+      { name: 'fs', target: 'stdio: node server.js' },
+    ]);
+    expect(text).toContain('skipped 2 project-level MCP servers:');
+    expect(text).toContain('api (http: https://example.com/mcp), fs (stdio: node server.js)');
   });
 });

--- a/apps/kimi-code/test/cli/v2-run-print.test.ts
+++ b/apps/kimi-code/test/cli/v2-run-print.test.ts
@@ -39,9 +39,15 @@ import { runV2Print } from '../../src/cli/v2/run-v2-print';
 const mocks = vi.hoisted(() => ({
   bootstrap: vi.fn(),
   ensureMainAgent: vi.fn(),
-  loadMcpServers: vi.fn(
-    async (_input: { includeProject?: boolean }): Promise<Record<string, unknown>> => ({}),
-  ),
+  loadMcpServersDetailed: vi.fn(async () => ({
+    servers: {},
+    origins: {},
+  })),
+  resolveMcpJsonPaths: vi.fn(async () => ({
+    user: '/tmp/kimi-code-test-home/mcp.json',
+    projectRoot: '/tmp/project/.mcp.json',
+    project: '/tmp/project/.kimi-code/mcp.json',
+  })),
   createKimiDefaultHeaders: vi.fn(() => ({})),
   resolveKimiHome: vi.fn((homeDir?: string) => homeDir ?? '/tmp/kimi-code-test-home'),
   createKimiDeviceId: vi.fn(() => 'device-1'),
@@ -62,7 +68,8 @@ vi.mock('@moonshot-ai/agent-core-v2', async (importOriginal) => {
 });
 
 vi.mock('@moonshot-ai/agent-core-v2/app/mcpConfig/configLoader', () => ({
-  loadMcpServers: mocks.loadMcpServers,
+  loadMcpServersDetailed: mocks.loadMcpServersDetailed,
+  resolveMcpJsonPaths: mocks.resolveMcpJsonPaths,
 }));
 
 vi.mock('@moonshot-ai/kimi-code-oauth', async () => {
@@ -318,7 +325,10 @@ describe('runV2Print', () => {
     // flip the default telemetry-on path these tests exercise.
     vi.stubEnv('KIMI_DISABLE_TELEMETRY', '');
     // `vi.clearAllMocks` keeps implementations, so re-pin the default here.
-    mocks.loadMcpServers.mockImplementation(async () => ({}));
+    mocks.loadMcpServersDetailed.mockImplementation(async () => ({
+      servers: {},
+      origins: {},
+    }));
   });
 
   afterEach(() => {
@@ -850,14 +860,16 @@ describe('runV2Print', () => {
     const stderr = writer();
     const { app, trustState } = makeFakeHarness();
     trustState.trusted = false;
-    mocks.loadMcpServers.mockImplementation(async (input: { includeProject?: boolean }) =>
-      input.includeProject === false
-        ? {}
-        : {
-            fs: { transport: 'stdio', command: 'node', args: ['server.js'] },
-            api: { transport: 'http', url: 'https://example.com/mcp' },
-          },
-    );
+    mocks.loadMcpServersDetailed.mockResolvedValue({
+      servers: {
+        fs: { transport: 'stdio', command: 'node', args: ['server.js'] },
+        api: { transport: 'http', url: 'https://example.com/mcp' },
+      },
+      origins: {
+        fs: '/tmp/project/.mcp.json',
+        api: '/tmp/project/.kimi-code/mcp.json',
+      },
+    });
 
     mocks.bootstrap.mockReturnValue({ app });
     mocks.ensureMainAgent.mockResolvedValue({ agentId: 'main', generation: 1 });
@@ -883,7 +895,7 @@ describe('runV2Print', () => {
 
     await runV2Print(opts() as never, '1.2.3-test', { stdout, stderr });
 
-    expect(mocks.loadMcpServers).not.toHaveBeenCalled();
+    expect(mocks.loadMcpServersDetailed).not.toHaveBeenCalled();
     expect(stderr.text()).not.toContain('not trusted');
   });
 
@@ -898,8 +910,33 @@ describe('runV2Print', () => {
 
     await runV2Print(opts() as never, '1.2.3-test', { stdout, stderr });
 
-    expect(mocks.loadMcpServers).toHaveBeenCalled();
+    expect(mocks.loadMcpServersDetailed).toHaveBeenCalled();
     expect(stderr.text()).not.toContain('not trusted');
+  });
+
+  it('warns for a project server that overrides a same-named user server', async () => {
+    const stdout = writer();
+    const stderr = writer();
+    const { app, trustState } = makeFakeHarness();
+    trustState.trusted = false;
+    mocks.loadMcpServersDetailed.mockResolvedValue({
+      servers: {
+        github: { transport: 'stdio', command: './project-github' },
+        toString: { transport: 'http', url: 'https://example.com/mcp' },
+      },
+      origins: {
+        github: '/tmp/project/.mcp.json',
+        toString: '/tmp/project/.kimi-code/mcp.json',
+      },
+    });
+
+    mocks.bootstrap.mockReturnValue({ app });
+    mocks.ensureMainAgent.mockResolvedValue({ agentId: 'main', generation: 1 });
+
+    await runV2Print(opts() as never, '1.2.3-test', { stdout, stderr });
+
+    expect(stderr.text()).toContain('github (stdio: ./project-github)');
+    expect(stderr.text()).toContain('toString (http: https://example.com/mcp)');
   });
 
   it('still runs when the trust-gated MCP probe fails', async () => {

--- a/apps/kimi-code/test/cli/v2-run-print.test.ts
+++ b/apps/kimi-code/test/cli/v2-run-print.test.ts
@@ -20,10 +20,12 @@ import {
   IEventBus,
   IEventDispatcher,
   IFileSystemStorageService,
+  IHostFileSystem,
   IOAuthToolkit,
   ISessionIndex,
   ISessionManager,
   ITelemetryService,
+  IWorkspaceInstanceManager,
   makeAgentScopeContext,
   resolveKimiHome,
   type BootstrapInput,
@@ -37,6 +39,9 @@ import { runV2Print } from '../../src/cli/v2/run-v2-print';
 const mocks = vi.hoisted(() => ({
   bootstrap: vi.fn(),
   ensureMainAgent: vi.fn(),
+  loadMcpServers: vi.fn(
+    async (_input: { includeProject?: boolean }): Promise<Record<string, unknown>> => ({}),
+  ),
   createKimiDefaultHeaders: vi.fn(() => ({})),
   resolveKimiHome: vi.fn((homeDir?: string) => homeDir ?? '/tmp/kimi-code-test-home'),
   createKimiDeviceId: vi.fn(() => 'device-1'),
@@ -55,6 +60,10 @@ vi.mock('@moonshot-ai/agent-core-v2', async (importOriginal) => {
     ensureMainAgent: mocks.ensureMainAgent,
   };
 });
+
+vi.mock('@moonshot-ai/agent-core-v2/app/mcpConfig/configLoader', () => ({
+  loadMcpServers: mocks.loadMcpServers,
+}));
 
 vi.mock('@moonshot-ai/kimi-code-oauth', async () => {
   const actual = await vi.importActual<typeof import('@moonshot-ai/kimi-code-oauth')>(
@@ -145,6 +154,7 @@ function makeFakeHarness() {
   // emits a streaming assistant delta before completing.
   const eventListeners = new Set<(event: Event2<any>) => void>();
   const profileState: { profileName: string | undefined } = { profileName: undefined };
+  const trustState = { trusted: true };
 
   const goal = { createGoal: vi.fn(), getGoal: vi.fn() };
   const agentServices = new Map<unknown, unknown>([
@@ -272,6 +282,15 @@ function makeFakeHarness() {
     ],
     [IOAuthToolkit, { getCachedAccessToken: vi.fn(async () => undefined) }],
     [IFileSystemStorageService, {}],
+    [IHostFileSystem, {}],
+    [
+      IWorkspaceInstanceManager,
+      {
+        getOrCreate: vi.fn(async () => ({
+          program: { trust: { get: vi.fn(async () => trustState.trusted) } },
+        })),
+      },
+    ],
     [
       ITelemetryService,
       (() => {
@@ -288,7 +307,7 @@ function makeFakeHarness() {
     ],
   ]);
   const app = fakeScope('app', appServices);
-  return { app, agent, session, agentServices, sessionServices, appServices, profileState };
+  return { app, agent, session, agentServices, sessionServices, appServices, profileState, trustState };
 }
 
 describe('runV2Print', () => {
@@ -298,6 +317,8 @@ describe('runV2Print', () => {
     // Pin the telemetry kill-switch to "unset" so the host environment cannot
     // flip the default telemetry-on path these tests exercise.
     vi.stubEnv('KIMI_DISABLE_TELEMETRY', '');
+    // `vi.clearAllMocks` keeps implementations, so re-pin the default here.
+    mocks.loadMcpServers.mockImplementation(async () => ({}));
   });
 
   afterEach(() => {
@@ -822,5 +843,80 @@ describe('runV2Print', () => {
     const appDisposeOrder = app.dispose.mock.invocationCallOrder[0];
     expect(lastGuardRelease).toBeGreaterThan(appDisposeOrder!);
     expect(await outcome).toBeInstanceOf(Error);
+  });
+
+  it('warns on stderr when workspace trust skips project-level MCP servers', async () => {
+    const stdout = writer();
+    const stderr = writer();
+    const { app, trustState } = makeFakeHarness();
+    trustState.trusted = false;
+    mocks.loadMcpServers.mockImplementation(async (input: { includeProject?: boolean }) =>
+      input.includeProject === false
+        ? {}
+        : {
+            fs: { transport: 'stdio', command: 'node', args: ['server.js'] },
+            api: { transport: 'http', url: 'https://example.com/mcp' },
+          },
+    );
+
+    mocks.bootstrap.mockReturnValue({ app });
+    mocks.ensureMainAgent.mockResolvedValue({ agentId: 'main', generation: 1 });
+
+    await runV2Print(opts() as never, '1.2.3-test', { stdout, stderr });
+
+    expect(stderr.text()).toContain(
+      'Warning: this folder is not trusted; skipped 2 project-level MCP servers: ' +
+        'api (http: https://example.com/mcp), fs (stdio: node server.js).',
+    );
+    expect(stderr.text()).toContain('"Trust this folder"');
+    // The warning is advisory only — the run itself is unaffected.
+    expect(stdout.text()).toContain('hello world');
+  });
+
+  it('does not read mcp.json for the trust warning when the folder is trusted', async () => {
+    const stdout = writer();
+    const stderr = writer();
+    const { app } = makeFakeHarness();
+
+    mocks.bootstrap.mockReturnValue({ app });
+    mocks.ensureMainAgent.mockResolvedValue({ agentId: 'main', generation: 1 });
+
+    await runV2Print(opts() as never, '1.2.3-test', { stdout, stderr });
+
+    expect(mocks.loadMcpServers).not.toHaveBeenCalled();
+    expect(stderr.text()).not.toContain('not trusted');
+  });
+
+  it('stays silent when untrusted but no project-level MCP servers are declared', async () => {
+    const stdout = writer();
+    const stderr = writer();
+    const { app, trustState } = makeFakeHarness();
+    trustState.trusted = false;
+
+    mocks.bootstrap.mockReturnValue({ app });
+    mocks.ensureMainAgent.mockResolvedValue({ agentId: 'main', generation: 1 });
+
+    await runV2Print(opts() as never, '1.2.3-test', { stdout, stderr });
+
+    expect(mocks.loadMcpServers).toHaveBeenCalled();
+    expect(stderr.text()).not.toContain('not trusted');
+  });
+
+  it('still runs when the trust-gated MCP probe fails', async () => {
+    const stdout = writer();
+    const stderr = writer();
+    const { app, appServices, trustState } = makeFakeHarness();
+    trustState.trusted = false;
+    const workspaces = appServices.get(IWorkspaceInstanceManager) as {
+      getOrCreate: ReturnType<typeof vi.fn>;
+    };
+    workspaces.getOrCreate.mockRejectedValueOnce(new Error('trust store unavailable'));
+
+    mocks.bootstrap.mockReturnValue({ app });
+    mocks.ensureMainAgent.mockResolvedValue({ agentId: 'main', generation: 1 });
+
+    await runV2Print(opts() as never, '1.2.3-test', { stdout, stderr });
+
+    expect(stdout.text()).toContain('hello world');
   });
 });

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -152,7 +152,11 @@ import {
 } from '@moonshot-ai/agent-core';
 import { encodeWorkDirKey } from '@moonshot-ai/agent-core-v2/_base/utils/workdir-slug';
 import { McpConnectionManager } from '@moonshot-ai/agent-core-v2/mcpCore/connection-manager';
-import { loadMcpServers } from '@moonshot-ai/agent-core-v2/app/mcpConfig/configLoader';
+import {
+  loadMcpServers,
+  loadMcpServersDetailed,
+  resolveMcpJsonPaths,
+} from '@moonshot-ai/agent-core-v2/app/mcpConfig/configLoader';
 import { fsSuggestRequestSchema } from '@moonshot-ai/agent-core-v2/workspace/workspaceFs/fs';
 import { IAppendLogStore } from '@moonshot-ai/agent-core-v2/persistence/interface/appendLogStore';
 import type { McpServerConfig as WorkspaceMcpServerConfig } from '@moonshot-ai/agent-core-v2/mcpCore/config-schema';
@@ -695,8 +699,8 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
    * via {@link engineAccessor} — the same `handlerFor({ root })` path
    * `createSession` takes (materializing the workspace handler is a no-op
    * cost here: session creation does it anyway). The gated-server list is
-   * what the pure config loader sees with project files included vs skipped
-   * (the workspaceTrust gate inside the engine's `workspaceMcpConfig`),
+   * the final merged config entries whose origins are project files (the
+   * workspaceTrust gate inside the engine's `workspaceMcpConfig`),
    * computed best-effort: an unreadable/invalid project file degrades to an
    * empty list rather than failing the caller.
    */
@@ -708,12 +712,18 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
     if (trusted) return { trusted: true, gatedMcpServers: [] };
     try {
       const fs = this.engineAccessor.get(IHostFileSystem);
-      const [withProject, userOnly] = await Promise.all([
-        loadMcpServers({ fs, cwd: workDir, homeDir: this.homeDir, includeProject: true }),
-        loadMcpServers({ fs, cwd: workDir, homeDir: this.homeDir, includeProject: false }),
+      const [paths, loaded] = await Promise.all([
+        resolveMcpJsonPaths({ fs, cwd: workDir, homeDir: this.homeDir }),
+        loadMcpServersDetailed({
+          fs,
+          cwd: workDir,
+          homeDir: this.homeDir,
+          includeProject: true,
+        }),
       ]);
-      const gatedMcpServers = Object.entries(withProject)
-        .filter(([name]) => !(name in userOnly))
+      const projectPaths = new Set([paths.projectRoot, paths.project]);
+      const gatedMcpServers = Object.entries(loaded.servers)
+        .filter(([name]) => projectPaths.has(loaded.origins[name] ?? ''))
         .map(([name, config]) => describeWorkspaceMcpServer(name, config))
         .toSorted((a, b) => a.name.localeCompare(b.name));
       return { trusted: false, gatedMcpServers };

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -1212,6 +1212,47 @@ describe('SDKRpcClientV2 workspace trust', () => {
     }
   });
 
+  it('reports project servers that override same-named user entries', async () => {
+    const { harness, homeDir } = await makeHarness();
+    const workDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-work-'));
+    tempDirs.push(workDir);
+    await writeFile(
+      join(homeDir, 'mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          github: { command: 'user-github', enabled: false },
+        },
+      }),
+      'utf-8',
+    );
+    await writeFile(
+      join(workDir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          github: { command: 'project-github', enabled: false },
+          toString: { transport: 'http', url: 'https://example.test/mcp', enabled: false },
+        },
+      }),
+      'utf-8',
+    );
+    try {
+      const info = await harness.getWorkspaceTrustInfo(workDir);
+      expect(info.trusted).toBe(false);
+      expect(info.gatedMcpServers).toEqual([
+        {
+          name: 'github',
+          transport: 'stdio',
+          command: 'project-github',
+          args: undefined,
+          cwd: workDir,
+        },
+        { name: 'toString', transport: 'http', url: 'https://example.test/mcp' },
+      ]);
+    } finally {
+      await harness.close();
+    }
+  });
+
   it('degrades the gated-server list to empty on an invalid project mcp.json', async () => {
     const { harness } = await makeHarness();
     const workDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-work-'));


### PR DESCRIPTION
## Related Issue

None — problem explained below.

## Problem

In `kimi -p` (print mode), project-level MCP servers (the project-root `.mcp.json` and `.kimi-code/mcp.json`) are silently skipped when the folder has never been trusted: the v2 engine's workspace-trust gate excludes them, but print mode has no trust prompt, no flag to grant trust, and no output indicating anything was skipped. This regressed when CLI surfaces defaulted to the agent-core-v2 engine (#2627) — before that, `kimi -p` ran on the v1 engine, which loads project MCP config unconditionally.

## What changed

`kimi -p` now probes the workspace trust state before creating the session. When the folder is untrusted and project-level MCP servers are declared, it prints a stderr warning listing the skipped servers and how to enable them (run `kimi` interactively and choose "Trust this folder"). The probe mirrors the SDK's `getWorkspaceTrustInfo` — a diff of the MCP config loader with project files included vs skipped — and is best-effort: a broken `mcp.json` or trust store never fails the run. Trusted folders, and untrusted folders with no project-level servers, produce no output.

Tests: unit tests for the warning formatter, plus harness-level tests covering untrusted-with-gated-servers (warns), trusted (no config read, no warning), untrusted-without-servers (silent), and probe failure (the run proceeds).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
