### PR TITLE
fix(kap-server): stop event journal writes after server close

### DIFF
--- a/packages/kap-server/src/transport/ws/v1/sessionEventBroadcaster.ts
+++ b/packages/kap-server/src/transport/ws/v1/sessionEventBroadcaster.ts
@@ -510,6 +510,9 @@ export class SessionEventBroadcaster {
     if (this.closed) return;
     this.closed = true;
     this.coreEventSubscription.dispose();
+    await Promise.all(
+      [...this.pendingStates.values()].map((pending) => pending.catch(() => undefined)),
+    );
     for (const [sessionId, state] of this.sessions) {
       await disposeSessionState(state);
       this.opts.transcriptService?.dropSession(sessionId);
@@ -575,7 +578,8 @@ export class SessionEventBroadcaster {
     return state;
   }
 
-  private ensureGlobalState(): Promise<SessionState> {
+  private ensureGlobalState(): Promise<SessionState | undefined> {
+    if (this.closed) return Promise.resolve(undefined);
     const existing = this.sessions.get(GLOBAL_SESSION_ID);
     if (existing !== undefined) return Promise.resolve(existing);
     let pending = this.pendingStates.get(GLOBAL_SESSION_ID);
@@ -587,14 +591,18 @@ export class SessionEventBroadcaster {
       });
       this.pendingStates.set(GLOBAL_SESSION_ID, pending);
     }
-    return pending as Promise<SessionState>;
+    return pending;
   }
 
-  private async createGlobalState(): Promise<SessionState> {
+  private async createGlobalState(): Promise<SessionState | undefined> {
     const journal = await SessionEventJournal.open(
       sessionJournalPath(this.opts.eventsDir, GLOBAL_SESSION_ID),
       this.opts.logger,
     );
+    if (this.closed) {
+      await journal.close();
+      return undefined;
+    }
     const state: SessionState = {
       sessionId: GLOBAL_SESSION_ID,
       journal,
@@ -767,6 +775,7 @@ export class SessionEventBroadcaster {
 
   private async dispatchGlobal(event: Event): Promise<void> {
     const state = await this.ensureGlobalState();
+    if (state === undefined) return;
     state.queue = state.queue
       .then(() => this.dispatch(state, event, isVolatileEventType(event.type)))
       .catch((error: unknown) => this.logDispatchDropped(state.sessionId, event.type, error));

--- a/packages/kap-server/src/transport/ws/v1/sessionEventJournal.ts
+++ b/packages/kap-server/src/transport/ws/v1/sessionEventJournal.ts
@@ -46,6 +46,7 @@ export class SessionEventJournal {
   private pendingLines: string[] = [];
   private flushPromise: Promise<void> | undefined;
   private headerPending: boolean;
+  private closed = false;
 
   private constructor(
     private readonly filePath: string,
@@ -103,6 +104,7 @@ export class SessionEventJournal {
   }
 
   append(seq: number, envelope: EventEnvelope): void {
+    if (this.closed) return;
     const line: JournalEventLine = { kind: 'event', seq, envelope };
     this.pendingLines.push(JSON.stringify(line));
     this.scheduleFlush();
@@ -138,6 +140,7 @@ export class SessionEventJournal {
   }
 
   async close(): Promise<void> {
+    this.closed = true;
     await this.flush();
   }
 

--- a/packages/kap-server/test/sessionEventBroadcaster.test.ts
+++ b/packages/kap-server/test/sessionEventBroadcaster.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -1320,6 +1320,19 @@ describe('SessionEventBroadcaster', () => {
         root: '/repo/a',
       },
     });
+
+    const journalPath = join(dir, '__global__.jsonl');
+    await vi.waitFor(async () => {
+      expect(await readFile(journalPath, 'utf8').catch(() => '')).toContain('wd_a');
+    });
+    const before = await readFile(journalPath, 'utf8');
+    eventBus.emit({
+      type: 'event.workspace.deleted',
+      payload: { workspaceId: 'wd_b', root: '/repo/b' },
+    });
+    await bc.close();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(await readFile(journalPath, 'utf8')).toBe(before);
   });
 
   it('gates event.di.unit_changed to connections opted into the DI debug feed', async () => {
@@ -2320,6 +2333,14 @@ describe('SessionEventBroadcaster', () => {
           delta: (envelope.payload as { delta: string }).delta,
         })),
     ).toEqual([{ offset: 0, delta: 'abc' }]);
+
+    eventBus.emit({
+      type: 'event.workspace.deleted',
+      payload: { workspaceId: 'wd_late', root: '/repo/late' },
+    });
+    await bc.close();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(await readdir(dir)).not.toContain('__global__.jsonl');
   });
 
   describe('transcript streaming', () => {

--- a/packages/kap-server/test/sessionEventJournal.test.ts
+++ b/packages/kap-server/test/sessionEventJournal.test.ts
@@ -53,6 +53,9 @@ describe('SessionEventJournal', () => {
     j1.append(j1.nextSeq(), envelope(2));
     await j1.close();
 
+    j1.append(j1.nextSeq(), envelope(3));
+    await j1.flush();
+
     const j2 = await SessionEventJournal.open(filePath);
     expect(j2.epoch).toBe(epoch);
     expect(j2.seq).toBe(2);


### PR DESCRIPTION
## Related Issue

No linked issue — internal fix for the flaky CI `test (5)` shard.

## Problem

The `test (5)` CI shard flaked 9 times in the last ~100 CI runs, always the same failure: `packages/kap-server/test/tools.test.ts` teardown dying with `ENOTEMPTY: directory not empty, rmdir '/tmp/kimi-server-v2-tools-*/server[/events]'` (vitest shard assignment is path-deterministic, so this file always lands on shard 5).

Root cause: `SessionEventBroadcaster.close()` was not a write barrier. After it resolved, in-flight session/global state creation (`pendingStates`, especially `createGlobalState`, which never re-checked the closed flag) and already-queued dispatches could still append to the event journal — `SessionEventJournal.append()` kept writing even after `journal.close()` — recreating `server/events/*.jsonl` while the test's `rm -rf` was walking the directory.

## What changed

- `SessionEventJournal` gains a closed flag: `close()` sets it before flushing and `append()` becomes a no-op afterwards, making the journal itself a write barrier.
- `SessionEventBroadcaster.close()` awaits all in-flight state creations (`pendingStates`) before disposing sessions, so nothing can register new state or subscriptions after close returns.
- `createGlobalState` re-checks the closed flag after opening the journal (matching the existing `createSessionState` pattern); `ensureGlobalState` returns `undefined` once closed and `dispatchGlobal` drops the event.
- Regression coverage is folded into existing journal/broadcaster tests (no new test files): append-after-close is dropped, a queued dispatch after close never reaches disk, and a global state creation racing close leaves no journal file behind.

Verification: focused journal/broadcaster suites pass (98 tests); mutation checks confirm each new assertion fails without its corresponding fix; full `@moonshot-ai/kap-server` suite passes (74 files, 1325 tests); typecheck and the no-comments check pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
