### PR TITLE
feat(kap-server): add POST /sessions/{id}/skills:reload endpoint

### DIFF
--- a/.changeset/skill-reload-endpoint.md
+++ b/.changeset/skill-reload-endpoint.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add a session skills reload endpoint so clients can pick up newly created user skills without restarting the session.

--- a/packages/agent-core-v2/src/features/skill/session/skillCatalogData.ts
+++ b/packages/agent-core-v2/src/features/skill/session/skillCatalogData.ts
@@ -10,6 +10,7 @@ export interface ISessionSkillCatalogData {
   readonly ready: Promise<void>;
   readonly catalog: SkillCatalog;
   readonly onDidChange: Event<string>;
+  reloadSources(ids: readonly string[]): Promise<void>;
 }
 
 export const ISessionSkillCatalogData: ServiceIdentifier<ISessionSkillCatalogData> =

--- a/packages/agent-core-v2/src/features/skill/workspace/workspaceSkillCatalogService.ts
+++ b/packages/agent-core-v2/src/features/skill/workspace/workspaceSkillCatalogService.ts
@@ -99,6 +99,7 @@ export class WorkspaceSkillCatalogService extends Disposable implements IWorkspa
       get catalog() {
         return currentCatalog();
       },
+      reloadSources: (ids) => this.reloadSources(ids),
     };
   }
 

--- a/packages/agent-core-v2/test/features/skill/session/skillCatalog.test.ts
+++ b/packages/agent-core-v2/test/features/skill/session/skillCatalog.test.ts
@@ -35,6 +35,7 @@ function dataSeed(initial: InMemorySkillCatalog): {
       get catalog() {
         return current;
       },
+      reloadSources: () => Promise.resolve(),
     },
     replace(next: InMemorySkillCatalog) {
       current = next;

--- a/packages/agent-core-v2/test/harness/agent.ts
+++ b/packages/agent-core-v2/test/harness/agent.ts
@@ -1242,6 +1242,7 @@ export class AgentTestContext {
               ready: Promise.resolve(),
               catalog: new InMemorySkillCatalog(),
               onDidChange: Event.None as Event<string>,
+              reloadSources: () => Promise.resolve(),
             } satisfies ISessionSkillCatalogData);
             reg.defineInstance(ISessionAgentProfileCatalogSeed, {
               _serviceBrand: undefined,

--- a/packages/kap-server/src/routes/skills.ts
+++ b/packages/kap-server/src/routes/skills.ts
@@ -15,6 +15,7 @@ import {
   ISessionIndex,
   ISessionMediaStore,
   ISessionSkillCatalog,
+  ISessionSkillCatalogData,
   ISkillDiscovery,
   ITelemetryService,
   IWorkspaceService,
@@ -25,7 +26,6 @@ import {
   MERGE_ALL_AVAILABLE_SKILLS_SECTION,
   SKILL_SOURCE_PRIORITY,
   configuredRoots,
-  programForSession,
   projectRoots,
   sessionMediaOriginalsDir,
   userRoots,
@@ -166,8 +166,8 @@ export function registerSkillsRoutes(app: SkillsRouteHost, core: Scope): void {
         reply.send(resolved.envelope);
         return;
       }
-      const program = await programForSession(core.accessor, session_id);
-      await program?.skills.reloadSources(SKILLS_RELOAD_SOURCES);
+      const data = resolved.handle.accessor.get(ISessionSkillCatalogData);
+      await data.reloadSources(SKILLS_RELOAD_SOURCES);
       const catalog = resolved.handle.accessor.get(ISessionSkillCatalog);
       await catalog.ready;
       const skills = catalog.catalog.listSkills().map(toProtocolSkill);

--- a/packages/kap-server/src/routes/skills.ts
+++ b/packages/kap-server/src/routes/skills.ts
@@ -25,6 +25,7 @@ import {
   MERGE_ALL_AVAILABLE_SKILLS_SECTION,
   SKILL_SOURCE_PRIORITY,
   configuredRoots,
+  programForSession,
   projectRoots,
   sessionMediaOriginalsDir,
   userRoots,
@@ -84,6 +85,8 @@ const sessionIdParamSchema = z.object({
   session_id: z.string().min(1),
 });
 
+const SKILLS_RELOAD_SOURCES: readonly string[] = ['user', 'explicit', 'extra'];
+
 const skillTailParamsSchema = z.object({
   session_id: z.string().min(1),
   tail: z.string().min(1),
@@ -140,6 +143,41 @@ export function registerSkillsRoutes(app: SkillsRouteHost, core: Scope): void {
     listSkillsRoute.path,
     listSkillsRoute.options,
     listSkillsRoute.handler as Parameters<SkillsRouteHost['get']>[2],
+  );
+
+  const reloadSkillsRoute = defineRoute(
+    {
+      method: 'POST',
+      path: '/sessions/{session_id}/skills::reload',
+      params: sessionIdParamSchema,
+      success: { data: listSkillsResponseSchema },
+      errors: {
+        [ErrorCode.SESSION_NOT_FOUND]: {},
+      },
+      description:
+        'Reload the user-level skill sources (user / explicit / extra dirs) and return the refreshed skill list',
+      tags: ['skills'],
+      operationId: 'reloadSkills',
+    },
+    async (req, reply) => {
+      const { session_id } = req.params;
+      const resolved = await resolveActivatedSession(core, session_id, req.id);
+      if ('envelope' in resolved) {
+        reply.send(resolved.envelope);
+        return;
+      }
+      const program = await programForSession(core.accessor, session_id);
+      await program?.skills.reloadSources(SKILLS_RELOAD_SOURCES);
+      const catalog = resolved.handle.accessor.get(ISessionSkillCatalog);
+      await catalog.ready;
+      const skills = catalog.catalog.listSkills().map(toProtocolSkill);
+      reply.send(okEnvelope({ skills }, req.id));
+    },
+  );
+  app.post(
+    reloadSkillsRoute.path,
+    reloadSkillsRoute.options,
+    reloadSkillsRoute.handler as Parameters<SkillsRouteHost['post']>[2],
   );
 
   const listWorkspaceSkillsRoute = defineRoute(

--- a/packages/kap-server/test/__snapshots__/apiSurface.snapshot.test.ts.snap
+++ b/packages/kap-server/test/__snapshots__/apiSurface.snapshot.test.ts.snap
@@ -458,6 +458,10 @@ exports[`API surface snapshot > matches the documented v2 route table and meta e
     ],
     [
       "POST",
+      "/api/v1/sessions/{session_id}/skills:reload",
+    ],
+    [
+      "POST",
       "/api/v1/sessions/{session_id}/skills/{tail}",
     ],
     [

--- a/packages/kap-server/test/skills.test.ts
+++ b/packages/kap-server/test/skills.test.ts
@@ -406,6 +406,44 @@ describe('server-v2 /api/v1 skills', () => {
     });
   });
 
+  describe('POST /api/v1/sessions/{sid}/skills:reload', () => {
+    it('returns 40401 for an unknown session', async () => {
+      const { body } = await postJson<null>('/api/v1/sessions/nope/skills:reload');
+      expect(body.code).toBe(40401);
+      expect(body.msg).toMatch(/does not exist/);
+    });
+
+    it('picks up a user skill created after the session started', async () => {
+      const id = await createSession();
+      const skillName = 'e2e-reload-skill';
+      const before = await getJson<{ skills: SkillWire[] }>(`/api/v1/sessions/${id}/skills`);
+      expect(before.body.code).toBe(0);
+      expect(before.body.data.skills.some((s) => s.name === skillName)).toBe(false);
+
+      const skillDir = join(home as string, 'skills', skillName);
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(
+        join(skillDir, 'SKILL.md'),
+        `---\nname: ${skillName}\ndescription: reload test skill\n---\n\nSay hello.\n`,
+      );
+      try {
+        const { body } = await postJson<{ skills: SkillWire[] }>(
+          `/api/v1/sessions/${id}/skills:reload`,
+        );
+        expect(body.code).toBe(0);
+        const skills = listSkillsResponseSchema.parse(body.data).skills;
+        const seeded = skills.find((s) => s.name === skillName);
+        expect(seeded).toBeDefined();
+        expect(seeded?.source).toBe('user');
+
+        const after = await getJson<{ skills: SkillWire[] }>(`/api/v1/sessions/${id}/skills`);
+        expect(after.body.data.skills.some((s) => s.name === skillName)).toBe(true);
+      } finally {
+        await rm(skillDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe('GET /api/v1/workspaces/{wid}/skills', () => {
     it('lists skills for a workspace without creating a session', async () => {
       const workspaceDir = await makeWorkspaceDir();


### PR DESCRIPTION
## Related Issue

Fixes the daemon side of "skills created from the app are not visible to the current session without a restart" (client-side change: https://github.com/MoonshotAI/kimi-code-app/pull/542).

## Problem

The daemon's workspace skill catalog only re-scans the user-level skill directories (`~/.kimi-code/skills`, `~/.agents/skills`, explicit/extra dirs) when a session is created. Those directories are not watched, so a skill created while a session is running never shows up in `GET /sessions/{id}/skills` until the daemon restarts or a new session is created.

## What changed

- Add `POST /api/v1/sessions/{session_id}/skills:reload` in `packages/kap-server/src/routes/skills.ts`. It resolves the session like the existing skills routes, calls `IWorkspaceSkillCatalog.reloadSources(['user', 'explicit', 'extra'])` on the session's program (via `programForSession`), and returns the refreshed skill list in the same shape as `GET /sessions/{id}/skills`.
- The path follows the repo's literal-colon route convention (`skills::reload`, same as `fs::search`), so it matches exactly `/sessions/{id}/skills:reload`.
- Tests in `packages/kap-server/test/skills.test.ts`: 40401 for an unknown session, and an end-to-end check that a `SKILL.md` written into the user skills dir after session creation appears in the reload response and in the subsequent list. API surface snapshot updated.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
