### PR TITLE
fix(remote-control): release the lock before reporting off and re-read the server token per forward

### DIFF
--- a/packages/kap-server/test/remoteControl.test.ts
+++ b/packages/kap-server/test/remoteControl.test.ts
@@ -14,6 +14,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest
 import { WebSocketServer, type RawData, type WebSocket } from 'ws';
 
 import { ErrorCode } from '../src/protocol/error-codes';
+import { writeServerToken } from '../src/services/auth/persistentToken';
 import { type RunningServer, startServer } from '../src/start';
 import { authedFetch } from './helpers/auth';
 import { TEST_HOST_IDENTITY } from './helpers/hostIdentity';
@@ -114,7 +115,29 @@ describe('server-v2 /api/v1/remote-control', () => {
     const restarted = await postRemoteControl(true);
     expect(restarted.code).toBe(0);
     expect(restarted.data.state).toBe('on');
-    relay.managementSockets[relay.managementSockets.length - 1]!.send(
+
+    await writeServerToken(home as string, 'rotated-server-token');
+    const httpSocket = relay.httpSockets.at(-1)!;
+    const rotatedResponsePromise = nextJsonMessage(httpSocket);
+    httpSocket.send(
+      JSON.stringify({
+        request_id: 'request-rotated',
+        type: 'request',
+        is_last: true,
+        body_base64: Buffer.from(
+          'GET /api/v1/healthz HTTP/1.1\r\nHost: relay.test\r\n\r\n',
+        ).toString('base64'),
+      }),
+    );
+    const rotatedMessage = await rotatedResponsePromise;
+    const rotatedResponse = Buffer.from(
+      rotatedMessage['body_base64'] as string,
+      'base64',
+    ).toString();
+    expect(rotatedResponse).toContain('HTTP/1.1 200');
+    expect(rotatedResponse).toContain('"ok":true');
+
+    relay.managementSockets.at(-1)!.send(
       JSON.stringify({ type: 'disconnect', payload: { reason: 'user_requested' } }),
     );
     await waitFor(async () => {
@@ -156,10 +179,19 @@ function rawDataText(data: RawData): string {
   return Buffer.from(data as ArrayBuffer).toString('utf8');
 }
 
+function nextJsonMessage(socket: WebSocket): Promise<Record<string, unknown>> {
+  return new Promise((resolve) => {
+    socket.once('message', (data) => {
+      resolve(JSON.parse(rawDataText(data)) as Record<string, unknown>);
+    });
+  });
+}
+
 async function startRegisterAckRelay(): Promise<{
   port: number;
   registrations: unknown[];
   managementSockets: WebSocket[];
+  httpSockets: WebSocket[];
   close(): Promise<void>;
 }> {
   const managementServer = new WebSocketServer({ noServer: true });
@@ -167,6 +199,7 @@ async function startRegisterAckRelay(): Promise<{
   const relayServer = createServer();
   const registrations: unknown[] = [];
   const managementSockets: WebSocket[] = [];
+  const httpSockets: WebSocket[] = [];
   managementServer.on('connection', (ws) => {
     managementSockets.push(ws);
     ws.on('error', () => {});
@@ -179,6 +212,7 @@ async function startRegisterAckRelay(): Promise<{
     });
   });
   httpTunnelServer.on('connection', (ws) => {
+    httpSockets.push(ws);
     ws.on('error', () => {});
   });
   relayServer.on('upgrade', (request, socket, head) => {
@@ -198,6 +232,7 @@ async function startRegisterAckRelay(): Promise<{
     port,
     registrations,
     managementSockets,
+    httpSockets,
     close: () =>
       new Promise((resolve, reject) => {
         relayServer.close((error) => {

--- a/packages/remote-control/src/manager.ts
+++ b/packages/remote-control/src/manager.ts
@@ -111,9 +111,15 @@ export function createRemoteControlManager(
 ): RemoteControlManager {
   const actor = createActor(
     createRemoteControlMachine(options, (handle) => {
-      void handle.closed.then(() => {
-        actor.send({ type: 'tunnel.exited' });
-      });
+      void handle.closed.then(
+        () => {
+          actor.send({ type: 'tunnel.exited' });
+        },
+        (error) => {
+          options.stderr?.write(`remote-control lock release failed: ${errorMessage(error)}\n`);
+          actor.send({ type: 'tunnel.exited' });
+        },
+      );
     }),
   );
   actor.start();

--- a/packages/remote-control/src/manager.ts
+++ b/packages/remote-control/src/manager.ts
@@ -50,7 +50,7 @@ function createRemoteControlMachine(
         const handle = await startRemoteControl({
           homeDir: options.homeDir,
           localOrigin: options.localOrigin(),
-          localServerToken: options.localServerToken(),
+          localServerToken: options.localServerToken,
           clientVersion: options.clientVersion,
           relayOrigin: options.relayOrigin,
           stderr: options.stderr,

--- a/packages/remote-control/src/remote-control.ts
+++ b/packages/remote-control/src/remote-control.ts
@@ -86,7 +86,7 @@ export type RemoteControlStatus =
 export interface RemoteControlOptions {
   readonly homeDir: string;
   readonly localOrigin: string;
-  readonly localServerToken: string;
+  readonly localServerToken: string | (() => string);
   readonly clientVersion: string;
   readonly relayOrigin?: string;
   readonly stderr?: Pick<NodeJS.WriteStream, 'write'>;
@@ -220,7 +220,11 @@ export function rewriteRemoteControlResponse(
 export async function startRemoteControl(
   options: RemoteControlOptions,
 ): Promise<RemoteControlHandle> {
-  if (options.localServerToken.length === 0) {
+  const localServerToken =
+    typeof options.localServerToken === 'function'
+      ? options.localServerToken
+      : () => options.localServerToken as string;
+  if (localServerToken().length === 0) {
     throw new Error('Remote Control requires local server authentication.');
   }
   const storage = new FileTokenStorage(join(options.homeDir, 'credentials'));
@@ -241,6 +245,7 @@ export async function startRemoteControl(
   });
   const client = new RemoteControlClient({
     ...options,
+    localServerToken,
     relayOrigin,
     deviceId,
     refreshToken: token.refreshToken,
@@ -251,8 +256,9 @@ export async function startRemoteControl(
     await lock.release();
     throw error;
   }
-  const closed = client.closed;
-  void closed.then(() => lock.release());
+  const closed = client.closed.then(async () => {
+    await lock.release();
+  });
   return {
     deviceId,
     deviceName,
@@ -260,14 +266,14 @@ export async function startRemoteControl(
     closed,
     close: async () => {
       await client.close();
-      await lock.release();
+      await closed;
     },
   };
 }
 
 class RemoteControlClient {
   private readonly localOrigin: string;
-  private readonly localServerToken: string;
+  private readonly localServerToken: () => string;
   private readonly clientVersion: string;
   private readonly relayOrigin: string;
   private readonly deviceId: string;
@@ -292,7 +298,8 @@ class RemoteControlClient {
   private initialReject: ((error: unknown) => void) | undefined;
 
   constructor(
-    options: RemoteControlOptions & {
+    options: Omit<RemoteControlOptions, 'localServerToken'> & {
+      readonly localServerToken: () => string;
       readonly relayOrigin: string;
       readonly deviceId: string;
       readonly refreshToken: string;
@@ -531,7 +538,7 @@ class RemoteControlClient {
       const response = await requestLocalHttp(
         this.localOrigin,
         parsed,
-        this.localServerToken,
+        this.localServerToken(),
         this.publicPrefix(),
       );
       this.sendHttpResponse(requestId, response);
@@ -570,7 +577,7 @@ class RemoteControlClient {
     try {
       local = await connectWebSocket(
         localWebSocketUrl(this.localOrigin, path),
-        this.localServerToken,
+        this.localServerToken(),
         relayHeaders(payload['headers']),
         earlyLocalFrames,
       );

--- a/packages/remote-control/test/remote-control.test.ts
+++ b/packages/remote-control/test/remote-control.test.ts
@@ -337,10 +337,11 @@ describe('Remote Control tunnel', () => {
 
     let handle: RemoteControlHandle | undefined;
     cleanups.push(async () => handle?.close());
+    let currentToken = 'local-server-token';
     handle = await startRemoteControl({
       homeDir,
       localOrigin: `http://127.0.0.1:${localPort}`,
-      localServerToken: 'local-server-token',
+      localServerToken: () => currentToken,
       clientVersion: CLIENT_VERSION,
       relayOrigin: `http://127.0.0.1:${relayPort}/coding-relay`,
       stderr: { write: () => true },
@@ -386,6 +387,19 @@ describe('Remote Control tunnel', () => {
     expect(response).toContain('Cache-Control: no-cache');
     expect(response).toContain(`/coding-relay/devices/${handle.deviceId}/boot.js`);
 
+    currentToken = 'rotated-server-token';
+    const rotatedResponsePromise = nextJsonMessage(httpConnections[0]!);
+    httpConnections[0]!.send(
+      JSON.stringify({
+        request_id: 'request-2',
+        type: 'request',
+        is_last: true,
+        body_base64: rawRequest.toString('base64'),
+      }),
+    );
+    await rotatedResponsePromise;
+    await waitFor(() => localHttpRequest?.headers.authorization === 'Bearer rotated-server-token');
+
     managementConnections[0]!.send(
       JSON.stringify({
         type: 'open_ws',
@@ -398,7 +412,7 @@ describe('Remote Control tunnel', () => {
     );
     await waitFor(() => streamConnections.length === 1 && localWs !== undefined);
     expect(localWsRequest?.headers['sec-websocket-protocol']).toBe(
-      'kimi-code.bearer.local-server-token',
+      'kimi-code.bearer.rotated-server-token',
     );
     expect(localWsRequest?.headers.authorization).toBeUndefined();
     expect(localWsRequest?.headers.cookie).toBeUndefined();
@@ -584,7 +598,7 @@ describe('Remote Control single-instance lock', () => {
       JSON.stringify({ type: 'disconnect', payload: { reason: 'user_requested' } }),
     );
     await second.closed;
-    await waitFor(() => !existsSync(remoteControlLockPath(homeDir)));
+    expect(existsSync(remoteControlLockPath(homeDir))).toBe(false);
   });
 
   it('does not remove a successor lock when closing', async () => {


### PR DESCRIPTION
## Related Issue

Follow-up to #3594 — addresses the two remaining P2 comments from the Codex review of `09d4abd`.

## Problem

Two race/lifecycle defects in the Remote Control tunnel shipped with #3594:

1. After the tunnel stops (relay-initiated or via `close()`), `closed` resolved before the machine-wide lock was released, so an immediate re-enable could fail spuriously with "already running".
2. The tunnel baked the local server token at construction; after token rotation every forwarded request failed with 401 until the tunnel was restarted.

## What changed

- `startRemoteControl`'s `closed` now resolves only after the run loop ends **and** the lock release completes; `close()` folds into the same single release path. The manager's `closed` subscription handles a failed release (logs and still transitions to off).
- `RemoteControlOptions.localServerToken` accepts `string | (() => string)`; the client reads the token on every forwarded HTTP request and WebSocket handshake, so a rotated token is picked up without a tunnel restart. String call sites are unaffected.

Tests (count unchanged, extended in place): the lock test asserts the lock file is gone deterministically after relay-initiated shutdown; the tunnel test switches to a token provider and asserts the rotated credential is used on the next forward and WS handshake.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
