### PR TITLE
fix(agent-core-v2): merge text deltas across empty reasoning stream parts

### DIFF
--- a/packages/agent-core-v2/src/agent/loop/loopService.ts
+++ b/packages/agent-core-v2/src/agent/loop/loopService.ts
@@ -1051,6 +1051,7 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
 
   private accumulateMachinePart(turn: ActiveTurn, part: ContentPart): void {
     const last = turn.partials.at(-1);
+    if (part.type === 'think' && last?.type === 'text' && isVacuousContentPart(part)) return;
     if (!turn.forceContentPartBoundary && last !== undefined && mergeInPlace(last, part)) return;
     turn.forceContentPartBoundary = false;
     turn.partials.push({ ...part });

--- a/packages/agent-core-v2/src/human/llm/message.ts
+++ b/packages/agent-core-v2/src/human/llm/message.ts
@@ -197,27 +197,31 @@ export function createMessageAccumulator(): MessageAccumulator {
   const message: AssistantMessage = { role: 'assistant', content: [], toolCalls: [] };
   const toolCallIndexMap = new Map<number | string, number>();
   let pending: StreamedMessagePart | null = null;
+  let deferredThink: ThinkPart | null = null;
   const flush = () => {
-    if (pending === null) {
-      return;
-    }
-    if (isContentPart(pending)) {
-      message.content.push(pending);
-    } else if (isToolCall(pending)) {
-      const ordinal = message.toolCalls.length;
-      message.toolCalls.push({
-        type: 'function',
-        id: pending.id,
-        name: pending.name,
-        arguments: pending.arguments,
-        extras: pending.extras,
-        rawId: pending.rawId,
-      });
-      if (pending._streamIndex !== undefined) {
-        toolCallIndexMap.set(pending._streamIndex, ordinal);
+    if (pending !== null) {
+      if (isContentPart(pending)) {
+        message.content.push(pending);
+      } else if (isToolCall(pending)) {
+        const ordinal = message.toolCalls.length;
+        message.toolCalls.push({
+          type: 'function',
+          id: pending.id,
+          name: pending.name,
+          arguments: pending.arguments,
+          extras: pending.extras,
+          rawId: pending.rawId,
+        });
+        if (pending._streamIndex !== undefined) {
+          toolCallIndexMap.set(pending._streamIndex, ordinal);
+        }
       }
+      pending = null;
     }
-    pending = null;
+    if (deferredThink !== null) {
+      message.content.push(deferredThink);
+      deferredThink = null;
+    }
   };
   return {
     push(part: StreamedMessagePart) {
@@ -238,8 +242,15 @@ export function createMessageAccumulator(): MessageAccumulator {
           return;
         }
       }
+      if (part.type === 'text') {
+        deferredThink = null;
+      }
       if (pending === null) {
         pending = structuredClone(part);
+        return;
+      }
+      if (pending.type === 'text' && part.type === 'think' && isVacuousContentPart(part)) {
+        deferredThink = structuredClone(part);
         return;
       }
       if (!mergeInPlace(pending, part)) {

--- a/packages/agent-core-v2/src/human/test/llm/thinking.test.ts
+++ b/packages/agent-core-v2/src/human/test/llm/thinking.test.ts
@@ -453,5 +453,22 @@ describe('openai requester thinking', () => {
     await expect(
       collect(chatCompletionChunks([{ reasoning: '' }, { content: 'hi' }])),
     ).resolves.toContainEqual({ type: 'think', think: '' });
+    await expect(
+      collect(
+        chatCompletionChunks([
+          { reasoning: '', content: 'hel' },
+          { reasoning: '', content: 'lo' },
+        ]),
+      ),
+    ).resolves.toEqual([
+      { type: 'think', think: '' },
+      { type: 'text', text: 'hello' },
+    ]);
+    await expect(
+      collect(chatCompletionChunks([{ content: 'hi' }, { reasoning: '' }])),
+    ).resolves.toEqual([
+      { type: 'text', text: 'hi' },
+      { type: 'think', think: '' },
+    ]);
   });
 });

--- a/packages/agent-core-v2/test/agent/loop/loop.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/loop.test.ts
@@ -67,7 +67,12 @@ describe('Agent loop', () => {
   it('runs a text-only agent turn from prompt to completion', async () => {
     profile.update({ activeToolNames: [] });
 
-    ctx.mockNextResponse({ type: 'think', think: '<think-1>' }, { type: 'text', text: '<text-1>' });
+    ctx.mockNextResponse(
+      { type: 'think', think: '<think-1>' },
+      { type: 'text', text: '<text-1>' },
+      { type: 'think', think: '' },
+      { type: 'text', text: '<text-2>' },
+    );
     await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Hello' }] });
 
     expect(await ctx.untilTurnEnd()).toMatchInlineSnapshot(`
@@ -90,16 +95,20 @@ describe('Agent loop', () => {
       [wire] llm.tools_snapshot          { "agentId": "main", "hash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945", "tools": [], "time": "<time>" }
       [emit] assistant.delta             { "time": "<time>", "agentId": "main", "turnId": 0, "delta": "<text-1>" }
       [emit] agent.activity.updated      { "time": "<time>", "lifecycle": "ready", "turn": { "turnId": 0, "origin": { "kind": "user" }, "phase": "streaming", "stream": "assistant", "step": 1, "ending": false, "pendingApprovals": [], "activeToolCalls": [], "since": "<time>" }, "background": [], "agentId": "main" }
+      [emit] thinking.delta              { "time": "<time>", "agentId": "main", "turnId": 0, "delta": "" }
+      [emit] agent.activity.updated      { "time": "<time>", "lifecycle": "ready", "turn": { "turnId": 0, "origin": { "kind": "user" }, "phase": "streaming", "stream": "thinking", "step": 1, "ending": false, "pendingApprovals": [], "activeToolCalls": [], "since": "<time>" }, "background": [], "agentId": "main" }
       [wire] llm.request                 { "agentId": "main", "kind": "loop", "provider": "openai", "model": "mock-model", "modelAlias": "mock-model", "thinkingEffort": "off", "maxTokens": 1000000, "toolSelect": false, "systemPromptHash": "ec9c34379c88babbc468ef2f3e0e08cd2f422c8c4a910664fb8bb394d703a575", "toolsHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945", "messageCount": 1, "turnStep": "0.1", "time": "<time>" }
-      [wire] usage.record                { "agentId": "main", "model": "mock-model", "usage": { "inputOther": 3, "output": 8, "inputCacheRead": 0, "inputCacheCreation": 0 }, "usageScope": "turn", "time": "<time>" }
-      [emit] agent.status.updated        { "time": "<time>", "agentId": "main", "usage": { "byModel": { "mock-model": { "inputOther": 3, "output": 8, "inputCacheRead": 0, "inputCacheCreation": 0 } }, "total": { "inputOther": 3, "output": 8, "inputCacheRead": 0, "inputCacheCreation": 0 }, "currentTurn": { "inputOther": 3, "output": 8, "inputCacheRead": 0, "inputCacheCreation": 0 } } }
-      [wire] token_counting.measured     { "agentId": "main", "length": 2, "tokens": 11, "time": "<time>" }
-      [emit] agent.status.updated        { "time": "<time>", "agentId": "main", "contextTokens": 11 }
-      [emit] turn.step.completed         { "time": "<time>", "agentId": "main", "turnId": 0, "step": 1, "stepId": "<uuid-1>", "usage": { "inputOther": 3, "output": 8, "inputCacheRead": 0, "inputCacheCreation": 0 }, "finishReason": "end_turn", "providerFinishReason": "completed", "rawFinishReason": "stop" }
+      [emit] assistant.delta             { "time": "<time>", "agentId": "main", "turnId": 0, "delta": "<text-2>" }
+      [emit] agent.activity.updated      { "time": "<time>", "lifecycle": "ready", "turn": { "turnId": 0, "origin": { "kind": "user" }, "phase": "streaming", "stream": "assistant", "step": 1, "ending": false, "pendingApprovals": [], "activeToolCalls": [], "since": "<time>" }, "background": [], "agentId": "main" }
+      [wire] usage.record                { "agentId": "main", "model": "mock-model", "usage": { "inputOther": 3, "output": 10, "inputCacheRead": 0, "inputCacheCreation": 0 }, "usageScope": "turn", "time": "<time>" }
+      [emit] agent.status.updated        { "time": "<time>", "agentId": "main", "usage": { "byModel": { "mock-model": { "inputOther": 3, "output": 10, "inputCacheRead": 0, "inputCacheCreation": 0 } }, "total": { "inputOther": 3, "output": 10, "inputCacheRead": 0, "inputCacheCreation": 0 }, "currentTurn": { "inputOther": 3, "output": 10, "inputCacheRead": 0, "inputCacheCreation": 0 } } }
+      [wire] token_counting.measured     { "agentId": "main", "length": 2, "tokens": 13, "time": "<time>" }
+      [emit] agent.status.updated        { "time": "<time>", "agentId": "main", "contextTokens": 13 }
+      [emit] turn.step.completed         { "time": "<time>", "agentId": "main", "turnId": 0, "step": 1, "stepId": "<uuid-1>", "usage": { "inputOther": 3, "output": 10, "inputCacheRead": 0, "inputCacheCreation": 0 }, "finishReason": "end_turn", "providerFinishReason": "completed", "rawFinishReason": "stop" }
       [emit] agent.activity.updated      { "time": "<time>", "lifecycle": "ready", "turn": { "turnId": 0, "origin": { "kind": "user" }, "phase": "running", "step": 1, "ending": false, "pendingApprovals": [], "activeToolCalls": [], "since": "<time>" }, "background": [], "agentId": "main" }
       [wire] context.append_loop_event   { "agentId": "main", "event": { "type": "content.part", "uuid": "<uuid-2>", "turnId": "0", "step": 1, "stepUuid": "<uuid-1>", "part": { "type": "think", "think": "<think-1>" } }, "time": "<time>" }
-      [wire] context.append_loop_event   { "agentId": "main", "event": { "type": "content.part", "uuid": "<uuid-3>", "turnId": "0", "step": 1, "stepUuid": "<uuid-1>", "part": { "type": "text", "text": "<text-1>" } }, "time": "<time>" }
-      [wire] context.append_loop_event   { "agentId": "main", "event": { "type": "step.end", "uuid": "<uuid-1>", "turnId": "0", "step": 1, "finishReason": "end_turn", "usage": { "inputOther": 3, "output": 8, "inputCacheRead": 0, "inputCacheCreation": 0 }, "messageId": "mock-1", "providerFinishReason": "completed", "rawFinishReason": "stop" }, "time": "<time>" }
+      [wire] context.append_loop_event   { "agentId": "main", "event": { "type": "content.part", "uuid": "<uuid-3>", "turnId": "0", "step": 1, "stepUuid": "<uuid-1>", "part": { "type": "text", "text": "<text-1><text-2>" } }, "time": "<time>" }
+      [wire] context.append_loop_event   { "agentId": "main", "event": { "type": "step.end", "uuid": "<uuid-1>", "turnId": "0", "step": 1, "finishReason": "end_turn", "usage": { "inputOther": 3, "output": 10, "inputCacheRead": 0, "inputCacheCreation": 0 }, "messageId": "mock-1", "providerFinishReason": "completed", "rawFinishReason": "stop" }, "time": "<time>" }
       [wire] turn.ended                  { "agentId": "main", "turnId": 0, "reason": "completed", "time": "<time>" }
       [emit] turn.ended                  { "time": "<time>", "agentId": "main", "turnId": 0, "reason": "completed" }
     `);


### PR DESCRIPTION
## Related Issue

Resolve #2226

## Problem

With some third-party OpenAI-compatible providers (e.g. DeepSeek-class models behind gateways), streamed assistant replies render one token per line. Those gateways pad every stream chunk with both `content` and an empty `reasoning_content: ""`. The stream parser yields an empty `think` part for each padded chunk (deliberate behavior — empty thinking blocks must survive a round trip, see #1676), and the stream accumulators only merge adjacent same-type parts, so the empty thinks break text deltas into one text part per token.

## What changed

- Stream message accumulation now skips a vacuous `think` part (blank, no `encrypted`) when it would break an open text run, so consecutive text deltas merge into a single text part. Empty thinking blocks in any other position are still preserved and replayed verbatim on the wire, so the #1676 semantics are unchanged.
- The same rule is applied in the v2 loop facade's part accumulation, which drains parts into `content.part` loop events.
- Existing tests extended (net-zero count): the reasoning stream-delta case now covers per-chunk empty reasoning padding, and the text-only turn loop case mocks an interleaved empty-think stream and snapshots the merged `content.part` output.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
