### PR TITLE
refactor(agent-core-v2): drop anthropic_beta and google-vertex protocol names

### DIFF
--- a/packages/agent-core-v2/src/human/llm-kimi/provider.ts
+++ b/packages/agent-core-v2/src/human/llm-kimi/provider.ts
@@ -10,7 +10,7 @@ export const kimiProvider = createProvider({
   id: 'kimi',
   protocols: {
     openai: { base: openAIBase, trait: kimiOpenAITrait },
-    anthropic_beta: { base: anthropicBetaBase, trait: kimiAnthropicTrait },
+    anthropic: { base: anthropicBetaBase, trait: kimiAnthropicTrait },
     openai_responses: { base: openAIResponsesBase, trait: kimiResponsesTrait },
   },
   media: kimiMediaContribution,

--- a/packages/agent-core-v2/src/human/llm/model.ts
+++ b/packages/agent-core-v2/src/human/llm/model.ts
@@ -4,6 +4,8 @@ export interface LlmConnection {
   readonly baseUrl?: string;
   readonly apiKey?: string;
   readonly defaultHeaders?: Record<string, string>;
+  readonly betaApi?: boolean;
+  readonly vertexai?: boolean;
 }
 
 export interface LlmModel extends LlmConnection {

--- a/packages/agent-core-v2/src/human/llm/protocol/base.ts
+++ b/packages/agent-core-v2/src/human/llm/protocol/base.ts
@@ -3,13 +3,7 @@ import type { LlmRequester } from '#/llm/requester/requester';
 
 import type { ProtocolTrait } from './trait';
 
-export type ProtocolName =
-  | 'openai'
-  | 'openai_responses'
-  | 'anthropic'
-  | 'anthropic_beta'
-  | 'google-genai'
-  | 'google-vertex';
+export type ProtocolName = 'openai' | 'openai_responses' | 'anthropic' | 'google-genai';
 
 export interface ProtocolBase {
   capability?(modelName: string): ModelCapability | undefined;

--- a/packages/agent-core-v2/src/human/llm/protocol/trait.ts
+++ b/packages/agent-core-v2/src/human/llm/protocol/trait.ts
@@ -18,7 +18,7 @@ export interface ProtocolEndpoint {
 export interface ProtocolTrait {
   readonly strictThinkingValidation?: boolean;
 
-  endpoint?(): ProtocolEndpoint | undefined;
+  endpoint?(ctx?: TraitContext): ProtocolEndpoint | undefined;
 
   defaultHeaders?(ctx: TraitContext): Record<string, string> | undefined;
 
@@ -82,7 +82,7 @@ export function resolveModelConnection(
   model: LlmModel,
   trait: ProtocolTrait | undefined,
 ): LlmModel {
-  const declaration = trait?.endpoint?.();
+  const declaration = trait?.endpoint?.({ model });
   if (declaration === undefined) {
     return model;
   }

--- a/packages/agent-core-v2/src/human/llm/provider-catalog.ts
+++ b/packages/agent-core-v2/src/human/llm/provider-catalog.ts
@@ -36,7 +36,6 @@ export interface CatalogModelDefinition extends LlmModel {
   readonly protocol?: ProtocolName;
   readonly defaultEffort?: string;
   readonly adaptiveThinking?: boolean;
-  readonly betaApi?: boolean;
   readonly name?: string;
   readonly aliases?: readonly string[];
   readonly oauth?: CatalogOAuthRef;
@@ -639,6 +638,7 @@ function mergeModel(
     defaultEffort: record.defaultEffort,
     adaptiveThinking: record.adaptiveThinking,
     betaApi: record.betaApi,
+    vertexai: record.vertexai,
     name: record.name,
     aliases: record.aliases,
     oauth: record.oauth,

--- a/packages/agent-core-v2/src/human/llm/provider/definition.ts
+++ b/packages/agent-core-v2/src/human/llm/provider/definition.ts
@@ -5,7 +5,7 @@ import type { ProtocolBase, ProtocolName } from '#/llm/protocol/base';
 import type { ProtocolTrait } from '#/llm/protocol/trait';
 import type { LlmRequester } from '#/llm/requester/requester';
 
-export interface ProviderProtocolDefinition {
+export interface ProtocolVariant {
   readonly base: ProtocolBase;
   readonly trait?: ProtocolTrait;
 }
@@ -22,7 +22,7 @@ export type ProviderModelSource = () => Promise<readonly LlmModelSeed[]>;
 
 export interface ProviderDefinition {
   readonly id: string;
-  readonly protocols: Readonly<Partial<Record<ProtocolName, ProviderProtocolDefinition>>>;
+  readonly protocols: Readonly<Partial<Record<ProtocolName, ProtocolVariant>>>;
   readonly media?: ProviderMediaContribution;
   readonly models?: ProviderModelSource;
 }
@@ -40,49 +40,40 @@ export interface Provider {
   createRequester(protocol?: ProtocolName): LlmRequester;
 }
 
-interface ProviderProtocolEntry {
-  readonly name: ProtocolName;
-  readonly base: ProtocolBase;
-  readonly trait?: ProtocolTrait;
-}
-
 export function createProvider(definition: ProviderDefinition): Provider {
-  const entries: ProviderProtocolEntry[] = [];
+  const entries = new Map<ProtocolName, ProtocolVariant>();
   for (const name of Object.keys(definition.protocols) as ProtocolName[]) {
     const protocol = definition.protocols[name];
     if (protocol !== undefined) {
-      entries.push({ name, base: protocol.base, trait: protocol.trait });
+      entries.set(name, protocol);
     }
   }
-  const defaultEntry = entries[0];
-  if (defaultEntry === undefined) {
+  const defaultVariant = entries.values().next().value;
+  if (defaultVariant === undefined) {
     throw new Error(`provider '${definition.id}' declares no protocols`);
   }
 
-  const protocolFor = (name: ProtocolName | undefined): ProviderProtocolEntry => {
+  const variantFor = (name: ProtocolName | undefined): ProtocolVariant => {
     if (name === undefined) {
-      return defaultEntry;
+      return defaultVariant;
     }
-    const found = entries.find((entry) => entry.name === name);
+    const found = entries.get(name);
     if (found === undefined) {
       throw new Error(
-        `provider '${definition.id}' has no protocol '${name}' (available: ${entries.map((entry) => entry.name).join(', ')})`,
+        `provider '${definition.id}' has no protocol '${name}' (available: ${[...entries.keys()].join(', ')})`,
       );
     }
     return found;
   };
 
-  const detectCapability = (
-    entry: ProviderProtocolEntry,
-    modelName: string,
-  ): ModelCapability =>
-    entry.trait?.capability?.(modelName) ??
-    entry.base.capability?.(modelName) ??
+  const detectCapability = (variant: ProtocolVariant, modelName: string): ModelCapability =>
+    variant.trait?.capability?.(modelName) ??
+    variant.base.capability?.(modelName) ??
     UNKNOWN_CAPABILITY;
 
   return {
     id: definition.id,
-    protocols: entries.map((entry) => entry.name),
+    protocols: [...entries.keys()],
     media: definition.media,
     listModels: async () => {
       if (definition.models === undefined) {
@@ -93,29 +84,28 @@ export function createProvider(definition: ProviderDefinition): Provider {
         provider: definition.id,
         model: seed.model,
         capability:
-          defaultEntry.trait?.capability?.(seed.model) ??
+          defaultVariant.trait?.capability?.(seed.model) ??
           seed.capability ??
-          defaultEntry.base.capability?.(seed.model) ??
+          defaultVariant.base.capability?.(seed.model) ??
           UNKNOWN_CAPABILITY,
         maxContextSize: seed.maxContextSize,
         maxInputSize: seed.maxInputSize,
         baseUrl: seed.baseUrl,
       }));
     },
-    resolveModel: (model, options = {}) => {
-      const entry = protocolFor(options.protocol);
-      return {
-        provider: definition.id,
-        model,
-        capability: detectCapability(entry, model),
-        baseUrl: options.baseUrl,
-        apiKey: options.apiKey,
-        defaultHeaders: options.defaultHeaders,
-      };
-    },
+    resolveModel: (model, options = {}) => ({
+      provider: definition.id,
+      model,
+      capability: detectCapability(variantFor(options.protocol), model),
+      baseUrl: options.baseUrl,
+      apiKey: options.apiKey,
+      defaultHeaders: options.defaultHeaders,
+      betaApi: options.betaApi,
+      vertexai: options.vertexai,
+    }),
     createRequester: (protocol) => {
-      const entry = protocolFor(protocol);
-      return entry.base.createRequester(entry.trait);
+      const variant = variantFor(protocol);
+      return variant.base.createRequester(variant.trait);
     },
   };
 }

--- a/packages/agent-core-v2/src/human/llm/provider/providers/standard.ts
+++ b/packages/agent-core-v2/src/human/llm/provider/providers/standard.ts
@@ -1,7 +1,7 @@
 import type { ProtocolTrait } from '#/llm/protocol/trait';
 import { createProvider } from '#/llm/provider/definition';
 import { anthropicBase } from '#/llm/requester/bases/anthropic/requester';
-import { createGoogleGenAIBase, googleGenAIBase } from '#/llm/requester/bases/google-genai/requester';
+import { googleGenAIBase } from '#/llm/requester/bases/google-genai/requester';
 import { openAIBase } from '#/llm/requester/bases/openai/requester';
 import { openAIResponsesBase } from '#/llm/requester/bases/openai-responses/requester';
 
@@ -36,12 +36,6 @@ export const googleProvider = createProvider({
       base: googleGenAIBase,
       trait: {
         endpoint: () => ({ apiKeyEnv: 'GOOGLE_API_KEY', baseUrlEnv: 'GOOGLE_GEMINI_BASE_URL' }),
-      },
-    },
-    'google-vertex': {
-      base: createGoogleGenAIBase({ vertexai: true }),
-      trait: {
-        endpoint: () => ({ apiKeyEnv: 'VERTEXAI_API_KEY', baseUrlEnv: 'GOOGLE_VERTEX_BASE_URL' }),
       },
     },
   },

--- a/packages/agent-core-v2/src/human/llm/provider/providers/standard.ts
+++ b/packages/agent-core-v2/src/human/llm/provider/providers/standard.ts
@@ -9,6 +9,17 @@ const openAITrait: ProtocolTrait = {
   endpoint: () => ({ apiKeyEnv: 'OPENAI_API_KEY', baseUrlEnv: 'OPENAI_BASE_URL' }),
 };
 
+const anthropicTrait: ProtocolTrait = {
+  endpoint: () => ({ apiKeyEnv: 'ANTHROPIC_API_KEY', baseUrlEnv: 'ANTHROPIC_BASE_URL' }),
+};
+
+export const googleGenAITrait: ProtocolTrait = {
+  endpoint: (ctx) =>
+    ctx?.model.vertexai === true
+      ? { apiKeyEnv: 'VERTEXAI_API_KEY', baseUrlEnv: 'GOOGLE_VERTEX_BASE_URL' }
+      : { apiKeyEnv: 'GOOGLE_API_KEY', baseUrlEnv: 'GOOGLE_GEMINI_BASE_URL' },
+};
+
 export const openaiProvider = createProvider({
   id: 'openai',
   protocols: {
@@ -20,24 +31,14 @@ export const openaiProvider = createProvider({
 export const anthropicProvider = createProvider({
   id: 'anthropic',
   protocols: {
-    anthropic: {
-      base: anthropicBase,
-      trait: {
-        endpoint: () => ({ apiKeyEnv: 'ANTHROPIC_API_KEY', baseUrlEnv: 'ANTHROPIC_BASE_URL' }),
-      },
-    },
+    anthropic: { base: anthropicBase, trait: anthropicTrait },
   },
 });
 
 export const googleProvider = createProvider({
   id: 'google',
   protocols: {
-    'google-genai': {
-      base: googleGenAIBase,
-      trait: {
-        endpoint: () => ({ apiKeyEnv: 'GOOGLE_API_KEY', baseUrlEnv: 'GOOGLE_GEMINI_BASE_URL' }),
-      },
-    },
+    'google-genai': { base: googleGenAIBase, trait: googleGenAITrait },
   },
   media: { inlineVideo: true },
 });

--- a/packages/agent-core-v2/src/human/llm/requester/bases/anthropic/format.ts
+++ b/packages/agent-core-v2/src/human/llm/requester/bases/anthropic/format.ts
@@ -284,7 +284,7 @@ export function createAnthropicFormat(
       }
       const { betaFeatures, ...restKwargs } = kwargs;
       const betas = Array.isArray(betaFeatures) ? (betaFeatures as string[]) : [];
-      const useBetaApi = betaApi || thinking?.keep !== undefined;
+      const useBetaApi = betaApi || ctx.model.betaApi === true || thinking?.keep !== undefined;
       const createParams: Record<string, unknown> = {
         model: ctx.model.model,
         max_tokens: resolveDefaultMaxTokens(ctx.model.model),

--- a/packages/agent-core-v2/src/human/llm/requester/bases/google-genai/requester.ts
+++ b/packages/agent-core-v2/src/human/llm/requester/bases/google-genai/requester.ts
@@ -125,7 +125,8 @@ export function createGoogleGenAIRequester(
   const vertexai = options?.vertexai === true;
   const resolveClient =
     options?.clientFactory ??
-    ((request: LlmClientContext) => createClient(request.model, request.headers, vertexai));
+    ((request: LlmClientContext) =>
+      createClient(request.model, request.headers, vertexai || request.model.vertexai === true));
   return {
     async generate(
       config: LlmRequestConfig,

--- a/packages/agent-core-v2/src/human/test/llm/provider-catalog.test.ts
+++ b/packages/agent-core-v2/src/human/test/llm/provider-catalog.test.ts
@@ -136,6 +136,35 @@ describe('providerCatalog ping', () => {
     catalog.stop();
   });
 
+  it('carries the model protocol flags into the ping generate config', async () => {
+    const seen: LlmModel[] = [];
+    const provider: Provider = {
+      id: 'test',
+      protocols: ['anthropic'],
+      listModels: () => Promise.resolve([]),
+      resolveModel: () => {
+        throw new Error('unused');
+      },
+      createRequester: () => ({
+        generate: (config) => {
+          seen.push(config.model);
+          return Promise.resolve();
+        },
+      }),
+    };
+    const catalog = await createProviderCatalog();
+    catalog.upsert({
+      provider,
+      models: [{ ...modelDef, protocol: 'anthropic', betaApi: true }],
+    });
+
+    catalog.ping('test', 'm1');
+
+    await until(() => seen.length > 0);
+    expect(seen[0]?.betaApi).toBe(true);
+    catalog.stop();
+  });
+
   it('defers a ping sent while refreshing until the refresh completes', async () => {
     let pulls = 0;
     let resolvePull: (models: readonly LlmModel[]) => void = () => {};

--- a/packages/agent-core-v2/src/human/test/llm/trait.test.ts
+++ b/packages/agent-core-v2/src/human/test/llm/trait.test.ts
@@ -28,7 +28,7 @@ import {
   kimiAnthropicTrait,
   kimiOpenAITrait,
 } from '#/llm-kimi/trait';
-import { anthropicProvider, openaiProvider } from '#/llm/provider/providers/standard';
+import { anthropicProvider, googleGenAITrait, openaiProvider } from '#/llm/provider/providers/standard';
 import type { LlmClientContext, LlmRequester, LlmRequestEvent } from '#/llm/requester/requester';
 import type { TokenUsage } from '#/llm/usage';
 import {
@@ -526,6 +526,82 @@ describe('endpoint', () => {
       defaultHeaders: { 'x-h': 'v' },
     });
     expect(isUnknownCapability(resolved.capability)).toBe(true);
+  });
+
+  it('passes protocol flags through resolveModel', () => {
+    const resolved = anthropicProvider.resolveModel('claude-sonnet-4-20250514', {
+      betaApi: true,
+      vertexai: true,
+    });
+    expect(resolved.betaApi).toBe(true);
+    expect(resolved.vertexai).toBe(true);
+    const plain = anthropicProvider.resolveModel('claude-sonnet-4-20250514');
+    expect(plain.betaApi).toBeUndefined();
+    expect(plain.vertexai).toBeUndefined();
+  });
+});
+
+
+describe('protocol variant flags', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses the anthropic beta api when the model opts in', async () => {
+    const client = stubAnthropicClient(anthropicStreamEvents);
+    const requester = createAnthropicRequester(undefined, {
+      clientFactory: client.clientFactory,
+    });
+    await requester.generate(
+      { model: { ...model, betaApi: true } },
+      { messages },
+      { signal: new AbortController().signal },
+    );
+    expect(client.betaCalled()).toBe(true);
+  });
+
+  it('switches google env names when the model opts into vertex', async () => {
+    vi.stubEnv('GOOGLE_API_KEY', 'gemini-key');
+    vi.stubEnv('VERTEXAI_API_KEY', 'vertex-key');
+    const chunks = [
+      {
+        responseId: 'gemini-resp-1',
+        candidates: [
+          {
+            content: { role: 'model', parts: [{ text: 'hi' }] },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 },
+      },
+    ];
+    const seen: LlmModel[] = [];
+    const client = createClientStub((captured, request) => {
+      seen.push(request.model);
+      return {
+        models: {
+          generateContentStream: async (params: Record<string, unknown>) => {
+            captured.push({ params, headers: request.headers });
+            return createAsyncStream(chunks);
+          },
+        },
+      };
+    });
+    const requester = createGoogleGenAIRequester(googleGenAITrait, {
+      clientFactory: client.clientFactory,
+    });
+    const signal = new AbortController().signal;
+    await requester.generate(
+      { model: { ...model, model: 'gemini-2.5-flash' } },
+      { messages },
+      { signal },
+    );
+    await requester.generate(
+      { model: { ...model, model: 'gemini-2.5-flash', vertexai: true } },
+      { messages },
+      { signal },
+    );
+    expect(seen.map((entry) => entry.apiKey)).toEqual(['gemini-key', 'vertex-key']);
   });
 });
 

--- a/packages/agent-core-v2/src/human/test/llm/trait.test.ts
+++ b/packages/agent-core-v2/src/human/test/llm/trait.test.ts
@@ -496,7 +496,7 @@ describe('endpoint', () => {
   });
 
   it('selects protocols by name and rejects undeclared ones', () => {
-    expect(kimiProvider.protocols).toEqual(['openai', 'anthropic_beta', 'openai_responses']);
+    expect(kimiProvider.protocols).toEqual(['openai', 'anthropic', 'openai_responses']);
     expect(() => kimiProvider.createRequester('google-genai')).toThrow(
       "provider 'kimi' has no protocol 'google-genai'",
     );

--- a/packages/agent-core-v2/src/llm-adapter/model/model-requester-impl.ts
+++ b/packages/agent-core-v2/src/llm-adapter/model/model-requester-impl.ts
@@ -301,10 +301,8 @@ function samplingExtraParams(
     case 'openai_responses':
       return { responses: { temperature, top_p: topP } };
     case 'anthropic':
-    case 'anthropic_beta':
       return { anthropic: { temperature, top_p: topP } };
     case 'google-genai':
-    case 'google-vertex':
       return { googleGenai: { temperature, topP } };
   }
 }

--- a/packages/agent-core-v2/src/llm-adapter/protocol/protocolAdapterRegistry.ts
+++ b/packages/agent-core-v2/src/llm-adapter/protocol/protocolAdapterRegistry.ts
@@ -5,7 +5,7 @@ import { UNKNOWN_CAPABILITY, toLlmCapability, type ModelCapability } from '../co
 import type { ModelThinkingMetadata } from '#human/llm/thinking';
 import type { ProviderMediaContribution } from '#human/llm/media/upload';
 import type { LlmModel } from '#human/llm/model';
-import type { ProtocolBase, ProtocolName } from '#human/llm/protocol/base';
+import type { ProtocolBase } from '#human/llm/protocol/base';
 import type { ProtocolTrait } from '#human/llm/protocol/trait';
 import { anthropicBase, anthropicBetaBase } from '#human/llm/requester/bases/anthropic/requester';
 import {
@@ -182,20 +182,7 @@ export class ProtocolAdapterRegistry implements IProtocolAdapterRegistry {
       alwaysThinking: model.alwaysThinking,
       adaptiveThinking: model.providerOptions?.adaptiveThinking,
     };
-    return { requester, protocol: protocolNameFor(model, route), model: llmModel, media: route.media };
-  }
-}
-
-function protocolNameFor(model: Model, route: AdapterRoute): ProtocolName {
-  switch (model.protocol) {
-    case 'openai':
-      return 'openai';
-    case 'openai_responses':
-      return 'openai_responses';
-    case 'anthropic':
-      return route.base === anthropicBetaBase ? 'anthropic_beta' : 'anthropic';
-    case 'google-genai':
-      return route.base === vertexGenAIBase ? 'google-vertex' : 'google-genai';
+    return { requester, protocol: model.protocol, model: llmModel, media: route.media };
   }
 }
 

--- a/packages/agent-core-v2/test/llm-adapter/protocol/protocolAdapterRegistry.test.ts
+++ b/packages/agent-core-v2/test/llm-adapter/protocol/protocolAdapterRegistry.test.ts
@@ -207,31 +207,24 @@ describe('resolve gateway routes', () => {
     expect(resolved.media?.uploadVideo).toBeUndefined();
   });
 
-  it('selects the anthropic beta base from providerOptions.betaApi', () => {
+  it('reports the wire protocol regardless of beta or vertex provider options', () => {
     const beta = registry.resolve(
       modelWith({ protocol: 'anthropic', providerOptions: { betaApi: true } }),
     );
-    expect(beta.protocol).toBe('anthropic_beta');
-    const plain = registry.resolve(modelWith({ protocol: 'anthropic' }));
-    expect(plain.protocol).toBe('anthropic');
-  });
-
-  it('routes kimi+anthropic through the kimi anthropic trait with media', () => {
-    const resolved = registry.resolve(modelWith({ protocol: 'anthropic', providerType: 'kimi' }));
-    expect(resolved.protocol).toBe('anthropic');
-    expect(typeof resolved.media?.uploadVideo).toBe('function');
-  });
-
-  it('selects the google vertex base from providerOptions.vertexai', () => {
+    expect(beta.protocol).toBe('anthropic');
     const vertex = registry.resolve(
       modelWith({
         protocol: 'google-genai',
         providerOptions: { vertexai: true, project: 'p', location: 'l' },
       }),
     );
-    expect(vertex.protocol).toBe('google-vertex');
-    const gemini = registry.resolve(modelWith({ protocol: 'google-genai' }));
-    expect(gemini.protocol).toBe('google-genai');
+    expect(vertex.protocol).toBe('google-genai');
+  });
+
+  it('routes kimi+anthropic through the kimi anthropic trait with media', () => {
+    const resolved = registry.resolve(modelWith({ protocol: 'anthropic', providerType: 'kimi' }));
+    expect(resolved.protocol).toBe('anthropic');
+    expect(typeof resolved.media?.uploadVideo).toBe('function');
   });
 
   it('carries thinking metadata and model limits onto the resolved LlmModel', () => {


### PR DESCRIPTION
## Related Issue

N/A — internal refactor identified from a code review of the human LLM layer in `agent-core-v2` (no tracking issue).

## Problem

In `agent-core-v2`'s human LLM layer, `ProtocolName` mixed wire protocols with deployment variants:

- `anthropic_beta` is not a protocol. It is the same Anthropic Messages wire format sent through the beta endpoint (`client.beta.messages.create`) — a client/endpoint option (`createAnthropicBase({ betaApi: true })`).
- `google-vertex` is not a protocol. Vertex AI is Google's hosting platform; the wire format is the same google-genai SDK, only a client-construction flag (`vertexai: true`) plus different env vars.

Because provider slots are keyed by `ProtocolName`, declaring these variants forced fake protocol names into the enum, and consumers had to map back and forth by object identity (`route.base === anthropicBetaBase ? 'anthropic_beta' : 'anthropic'`).

Request-derivable beta usage is already auto-detected at encode time (`thinking.keep !== undefined` forces the beta endpoint per request). The remaining deployment knowledge ("this model uses the beta path", "this deployment is Vertex") is per-model connection state, so the variant is chosen at generate time from the model, not pinned when the requester is created.

## What changed

- `ProtocolName` narrowed to the four real wire protocols: `openai`, `openai_responses`, `anthropic`, `google-genai`.
- `betaApi` / `vertexai` are now fields of `LlmConnection` (inherited by `LlmModel` and by the catalog's model definition). Requesters read them from `config.model` on every generate call, so the variant is resolved at generate time and `Provider.createRequester(protocol)` takes no protocol options — upper layers thread nothing protocol-specific.
- anthropic requester: `useBetaApi` = the base's own default (kimi's beta base) OR `model.betaApi` OR `thinking.keep` (per request, as before).
- google-genai requester: client construction reads `model.vertexai`; `googleGenAITrait.endpoint` takes an optional ctx and switches env names (`GOOGLE_API_KEY` / `GOOGLE_GEMINI_BASE_URL` vs `VERTEXAI_API_KEY` / `GOOGLE_VERTEX_BASE_URL`) by the flag — Vertex stays available as a model-level deployment option, not a protocol.
- kimi provider: unchanged semantics — the `anthropic` slot is statically the beta base (kimi's anthropic endpoint is the beta path).
- Provider catalog: `betaApi` (and now `vertexai`) ride on the model definition into the ping probe's generate config; `mergeModel` carries both.
- llm-adapter: `protocolNameFor` deleted; `resolve` returns `model.protocol` directly (the adapter's `Protocol` zod enum already has only the four clean values). `samplingExtraParams` drops the two duplicate case arms. Per-model base selection via `providerOptions.betaApi` / `vertexai` is unchanged — the trait `endpoint` ctx parameter is optional, so the adapter's static endpoint aggregation is untouched.
- Tests: `resolveModel` passes the flags through; `model.betaApi` selects the anthropic beta endpoint (`betaCalled()`); `model.vertexai` switches google env names at request time; the ping probe carries the flags in its generate config; kimi protocol list expectation updated; the two beta/vertex registry tests merged into one asserting the resolved protocol always equals the wire protocol.

No user-facing change: the user-facing `ProtocolSchema` already exposed only the four wire protocols, so no changeset.

Verification: `typecheck` / `check-no-comments` / `oxlint` pass; full agent-core-v2 vitest green except three pre-existing environment-dependent failures (auth install-marker ×2, telemetry endpoint ×1) that fail identically on the clean base commit.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
