### PR TITLE
fix(sdk): count cron turns as replay turn boundaries

### DIFF
--- a/.changeset/witty-crabs-tap.md
+++ b/.changeset/witty-crabs-tap.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix slow response streaming and rendering after resuming sessions with many scheduled cron turns.

--- a/packages/node-sdk/src/replay.ts
+++ b/packages/node-sdk/src/replay.ts
@@ -113,10 +113,11 @@ function isAgentReplayUserTurnRecord(record: AgentReplayRecord): boolean {
       return message.origin.trigger === 'user-slash';
     case 'shell_command':
       return message.origin.phase === 'input';
-    case 'background_task':
-    case 'compaction_summary':
     case 'cron_job':
     case 'cron_missed':
+      return true;
+    case 'background_task':
+    case 'compaction_summary':
     case 'hook_result':
     case 'injection':
     case 'retry':

--- a/packages/node-sdk/test/replay.test.ts
+++ b/packages/node-sdk/test/replay.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import { limitAgentReplayByTurns, type AgentReplayRecord } from '#/replay';
+
+function userTurn(text: string, time: number): AgentReplayRecord {
+  return {
+    type: 'message',
+    time,
+    message: {
+      role: 'user',
+      content: [{ type: 'text', text }],
+      toolCalls: [],
+      origin: { kind: 'user' },
+    },
+  };
+}
+
+function cronTurn(text: string, time: number): AgentReplayRecord {
+  return {
+    type: 'message',
+    time,
+    message: {
+      role: 'user',
+      content: [{ type: 'text', text }],
+      toolCalls: [],
+      origin: { kind: 'cron_job', jobId: 'job-1', cron: '*/15 * * * *', recurring: true, coalescedCount: 1, stale: false },
+    },
+  };
+}
+
+function cronMissedTurn(text: string, time: number): AgentReplayRecord {
+  return {
+    type: 'message',
+    time,
+    message: {
+      role: 'user',
+      content: [{ type: 'text', text }],
+      toolCalls: [],
+      origin: { kind: 'cron_missed', count: 3 },
+    },
+  };
+}
+
+function injection(text: string, time: number): AgentReplayRecord {
+  return {
+    type: 'message',
+    time,
+    message: {
+      role: 'user',
+      content: [{ type: 'text', text }],
+      toolCalls: [],
+      origin: { kind: 'injection', variant: 'reminder' },
+    },
+  };
+}
+
+function assistant(text: string, time: number): AgentReplayRecord {
+  return {
+    type: 'message',
+    time,
+    message: {
+      role: 'assistant',
+      content: [{ type: 'text', text }],
+      toolCalls: [],
+    },
+  };
+}
+
+function replayBytes(records: readonly AgentReplayRecord[]): number {
+  return records.reduce((sum, record) => sum + JSON.stringify(record).length, 0);
+}
+
+describe('limitAgentReplayByTurns', () => {
+  it('keeps only the last N user turns', () => {
+    const records: AgentReplayRecord[] = [];
+    for (let turn = 0; turn < 20; turn++) {
+      records.push(userTurn(`prompt ${turn}`, turn * 10));
+      records.push(assistant(`answer ${turn}`, turn * 10 + 1));
+    }
+    const limited = limitAgentReplayByTurns(records, 5);
+    expect(limited[0]).toMatchObject({ message: { origin: { kind: 'user' } } });
+    expect(JSON.stringify(limited)).toContain('prompt 15');
+    expect(JSON.stringify(limited)).not.toContain('prompt 14');
+  });
+
+  it('bounds replay volume when cron turns dominate the history', () => {
+    const records: AgentReplayRecord[] = [];
+    let time = 0;
+    for (let turn = 0; turn < 30; turn++) {
+      records.push(userTurn(`manual prompt ${turn}`, time++));
+      records.push(assistant('manual answer', time++));
+      for (let cron = 0; cron < 200; cron++) {
+        records.push(cronTurn(`cron fire ${turn}:${cron} ${'x'.repeat(500)}`, time++));
+        records.push(assistant(`cron report ${'y'.repeat(2000)}`, time++));
+      }
+    }
+    const total = replayBytes(records);
+    const limited = limitAgentReplayByTurns(records, 10);
+    expect(limited.length).toBeLessThan(records.length / 10);
+    expect(replayBytes(limited)).toBeLessThan(total / 10);
+    expect(JSON.stringify(limited.at(-2))).toContain('cron fire 29:199');
+  });
+
+  it('treats cron_missed deliveries as turn boundaries', () => {
+    const records: AgentReplayRecord[] = [];
+    for (let turn = 0; turn < 20; turn++) {
+      records.push(cronMissedTurn(`missed ${turn}`, turn * 2));
+      records.push(assistant('report', turn * 2 + 1));
+    }
+    const limited = limitAgentReplayByTurns(records, 5);
+    expect(JSON.stringify(limited)).toContain('missed 15');
+    expect(JSON.stringify(limited)).not.toContain('missed 14');
+  });
+
+  it('does not let injection bursts shrink the window', () => {
+    const records: AgentReplayRecord[] = [];
+    for (let turn = 0; turn < 8; turn++) {
+      records.push(userTurn(`prompt ${turn}`, turn * 100));
+      records.push(assistant(`answer ${turn}`, turn * 100 + 1));
+      for (let i = 0; i < 50; i++) {
+        records.push(injection(`reminder ${turn}:${i}`, turn * 100 + 2 + i));
+      }
+    }
+    const limited = limitAgentReplayByTurns(records, 5);
+    expect(JSON.stringify(limited)).toContain('prompt 3');
+    expect(JSON.stringify(limited)).not.toContain('prompt 2');
+  });
+});


### PR DESCRIPTION
## Related Issue

No linked issue — reported via internal user feedback and root-caused from the affected session data.

## Problem

After resuming a session whose history is dominated by cron-fired turns, response streaming collapses to 30–50 tok/s in the TUI even though the server streams at ~200 tok/s, and it reproduces on every resume of that session (a fresh session on the same machine streams at full speed).

Root cause: `limitAgentReplayByTurns` only counted human-typed prompts as turn boundaries — `cron_job` / `cron_missed` records were not turns. On the affected session (4,280 cron turns vs 63 real user turns) the "last 11 turns" replay fetch therefore returned **10,478 records (~9 MB, ~45% of the whole history)**, all of which the TUI mounts and keeps mounted for the process lifetime. Every render frame then walks ~100k mounted transcript lines; during streaming (20 fps flush) that saturates the event loop on modest hardware, so the client cannot drain the socket and the measured server-decode window stretches (the debug split attributes this starvation to "server", which is misleading).

Verified against the real session data: print mode (no TUI) streams at full speed; the mock-server drain of 4,000 tokens takes 10 ms once the transcript is bounded.

## What changed

- `packages/node-sdk/src/replay.ts`: treat `cron_job` and `cron_missed` replay records as turn boundaries. This mirrors the TUI transcript window's own boundary rule (`CronMessageComponent` is already a fold-segment boundary there). The resumed replay on the affected session drops from 10,478 to **137 records**; end-to-end resume output shrinks from 31 MB to 351 KB.
- `packages/node-sdk/test/replay.test.ts` (new): bounds replay volume when cron turns dominate (failed before the fix), treats `cron_missed` as a boundary, verifies injection bursts do not shrink the window, and pins the existing user-turn semantics.

Validation: node-sdk 138 tests, apps/kimi-code 2452 TUI tests, typecheck, oxlint — all green.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
