### PR TITLE
feat(agent-core-v2): watch user-level skill roots so the catalog stays fresh

### DIFF
--- a/.changeset/watch-user-skill-roots.md
+++ b/.changeset/watch-user-skill-roots.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Watch the user-level skill roots (`~/.kimi-code/skills` and `~/.agents/skills`) so the workspace skill catalog refreshes automatically when skills are created, modified, or deleted while the daemon is running — no restart or manual reload needed.

--- a/packages/agent-core-v2/src/features/skill/catalog/userFileSkillSource.ts
+++ b/packages/agent-core-v2/src/features/skill/catalog/userFileSkillSource.ts
@@ -1,10 +1,15 @@
+import { join } from 'pathe';
+
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
-import { Disposable } from '#/_base/di/lifecycle';
+import { Disposable, DisposableStore } from '#/_base/di/lifecycle';
 import { Emitter, type Event } from '#/_base/event';
 import { LifecycleScope } from '#/app/scopes';
 import { ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { IConfigService } from '#/app/config/config';
+import { TimeoutTimer } from '#/_base/utils/timer';
+import { subtreeWatchFilter } from '#/_base/utils/paths';
+import { watch } from '#human/utils/watch';
 
 import {
   MERGE_ALL_AVAILABLE_SKILLS_SECTION,
@@ -21,6 +26,8 @@ export interface IUserFileSkillSource extends ISkillSource {
 export const IUserFileSkillSource: ServiceIdentifier<IUserFileSkillSource> =
   createDecorator<IUserFileSkillSource>('userFileSkillSource');
 
+const WATCH_DEBOUNCE_MS = 200;
+
 export class UserFileSkillSource extends Disposable implements IUserFileSkillSource {
   declare readonly _serviceBrand: undefined;
 
@@ -28,6 +35,9 @@ export class UserFileSkillSource extends Disposable implements IUserFileSkillSou
   readonly priority = SKILL_SOURCE_PRIORITY.user;
   private readonly onDidChangeEmitter = this._register(new Emitter<void>());
   readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+  private readonly watchDebounce = this._register(new TimeoutTimer());
+  private readonly watchResources = this._register(new DisposableStore());
+  private watchReady: Promise<void> = Promise.resolve();
 
   constructor(
     @ISkillDiscovery private readonly discovery: ISkillDiscovery,
@@ -40,9 +50,13 @@ export class UserFileSkillSource extends Disposable implements IUserFileSkillSou
         if (event.domain === MERGE_ALL_AVAILABLE_SKILLS_SECTION) this.onDidChangeEmitter.fire();
       }),
     );
+    if ((this.bootstrap.args.skillDirs?.length ?? 0) === 0) {
+      this.watchUserSkillRoots();
+    }
   }
 
   async load(): Promise<SkillContribution> {
+    await this.watchReady;
     if ((this.bootstrap.args.skillDirs?.length ?? 0) > 0) {
       return { skills: [] };
     }
@@ -52,6 +66,39 @@ export class UserFileSkillSource extends Disposable implements IUserFileSkillSou
     return this.discovery.discover(
       await userRoots(this.bootstrap.homeDir, this.bootstrap.osHomeDir, { mergeAllAvailableSkills }),
     );
+  }
+
+  private watchUserSkillRoots(): void {
+    const watchedBases = new Set<string>();
+    const ready: Promise<void>[] = [];
+    const targets = [
+      {
+        base: this.bootstrap.homeDir,
+        candidates: [join(this.bootstrap.homeDir, 'skills')],
+      },
+      {
+        base: this.bootstrap.osHomeDir,
+        candidates: [join(this.bootstrap.osHomeDir, '.agents', 'skills')],
+      },
+    ];
+    for (const { base, candidates } of targets) {
+      if (watchedBases.has(base)) continue;
+      watchedBases.add(base);
+      const handle = watch(base, {
+        ignored: subtreeWatchFilter(base, candidates),
+        signal: true,
+      });
+      this.watchResources.add(handle);
+      this.watchResources.add(
+        handle.onDidChange(() => {
+          this.watchDebounce.cancelAndSet(() => {
+            this.onDidChangeEmitter.fire();
+          }, WATCH_DEBOUNCE_MS);
+        }),
+      );
+      ready.push(handle.ready);
+    }
+    this.watchReady = Promise.all(ready).then(() => undefined);
   }
 }
 

--- a/packages/agent-core-v2/src/features/skill/catalog/userFileSkillSource.ts
+++ b/packages/agent-core-v2/src/features/skill/catalog/userFileSkillSource.ts
@@ -69,21 +69,16 @@ export class UserFileSkillSource extends Disposable implements IUserFileSkillSou
   }
 
   private watchUserSkillRoots(): void {
-    const watchedBases = new Set<string>();
+    const candidatesByBase = new Map<string, string[]>();
+    const addTarget = (base: string, candidate: string): void => {
+      const candidates = candidatesByBase.get(base);
+      if (candidates === undefined) candidatesByBase.set(base, [candidate]);
+      else candidates.push(candidate);
+    };
+    addTarget(this.bootstrap.homeDir, join(this.bootstrap.homeDir, 'skills'));
+    addTarget(this.bootstrap.osHomeDir, join(this.bootstrap.osHomeDir, '.agents', 'skills'));
     const ready: Promise<void>[] = [];
-    const targets = [
-      {
-        base: this.bootstrap.homeDir,
-        candidates: [join(this.bootstrap.homeDir, 'skills')],
-      },
-      {
-        base: this.bootstrap.osHomeDir,
-        candidates: [join(this.bootstrap.osHomeDir, '.agents', 'skills')],
-      },
-    ];
-    for (const { base, candidates } of targets) {
-      if (watchedBases.has(base)) continue;
-      watchedBases.add(base);
+    for (const [base, candidates] of candidatesByBase) {
       const handle = watch(base, {
         ignored: subtreeWatchFilter(base, candidates),
         signal: true,

--- a/packages/agent-core-v2/test/app/bootstrap/stubs.ts
+++ b/packages/agent-core-v2/test/app/bootstrap/stubs.ts
@@ -16,6 +16,7 @@ export function stubBootstrap(
   homeDir = '/tmp/kimi-home',
   env: NodeJS.ProcessEnv = {},
   args: HostArgsInput = {},
+  osHomeDir = '/home/test',
 ): IBootstrapService {
   const scopes: Record<PersistenceScopeName, string> = {
     config: '',
@@ -31,7 +32,7 @@ export function stubBootstrap(
     platform: 'linux',
     arch: 'x64',
     cwd: '/tmp',
-    osHomeDir: '/home/test',
+    osHomeDir,
     homeDir,
     configPath: `${homeDir}/config.toml`,
     configKey: 'config.toml',

--- a/packages/agent-core-v2/test/features/skill/workspace/skillCatalog.test.ts
+++ b/packages/agent-core-v2/test/features/skill/workspace/skillCatalog.test.ts
@@ -1117,6 +1117,34 @@ describe('WorkspaceSkillCatalogService', () => {
     }
   });
 
+  it('merges both skill-root candidates into one watch when homeDir equals osHomeDir', async () => {
+    const host = createScopedTestHost([
+      stubPair(IFlagService, stubFlag(true)),
+      stubPair(IBootstrapService, stubBootstrap('/home', {}, {}, '/home')),
+      stubPair(IConfigService, configStub()),
+      stubPair(IPluginService, pluginStub()),
+      stubPair(ILogService, stubLog()),
+      stubPair(ISkillDiscovery, new FileSkillDiscovery(stubLog())),
+    ]);
+    const workspace = host.child('program', 'w1', [
+      stubPair(IWorkspaceContext, workspaceContextStub('/work')),
+    ]);
+
+    try {
+      const catalog = workspace.accessor.get(IWorkspaceSkillCatalog);
+      await catalog.load();
+
+      const homeCalls = watchMockState.calls.filter((call) => call.path === '/home');
+      expect(homeCalls).toHaveLength(1);
+      const ignored = homeCalls[0]?.options?.ignored;
+      expect(ignored?.('/home/skills/demo/SKILL.md')).toBe(false);
+      expect(ignored?.('/home/.agents/skills/demo/SKILL.md')).toBe(false);
+      expect(ignored?.('/home/sessions/s1/state.json')).toBe(true);
+    } finally {
+      host.dispose();
+    }
+  });
+
   it('does not watch the user skill roots when explicit skillDirs are set', async () => {
     const host = createScopedTestHost([
       stubPair(IFlagService, stubFlag(true)),
@@ -1219,7 +1247,6 @@ describe('WorkspaceSkillCatalogService', () => {
         return Promise.race([refreshed, timedOut]);
       };
 
-      // create
       const created = waitForUserChange();
       const skillDir = join(homeDir, 'skills', 'watched-user-skill');
       await mkdir(skillDir, { recursive: true });
@@ -1227,19 +1254,16 @@ describe('WorkspaceSkillCatalogService', () => {
       await created;
       expect(catalog.catalog.getSkill('watched-user-skill')?.description).toBe('v1');
 
-      // modify
       const modified = waitForUserChange();
       await writeSkill(skillDir, 'v2');
       await modified;
       expect(catalog.catalog.getSkill('watched-user-skill')?.description).toBe('v2');
 
-      // delete
       const deleted = waitForUserChange();
       await rm(skillDir, { recursive: true, force: true });
       await deleted;
       expect(catalog.catalog.getSkill('watched-user-skill')).toBeUndefined();
 
-      // create under ~/.agents/skills
       const osCreated = waitForUserChange();
       const osSkillDir = join(osHomeDir, '.agents', 'skills', 'watched-user-skill');
       await mkdir(osSkillDir, { recursive: true });

--- a/packages/agent-core-v2/test/features/skill/workspace/skillCatalog.test.ts
+++ b/packages/agent-core-v2/test/features/skill/workspace/skillCatalog.test.ts
@@ -1086,4 +1086,170 @@ describe('WorkspaceSkillCatalogService', () => {
       await rm(workDir, { recursive: true, force: true });
     }
   }, 15000);
+
+  it('watches both user-level skill roots and prunes unrelated paths', async () => {
+    const host = createScopedTestHost([
+      stubPair(IFlagService, stubFlag(true)),
+      stubPair(IBootstrapService, stubBootstrap('/home', {}, {}, '/os-home')),
+      stubPair(IConfigService, configStub()),
+      stubPair(IPluginService, pluginStub()),
+      stubPair(ILogService, stubLog()),
+      stubPair(ISkillDiscovery, new FileSkillDiscovery(stubLog())),
+    ]);
+    const workspace = host.child('program', 'w1', [
+      stubPair(IWorkspaceContext, workspaceContextStub('/work')),
+    ]);
+
+    try {
+      const catalog = workspace.accessor.get(IWorkspaceSkillCatalog);
+      await catalog.load();
+
+      const homeCall = watchMockState.calls.find((call) => call.path === '/home');
+      const osCall = watchMockState.calls.find((call) => call.path === '/os-home');
+      expect(homeCall).toBeDefined();
+      expect(osCall).toBeDefined();
+      expect(homeCall?.options?.ignored?.('/home/skills/demo/SKILL.md')).toBe(false);
+      expect(homeCall?.options?.ignored?.('/home/sessions/s1/state.json')).toBe(true);
+      expect(osCall?.options?.ignored?.('/os-home/.agents/skills/demo/SKILL.md')).toBe(false);
+      expect(osCall?.options?.ignored?.('/os-home/Downloads/x.zip')).toBe(true);
+    } finally {
+      host.dispose();
+    }
+  });
+
+  it('does not watch the user skill roots when explicit skillDirs are set', async () => {
+    const host = createScopedTestHost([
+      stubPair(IFlagService, stubFlag(true)),
+      stubPair(IBootstrapService, stubBootstrap('/home', {}, { skillDirs: ['/explicit'] }, '/os-home')),
+      stubPair(IConfigService, configStub()),
+      stubPair(IPluginService, pluginStub()),
+      stubPair(ILogService, stubLog()),
+      stubPair(ISkillDiscovery, new FileSkillDiscovery(stubLog())),
+    ]);
+    const workspace = host.child('program', 'w1', [
+      stubPair(IWorkspaceContext, workspaceContextStub('/work')),
+    ]);
+
+    try {
+      const catalog = workspace.accessor.get(IWorkspaceSkillCatalog);
+      await catalog.load();
+
+      const watchedPaths = watchMockState.calls.map((call) => call.path);
+      expect(watchedPaths).not.toContain('/home');
+      expect(watchedPaths).not.toContain('/os-home');
+    } finally {
+      host.dispose();
+    }
+  });
+
+  it('disposes the user root watches when the app scope is disposed', async () => {
+    const handles: { disposed: boolean }[] = [];
+    watchMockState.factory = () => {
+      const handle = {
+        ready: Promise.resolve(),
+        onDidChange: () => ({ dispose: () => {} }),
+        disposed: false,
+        dispose: () => {
+          handle.disposed = true;
+        },
+      };
+      handles.push(handle);
+      return handle;
+    };
+    const host = createScopedTestHost([
+      stubPair(IFlagService, stubFlag(true)),
+      stubPair(IBootstrapService, bootstrapStub),
+      stubPair(IConfigService, configStub()),
+      stubPair(IPluginService, pluginStub()),
+      stubPair(ILogService, stubLog()),
+      stubPair(ISkillDiscovery, new FileSkillDiscovery(stubLog())),
+    ]);
+    const workspace = host.child('program', 'w1', [
+      stubPair(IWorkspaceContext, workspaceContextStub('/work')),
+    ]);
+
+    const catalog = workspace.accessor.get(IWorkspaceSkillCatalog);
+    await catalog.load();
+    expect(handles.length).toBeGreaterThan(0);
+
+    host.dispose();
+    expect(handles.every((handle) => handle.disposed)).toBe(true);
+  });
+
+  it('rescans the user source when skills appear, change and disappear under the user roots', async () => {
+    watchMockState.mode = 'real';
+    const homeDir = await mkdtemp(join(tmpdir(), 'skill-user-watch-'));
+    const osHomeDir = await mkdtemp(join(tmpdir(), 'skill-os-watch-'));
+    const host = createScopedTestHost([
+      stubPair(IFlagService, stubFlag(true)),
+      stubPair(IBootstrapService, stubBootstrap(homeDir, {}, {}, osHomeDir)),
+      stubPair(IConfigService, configStub()),
+      stubPair(IPluginService, pluginStub()),
+      stubPair(ILogService, stubLog()),
+      stubPair(ISkillDiscovery, new FileSkillDiscovery(stubLog())),
+    ]);
+    const workspace = host.child('program', 'w1', [
+      stubPair(IWorkspaceContext, workspaceContextStub('/work')),
+    ]);
+    const writeSkill = (dir: string, description: string) =>
+      writeFile(
+        join(dir, 'SKILL.md'),
+        `---\nname: watched-user-skill\ndescription: ${description}\n---\nbody`,
+        'utf8',
+      );
+
+    try {
+      const catalog = workspace.accessor.get(IWorkspaceSkillCatalog);
+      await catalog.load();
+      expect(catalog.catalog.getSkill('watched-user-skill')).toBeUndefined();
+
+      const waitForUserChange = (): Promise<string> => {
+        const refreshed = new Promise<string>((resolvePromise) => {
+          const d = catalog.onDidChange((sourceId) => {
+            if (sourceId !== 'user') return;
+            d.dispose();
+            resolvePromise(sourceId);
+          });
+        });
+        const timedOut = new Promise<never>((_resolve, reject) => {
+          setTimeout(() => {
+            reject(new Error('user watch refresh timed out'));
+          }, 10000);
+        });
+        return Promise.race([refreshed, timedOut]);
+      };
+
+      // create
+      const created = waitForUserChange();
+      const skillDir = join(homeDir, 'skills', 'watched-user-skill');
+      await mkdir(skillDir, { recursive: true });
+      await writeSkill(skillDir, 'v1');
+      await created;
+      expect(catalog.catalog.getSkill('watched-user-skill')?.description).toBe('v1');
+
+      // modify
+      const modified = waitForUserChange();
+      await writeSkill(skillDir, 'v2');
+      await modified;
+      expect(catalog.catalog.getSkill('watched-user-skill')?.description).toBe('v2');
+
+      // delete
+      const deleted = waitForUserChange();
+      await rm(skillDir, { recursive: true, force: true });
+      await deleted;
+      expect(catalog.catalog.getSkill('watched-user-skill')).toBeUndefined();
+
+      // create under ~/.agents/skills
+      const osCreated = waitForUserChange();
+      const osSkillDir = join(osHomeDir, '.agents', 'skills', 'watched-user-skill');
+      await mkdir(osSkillDir, { recursive: true });
+      await writeSkill(osSkillDir, 'os');
+      await osCreated;
+      expect(catalog.catalog.getSkill('watched-user-skill')?.description).toBe('os');
+    } finally {
+      host.dispose();
+      await rm(homeDir, { recursive: true, force: true });
+      await rm(osHomeDir, { recursive: true, force: true });
+    }
+  }, 30000);
 });


### PR DESCRIPTION
## Problem

Skills created in the user-level skill directories (`~/.kimi-code/skills`, `~/.agents/skills`) while the daemon is running are not visible to any session: `UserFileSkillSource` only re-scans those directories when the workspace skill catalog is (re)loaded, which in practice means a daemon restart. The project-level roots did not have this problem — `WorkspaceRootSkillSource` watches the project root and reloads on change.

## What changed

Mirror the project-level watch pattern in `UserFileSkillSource`:

- Watch both user-level base directories: `bootstrap.homeDir` (KIMI_CODE_HOME, covering `skills/`) and `bootstrap.osHomeDir` (covering `.agents/skills/`), each with a `subtreeWatchFilter` that prunes everything outside the skill-root candidates so the rest of the home directory is neither traversed nor reported.
- Change events are debounced (200ms, same as the workspace source) and fire `onDidChange`, which makes `WorkspaceSkillCatalogService` reload the `'user'` source — so `GET /sessions/{id}/skills` is always fresh.
- `load()` awaits watch readiness (same race-avoidance as the workspace source), and the watch handles are registered on the service's `DisposableStore`, so they are disposed with the App scope.
- When explicit `skillDirs` are configured the user source is inactive, so no watches are installed.

Tests in `packages/agent-core-v2/test/features/skill/workspace/skillCatalog.test.ts`: watch registration and filter pruning for both roots, no watches with explicit `skillDirs`, disposal with the App scope, and an end-to-end real-watcher test that creates / modifies / deletes a `SKILL.md` under tmpdir home roots (including `.agents/skills`) and asserts the catalog updates after the debounce.

## Relationship to #3597

This supersedes #3597 (`POST /sessions/{id}/skills:reload`): with the catalog kept fresh by the watcher, no reload endpoint is needed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Verified locally: `agent-core-v2` skill feature tests (135 tests) and the broader `test/features test/app test/workspace test/session` suites (2716 tests), `kap-server` skills tests (20 tests), `tsc --noEmit` for both packages, and repo-wide `oxlint --type-aware` (0 errors).
