### PR TITLE
feat(cli): send pasted images to the /btw side agent

### DIFF
--- a/.changeset/btw-image-support.md
+++ b/.changeset/btw-image-support.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add image support to /btw: pasted images now reach the side agent, which can also view image and video files.

--- a/.changeset/btw-readonly-tools.md
+++ b/.changeset/btw-readonly-tools.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Add read-only tools to the /btw side agent. It can now read and search files to answer questions about the codebase; write and execute tools stay disabled.
+Add read-only tools to the /btw side agent so it can answer questions about files in the codebase.

--- a/.changeset/btw-readonly-tools.md
+++ b/.changeset/btw-readonly-tools.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add read-only tools to the /btw side agent. It can now read and search files to answer questions about the codebase; write and execute tools stay disabled.

--- a/.changeset/btw-readonly-tools.md
+++ b/.changeset/btw-readonly-tools.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Add read-only tools to the /btw side agent so it can answer questions about files in the codebase.
+Add read-only tools to the /btw side agent.

--- a/apps/kimi-code/src/tui/controllers/btw-panel.ts
+++ b/apps/kimi-code/src/tui/controllers/btw-panel.ts
@@ -2,6 +2,7 @@ import { Spacer } from '@moonshot-ai/pi-tui';
 import type {
   Event,
   KimiHarness,
+  PromptInput,
   Session,
   TurnEndedEvent,
 } from '@moonshot-ai/kimi-code-sdk';
@@ -14,7 +15,17 @@ import { createMarkdownTheme } from '../theme/pi-tui-theme';
 import type { InlineSkillActivation } from '../types';
 import type { TUIState } from '../tui-state';
 
+import type { StagingLease } from './staging-leases';
+
 const BTW_BUSY_NOTICE = 'Wait for /btw to finish before sending another question.';
+
+export interface BtwPreparedPrompt {
+  /** Media-expanded RPC input; undefined means send the plain text prompt. */
+  readonly input?: PromptInput;
+  /** Staged-media lease and its exact-binding submission id (plain prompts only). */
+  readonly lease?: StagingLease;
+  readonly submissionId?: string;
+}
 
 export interface BtwPanelHost {
   state: TUIState;
@@ -22,6 +33,22 @@ export interface BtwPanelHost {
   readonly harness: KimiHarness;
 
   showError(msg: string): void;
+  /**
+   * Expand pasted image/video placeholders into daemon file-ref parts for the
+   * side agent (the /btw counterpart of the main send path's media
+   * preparation). Returns undefined when preparation failed — the error was
+   * already shown.
+   */
+  prepareBtwPrompt(
+    text: string,
+    opts: { readonly stage: boolean },
+  ): Promise<BtwPreparedPrompt | undefined>;
+  /** Track a prompt dispatch carrying staged media; see StagingLeaseTracker.trackDispatch. */
+  trackBtwDispatch(
+    lease: StagingLease | undefined,
+    request: Promise<unknown>,
+    onError: (error: unknown) => void,
+  ): void;
 }
 
 export class BtwPanelController {
@@ -180,27 +207,51 @@ export class BtwPanelController {
     panel: BtwPanelComponent,
     inlineSkillActivations?: readonly InlineSkillActivation[],
   ): void {
+    void this.prepareAndPrompt(agentId, prompt, panel, inlineSkillActivations);
+  }
+
+  private async prepareAndPrompt(
+    agentId: string,
+    prompt: string,
+    panel: BtwPanelComponent,
+    inlineSkillActivations?: readonly InlineSkillActivation[],
+  ): Promise<void> {
     const session = this.host.session;
     if (session === undefined) {
       panel.markFailed(NO_ACTIVE_SESSION_MESSAGE);
       this.host.state.ui.requestRender();
       return;
     }
-    const send =
-      inlineSkillActivations !== undefined && inlineSkillActivations.length > 0
-        ? () =>
-            session.promptWithSkills(
-              prompt,
-              inlineSkillActivations.map((activation) => ({
-                name: activation.skillName,
-                args: activation.args,
-              })),
-            )
-        : () => session.prompt(prompt);
-    void this.withInteractiveAgent(agentId, send).catch((error: unknown) => {
-      panel.markFailed(`Failed to send /btw prompt: ${formatErrorMessage(error)}`);
+    const useSkills = inlineSkillActivations !== undefined && inlineSkillActivations.length > 0;
+    // Skill bundles have no prompt-id channel, so they match the main turn's
+    // inline-skill path: media rides along without a staged lease.
+    const prepared = await this.host.prepareBtwPrompt(prompt, { stage: !useSkills });
+    if (prepared === undefined) {
+      panel.markFailed('Failed to prepare the media attachment.');
       this.host.state.ui.requestRender();
-    });
+      return;
+    }
+    const input = prepared.input ?? prompt;
+    const send = useSkills
+      ? () =>
+          session.promptWithSkills(
+            input,
+            inlineSkillActivations.map((activation) => ({
+              name: activation.skillName,
+              args: activation.args,
+            })),
+          )
+      : prepared.submissionId !== undefined
+        ? () => session.prompt(input, { promptId: prepared.submissionId })
+        : () => session.prompt(input);
+    this.host.trackBtwDispatch(
+      prepared.lease,
+      this.withInteractiveAgent(agentId, send),
+      (error: unknown) => {
+        panel.markFailed(`Failed to send /btw prompt: ${formatErrorMessage(error)}`);
+        this.host.state.ui.requestRender();
+      },
+    );
   }
 
   private async cancelAgent(agentId: string): Promise<void> {

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -120,7 +120,7 @@ import { MEDIA_INGESTION_SUBMIT_WAIT_MS } from './constant/media';
 import { CHROME_GUTTER } from './constant/rendering';
 import { MAX_TERMINAL_TITLE_LENGTH } from './constant/terminal';
 import { AuthFlowController } from './controllers/auth-flow';
-import { BtwPanelController } from './controllers/btw-panel';
+import { BtwPanelController, type BtwPreparedPrompt } from './controllers/btw-panel';
 import { ClipboardImageHintController } from './controllers/clipboard-image-hint';
 import { EditorKeyboardController } from './controllers/editor-keyboard';
 import { SessionEventHandler } from './controllers/session-event-handler';
@@ -1519,6 +1519,66 @@ export class KimiTUI {
       imageAttachmentIds:
         extraction.imageAttachmentIds.length > 0 ? extraction.imageAttachmentIds : undefined,
     });
+  }
+
+  /**
+   * /btw counterpart of the send path's media preparation (see
+   * sendNormalUserInput): expands pasted image/video placeholders into daemon
+   * file-ref parts for the side agent. The side panel has no queue or
+   * cache-hint interception, so this stops at extraction + validation; staged
+   * prompts also get a media lease with an exact-binding submission id, while
+   * unstaged ones (skill bundles) match the main inline-skill path.
+   */
+  async prepareBtwPrompt(
+    text: string,
+    opts: { readonly stage: boolean },
+  ): Promise<BtwPreparedPrompt | undefined> {
+    const ingestionWait = pendingMediaIngestions(
+      text,
+      this.imageStore,
+      MEDIA_INGESTION_SUBMIT_WAIT_MS,
+    );
+    if (ingestionWait !== undefined) await ingestionWait;
+    let extraction: ReturnType<typeof extractMediaAttachments>;
+    try {
+      extraction = extractMediaAttachments(text, this.imageStore);
+    } catch (error) {
+      this.showError(`Failed to prepare media attachment: ${formatErrorMessage(error)}`);
+      return undefined;
+    }
+    if (!extraction.hasMedia) return {};
+    const stagingLease = opts.stage
+      ? this.staging.create(
+          // One retain per unique id per extraction, exactly like the main
+          // send path's lease (see sendNormalUserInput).
+          [...new Set([...extraction.imageAttachmentIds, ...extraction.videoAttachmentIds])],
+          [],
+          'user',
+          randomUUID(),
+        )
+      : undefined;
+    if (!this.validateMediaCapabilities(extraction)) {
+      this.staging.release(stagingLease);
+      return undefined;
+    }
+    return {
+      input: resolveOriginalCaptions(
+        extraction.parts,
+        extraction.imageAttachmentIds,
+        this.imageStore,
+        originalsDirForSession(this.session),
+      ),
+      lease: stagingLease,
+      submissionId: stagingLease?.submissionId,
+    };
+  }
+
+  trackBtwDispatch(
+    lease: StagingLease | undefined,
+    request: Promise<unknown>,
+    onError: (error: unknown) => void,
+  ): void {
+    this.staging.trackDispatch(lease, request, onError);
   }
 
   validateMediaCapabilities(extraction: {

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -4708,6 +4708,56 @@ command = "vim"
     expect(stripSgr(renderBtwPanel(driver))).toContain('Q: What are you working on right now?');
   });
 
+  it('sends a pasted image in the initial /btw prompt as daemon file-ref parts', async () => {
+    const session = makeSession();
+    const { driver, harness } = await makeDriver(session);
+    const imageStore = (driver as unknown as { imageStore: ImageAttachmentStore }).imageStore;
+    const attachment = stagedImage(imageStore, 'file-btw');
+
+    driver.handleUserInput(`/btw describe ${attachment.placeholder}`);
+
+    await vi.waitFor(() => {
+      expect(session.prompt).toHaveBeenCalledWith(
+        [
+          { type: 'text', text: 'describe ' },
+          { type: 'image_url', imageUrl: { url: 'kimi-file://file-btw' } },
+        ],
+        { promptId: expect.any(String) },
+      );
+    });
+    expect(harness.deleteFile).not.toHaveBeenCalled();
+    emitTurn(driver, 1, () => {
+      expect(harness.deleteFile).not.toHaveBeenCalled();
+    });
+    await vi.waitFor(() => {
+      expect(harness.deleteFile).toHaveBeenCalledWith('file-btw');
+    });
+  });
+
+  it('sends a pasted image in follow-up /btw panel input as daemon file-ref parts', async () => {
+    const session = makeSession();
+    const { driver } = await makeDriver(session);
+    driver.handleUserInput('/btw');
+    await vi.waitFor(() => {
+      expect(session.startBtw).toHaveBeenCalled();
+      expect(driver.state.btwPanelContainer.children).toHaveLength(2);
+    });
+    const imageStore = (driver as unknown as { imageStore: ImageAttachmentStore }).imageStore;
+    const attachment = stagedImage(imageStore, 'file-btw-2');
+
+    driver.handleUserInput(`look at ${attachment.placeholder}`);
+
+    await vi.waitFor(() => {
+      expect(session.prompt).toHaveBeenCalledWith(
+        [
+          { type: 'text', text: 'look at ' },
+          { type: 'image_url', imageUrl: { url: 'kimi-file://file-btw-2' } },
+        ],
+        { promptId: expect.any(String) },
+      );
+    });
+  });
+
   it('sends /btw panel input with inline skills via promptWithSkills (v2 engine)', async () => {
     const session = makeSession({
       id: 'ses-lazy',

--- a/docs/en/reference/server-api.md
+++ b/docs/en/reference/server-api.md
@@ -751,7 +751,7 @@ On success, `data` is `{ aborted: true }`.
 
 #### `POST /api/v1/sessions/{session_id}:btw`
 
-Starts a "by the way" side conversation: forks the main agent into a child agent whose tool calls are limited to the read-only tools `Read`, `Grep`, and `Glob`, so quick side questions run in isolation without touching the working context. Requires a usable model configuration.
+Starts a "by the way" side conversation: forks the main agent into a child agent whose tool calls are limited to the read-only tools `Read`, `Grep`, `Glob`, and `ReadMediaFile`, so quick side questions run in isolation without touching the working context. Requires a usable model configuration.
 
 On success, `data` is `{ agent_id }` — the id of the new child agent.
 

--- a/docs/en/reference/server-api.md
+++ b/docs/en/reference/server-api.md
@@ -751,7 +751,7 @@ On success, `data` is `{ aborted: true }`.
 
 #### `POST /api/v1/sessions/{session_id}:btw`
 
-Starts a "by the way" side conversation: forks the main agent into a child agent whose tool calls are disabled, so quick side questions run in isolation without touching the working context. Requires a usable model configuration.
+Starts a "by the way" side conversation: forks the main agent into a child agent whose tool calls are limited to the read-only tools Read, Grep, and Glob, so quick side questions run in isolation without touching the working context. Requires a usable model configuration.
 
 On success, `data` is `{ agent_id }` — the id of the new child agent.
 

--- a/docs/en/reference/server-api.md
+++ b/docs/en/reference/server-api.md
@@ -751,7 +751,7 @@ On success, `data` is `{ aborted: true }`.
 
 #### `POST /api/v1/sessions/{session_id}:btw`
 
-Starts a "by the way" side conversation: forks the main agent into a child agent whose tool calls are limited to the read-only tools Read, Grep, and Glob, so quick side questions run in isolation without touching the working context. Requires a usable model configuration.
+Starts a "by the way" side conversation: forks the main agent into a child agent whose tool calls are limited to the read-only tools `Read`, `Grep`, and `Glob`, so quick side questions run in isolation without touching the working context. Requires a usable model configuration.
 
 On success, `data` is `{ agent_id }` — the id of the new child agent.
 

--- a/docs/zh/reference/server-api.md
+++ b/docs/zh/reference/server-api.md
@@ -751,7 +751,7 @@ schema 还接受 `agent_config` 内的 `system_prompt`、`tools`、`mcp_servers`
 
 #### `POST /api/v1/sessions/{session_id}:btw`
 
-开启一个 `"by the way"` 旁路对话：把 main agent fork 成一个禁用工具调用的子 Agent，让快速的临时问题在隔离环境中运行，不触碰工作上下文。需要可用的模型配置。
+开启一个 `"by the way"` 旁路对话：把 main agent fork 成一个仅可使用只读工具（Read、Grep、Glob）的子 Agent，让快速的临时问题在隔离环境中运行，不触碰工作上下文。需要可用的模型配置。
 
 成功时，`data` 为 `{ agent_id }`——新子 Agent 的 id。
 

--- a/docs/zh/reference/server-api.md
+++ b/docs/zh/reference/server-api.md
@@ -751,7 +751,7 @@ schema 还接受 `agent_config` 内的 `system_prompt`、`tools`、`mcp_servers`
 
 #### `POST /api/v1/sessions/{session_id}:btw`
 
-开启一个 `"by the way"` 旁路对话：把 main agent fork 成一个仅可使用只读工具（`Read`、`Grep`、`Glob`）的子 Agent，让快速的临时问题在隔离环境中运行，不触碰工作上下文。需要可用的模型配置。
+开启一个 `"by the way"` 旁路对话：把 main agent fork 成一个仅可使用只读工具（`Read`、`Grep`、`Glob`、`ReadMediaFile`）的子 Agent，让快速的临时问题在隔离环境中运行，不触碰工作上下文。需要可用的模型配置。
 
 成功时，`data` 为 `{ agent_id }`——新子 Agent 的 id。
 

--- a/docs/zh/reference/server-api.md
+++ b/docs/zh/reference/server-api.md
@@ -751,7 +751,7 @@ schema 还接受 `agent_config` 内的 `system_prompt`、`tools`、`mcp_servers`
 
 #### `POST /api/v1/sessions/{session_id}:btw`
 
-开启一个 `"by the way"` 旁路对话：把 main agent fork 成一个仅可使用只读工具（Read、Grep、Glob）的子 Agent，让快速的临时问题在隔离环境中运行，不触碰工作上下文。需要可用的模型配置。
+开启一个 `"by the way"` 旁路对话：把 main agent fork 成一个仅可使用只读工具（`Read`、`Grep`、`Glob`）的子 Agent，让快速的临时问题在隔离环境中运行，不触碰工作上下文。需要可用的模型配置。
 
 成功时，`data` 为 `{ agent_id }`——新子 Agent 的 id。
 

--- a/packages/agent-core-v2/src/features/btw/btw.ts
+++ b/packages/agent-core-v2/src/features/btw/btw.ts
@@ -1,19 +1,22 @@
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
 
+export const BTW_READONLY_TOOLS = new Set(['Read', 'Grep', 'Glob']);
+
 export const TOOL_CALL_DISABLED_MESSAGE =
-  'Tool calls are disabled for side questions. Answer with text only.';
+  'Only the read-only tools Read, Grep, and Glob are available for side questions. Other tool calls are disabled.';
 
 export const SIDE_QUESTION_SYSTEM_REMINDER = `
-This is a side-channel conversation with the user. You should answer user questions directly based on what you already know.
+This is a side-channel conversation with the user. You should answer user questions directly.
 
 IMPORTANT:
 - You are a separate, lightweight instance.
 - The main agent continues independently; do not reference being interrupted.
-- Do not call any tools. All tool calls are disabled and will be rejected.
-  Even though tool definitions are visible in this request, they exist only
-  for technical reasons (prompt cache). You must not use them.
-- Respond only with text based on what you already know from the conversation
-  and this side-channel conversation.
+- You may use the read-only tools Read, Grep, and Glob to inspect files when
+  the answer depends on current file contents. All other tools are disabled
+  and will be rejected, even though their definitions are visible in this
+  request (they exist only for technical reasons — prompt cache).
+- Prefer answering from what you already know from the conversation and this
+  side-channel conversation; reach for the read-only tools only when needed.
 - Follow-up turns may happen in this side-channel conversation.
 - If you do not know the answer, say so directly.
 `.trim();

--- a/packages/agent-core-v2/src/features/btw/btw.ts
+++ b/packages/agent-core-v2/src/features/btw/btw.ts
@@ -1,9 +1,9 @@
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
 
-export const BTW_READONLY_TOOLS = new Set(['Read', 'Grep', 'Glob']);
+export const BTW_READONLY_TOOLS = new Set(['Read', 'Grep', 'Glob', 'ReadMediaFile']);
 
 export const TOOL_CALL_DISABLED_MESSAGE =
-  'Only the read-only tools Read, Grep, and Glob are available for side questions. Other tool calls are disabled.';
+  'Only the read-only tools Read, Grep, Glob, and ReadMediaFile are available for side questions. Other tool calls are disabled.';
 
 export const SIDE_QUESTION_SYSTEM_REMINDER = `
 This is a side-channel conversation with the user. You should answer user questions directly.
@@ -12,9 +12,11 @@ IMPORTANT:
 - You are a separate, lightweight instance.
 - The main agent continues independently; do not reference being interrupted.
 - You may use the read-only tools Read, Grep, and Glob to inspect files when
-  the answer depends on current file contents. All other tools are disabled
-  and will be rejected, even though their definitions are visible in this
-  request (they exist only for technical reasons — prompt cache).
+  the answer depends on current file contents, and ReadMediaFile to view an
+  image or video file (including images the user attached to their message).
+  All other tools are disabled and will be rejected, even though their
+  definitions are visible in this request (they exist only for technical
+  reasons — prompt cache).
 - Prefer answering from what you already know from the conversation and this
   side-channel conversation; reach for the read-only tools only when needed.
 - Follow-up turns may happen in this side-channel conversation.

--- a/packages/agent-core-v2/src/features/btw/btwService.ts
+++ b/packages/agent-core-v2/src/features/btw/btwService.ts
@@ -6,7 +6,12 @@ import { IAgentScopeContext } from '#/agent/scopeContext/scopeContext';
 import { ErrorCodes, Error2 } from '#/errors';
 import { IAgentLifecycleService, MAIN_AGENT_ID } from '#/session/agentLifecycle/agentLifecycle';
 
-import { ISessionBtwService, SIDE_QUESTION_SYSTEM_REMINDER, TOOL_CALL_DISABLED_MESSAGE } from './btw';
+import {
+  BTW_READONLY_TOOLS,
+  ISessionBtwService,
+  SIDE_QUESTION_SYSTEM_REMINDER,
+  TOOL_CALL_DISABLED_MESSAGE,
+} from './btw';
 
 export class SessionBtwService implements ISessionBtwService {
   declare readonly _serviceBrand: undefined;
@@ -32,7 +37,9 @@ export class SessionBtwService implements ISessionBtwService {
     child.accessor
       .get(IAgentToolExecutorService)
       ?.onBeforeExecuteTool((event) => {
-        event.veto(denyToolExecution(reason));
+        if (!BTW_READONLY_TOOLS.has(event.toolCall.name)) {
+          event.veto(denyToolExecution(reason));
+        }
       });
     return childContext.agentId;
   }

--- a/packages/agent-core-v2/test/features/btw/btw.test.ts
+++ b/packages/agent-core-v2/test/features/btw/btw.test.ts
@@ -7,6 +7,7 @@ import { TestInstantiationService } from '#/_base/di/test';
 import { IAgentToolApprovalService } from '#/agent/toolApproval/toolApproval';
 import { IAgentToolExecutorService } from '#/agent/toolExecutor/toolExecutor';
 import {
+  BTW_READONLY_TOOLS,
   ISessionBtwService,
   SIDE_QUESTION_SYSTEM_REMINDER,
   TOOL_CALL_DISABLED_MESSAGE,
@@ -86,26 +87,47 @@ describe('SessionBtwService', () => {
     });
   });
 
-  it('vetoes every tool call on the child through the btw deny listener', async () => {
+  it('vetoes non-read-only tool calls on the child through the btw deny listener', async () => {
     const svc = ix.get(ISessionBtwService);
     await svc.start();
 
-    const toolCall: ToolCall = { type: 'function', id: 'call_1', name: 'Bash', arguments: '{}' };
-    const decision = await executorEvents.fireBeforeExecute({
-      turnId: 0,
-      signal: new AbortController().signal,
-      toolCall,
-      toolCalls: [toolCall],
-      args: {},
-      execution: { approvalRule: 'Bash', execute: async () => ({ output: '' }) },
-    });
+    for (const name of ['Bash', 'Write', 'Edit']) {
+      const toolCall: ToolCall = { type: 'function', id: `call_${name}`, name, arguments: '{}' };
+      const decision = await executorEvents.fireBeforeExecute({
+        turnId: 0,
+        signal: new AbortController().signal,
+        toolCall,
+        toolCalls: [toolCall],
+        args: {},
+        execution: { approvalRule: name, execute: async () => ({ output: '' }) },
+      });
 
-    expect(decision).toEqual({
-      veto: {
-        output: `${TOOL_CALL_DISABLED_MESSAGE} [worker guidance]`,
-        isError: true,
-      },
-    });
+      expect(decision).toEqual({
+        veto: {
+          output: `${TOOL_CALL_DISABLED_MESSAGE} [worker guidance]`,
+          isError: true,
+        },
+      });
+    }
     expect(formatDenyMessage).toHaveBeenCalledWith(TOOL_CALL_DISABLED_MESSAGE);
+  });
+
+  it('allows read-only tool calls (Read, Grep, Glob) on the child', async () => {
+    const svc = ix.get(ISessionBtwService);
+    await svc.start();
+
+    for (const name of BTW_READONLY_TOOLS) {
+      const toolCall: ToolCall = { type: 'function', id: `call_${name}`, name, arguments: '{}' };
+      const decision = await executorEvents.fireBeforeExecute({
+        turnId: 0,
+        signal: new AbortController().signal,
+        toolCall,
+        toolCalls: [toolCall],
+        args: {},
+        execution: { approvalRule: name, execute: async () => ({ output: '' }) },
+      });
+
+      expect(decision).toBeUndefined();
+    }
   });
 });

--- a/packages/agent-core-v2/test/features/btw/btw.test.ts
+++ b/packages/agent-core-v2/test/features/btw/btw.test.ts
@@ -112,10 +112,11 @@ describe('SessionBtwService', () => {
     expect(formatDenyMessage).toHaveBeenCalledWith(TOOL_CALL_DISABLED_MESSAGE);
   });
 
-  it('allows read-only tool calls (Read, Grep, Glob) on the child', async () => {
+  it('allows read-only tool calls (Read, Grep, Glob, ReadMediaFile) on the child', async () => {
     const svc = ix.get(ISessionBtwService);
     await svc.start();
 
+    expect([...BTW_READONLY_TOOLS].toSorted()).toEqual(['Glob', 'Grep', 'Read', 'ReadMediaFile']);
     for (const name of BTW_READONLY_TOOLS) {
       const toolCall: ToolCall = { type: 'function', id: `call_${name}`, name, arguments: '{}' };
       const decision = await executorEvents.fireBeforeExecute({


### PR DESCRIPTION
## Problem

The /btw side-question panel is a text-only channel: when the user pastes an image and asks a side question, the `[image #N]` placeholder goes to the side agent as literal text and the image bytes never leave the TUI's attachment store — the side agent cannot see the image at all. The daemon side is already ready (mediaResolver / prompt media intake / session media store all apply to the forked btw child); only the TUI input path drops the media.

## What changed

- The btw panel's prompt path now expands pasted image/video placeholders into daemon file-ref prompt parts exactly like the main send path: bounded ingestion wait, `extractMediaAttachments`, model capability validation, and a staged-media lease with an exact-binding submission id (`promptId`) so the staging upload is released when the consuming turn ends. Skill bundles match the main inline-skill path (media rides along, no lease). This covers both the initial `/btw <question>` prompt and follow-up panel input.
- The btw child's read-only tool allowlist gains `ReadMediaFile` (already auto-approved by the default-tool-approve policy), so models without image input can still view images via the degraded `<image path>` form; the side-question reminder mentions it.
- Server-api docs (en/zh) updated for the new allowlist entry.

## Relationship to #3613

**Stacked on #3613** (`feat/btw-readonly-tools`, base of this PR): that PR introduced the `BTW_READONLY_TOOLS` allowlist this change extends with `ReadMediaFile`. Once #3613 merges, this PR's base retargets to main. Self-contained alternative (duplicating the allowlist on main) was rejected to avoid a guaranteed merge conflict between the two PRs.

## Tests

- `btw.test.ts` (agent-core-v2): the read-only allow test now pins the exact allowlist `{Read, Grep, Glob, ReadMediaFile}` and verifies ReadMediaFile passes the veto.
- `kimi-tui-message-flow.test.ts`: two new cases — a pasted image in the initial `/btw` prompt and in follow-up panel input is sent as `kimi-file://` parts with a `promptId`, and the staging upload survives until the consuming turn ends.