### PR TITLE
feat(kap-server): expose session deletion with serialized cleanup

### DIFF
--- a/.changeset/session-delete-action.md
+++ b/.changeset/session-delete-action.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add session deletion to the server API via `POST /api/v1/sessions/{id}:delete`.

--- a/apps/kimi-inspect/src/activity/store.test.ts
+++ b/apps/kimi-inspect/src/activity/store.test.ts
@@ -199,6 +199,21 @@ describe('SessionActivityHub', () => {
     expect(hub.store.get('s1')).toBeUndefined();
     expect(onListChanged).toHaveBeenCalledTimes(1);
 
+    instances[0]!.emitFrame({
+      type: 'event.session.work_changed',
+      session_id: 's2',
+      payload: { type: 'event.session.work_changed', busy: true },
+    });
+    expect(hub.store.get('s2')).toBeDefined();
+
+    instances[0]!.emitFrame({
+      type: 'event.session.deleted',
+      session_id: '__global__',
+      payload: { type: 'event.session.deleted', sessionId: 's2', workspace_id: 'wd_1' },
+    });
+    expect(hub.store.get('s2')).toBeUndefined();
+    expect(onListChanged).toHaveBeenCalledTimes(2);
+
     for (const type of [
       'event.workspace.created',
       'event.workspace.updated',
@@ -206,7 +221,7 @@ describe('SessionActivityHub', () => {
     ]) {
       instances[0]!.emitFrame({ type, session_id: '__global__', payload: {} });
     }
-    expect(onListChanged).toHaveBeenCalledTimes(4);
+    expect(onListChanged).toHaveBeenCalledTimes(5);
     hub.close();
   });
 });

--- a/apps/kimi-inspect/src/activity/store.ts
+++ b/apps/kimi-inspect/src/activity/store.ts
@@ -106,6 +106,10 @@ export class SessionActivityHub {
           this.store.remove(sessionId);
           opts.onListChanged();
         },
+        onSessionDeleted: (sessionId) => {
+          this.store.remove(sessionId);
+          opts.onListChanged();
+        },
         onWorkspaceChanged: () => opts.onListChanged(),
         onReconnected: () => void this.seed(),
       },

--- a/apps/kimi-inspect/src/activity/ws.ts
+++ b/apps/kimi-inspect/src/activity/ws.ts
@@ -64,6 +64,10 @@ export interface GlobalEventsWsHandlers {
    *  carries the `__global__` watermark; the real session id rides in the
    *  payload. */
   onSessionArchived?: ((sessionId: string) => void) | undefined;
+  /** A session was permanently deleted (list-level signal). Same envelope
+   *  shape as `event.session.archived`: the real session id rides in the
+   *  payload. */
+  onSessionDeleted?: (sessionId: string) => void;
   /** A workspace was created / updated / deleted (list-level signal). */
   onWorkspaceChanged?: (() => void) | undefined;
   /** A DI unit of the engine's scope tree changed state (debug feed). */
@@ -192,6 +196,14 @@ export class GlobalEventsWs {
         const archivedId = payload?.sessionId;
         if (typeof archivedId === 'string' && archivedId !== '') {
           this.handlers.onSessionArchived?.(archivedId);
+        }
+        return;
+      }
+      case 'event.session.deleted': {
+        const payload = frame.payload as { sessionId?: unknown } | undefined;
+        const deletedId = payload?.sessionId;
+        if (typeof deletedId === 'string' && deletedId !== '') {
+          this.handlers.onSessionDeleted?.(deletedId);
         }
         return;
       }

--- a/packages/agent-core-v2/src/app/sessionManager/sessionManager.ts
+++ b/packages/agent-core-v2/src/app/sessionManager/sessionManager.ts
@@ -31,6 +31,7 @@ export interface ISessionManager {
   readonly onDidCreateSession?: Event<SessionCreatedEvent & IWaitUntil>;
   readonly onWillCloseSession?: Event<SessionWillCloseEvent & IWaitUntil>;
   readonly onDidCloseSession?: Event<SessionClosedEvent>;
+  readonly onWillDeleteSession?: Event<{ readonly sessionId: string } & IWaitUntil>;
   readonly onDidArchiveSession?: Event<SessionArchivedEvent>;
   readonly onDidForkSession?: Event<SessionForkedEvent>;
   create(options: CreateManagedSessionOptions): Promise<ISessionScopeHandle>;

--- a/packages/agent-core-v2/src/app/sessionManager/sessionManagerService.ts
+++ b/packages/agent-core-v2/src/app/sessionManager/sessionManagerService.ts
@@ -50,6 +50,8 @@ export class SessionManager implements ISessionManager {
   readonly onWillCloseSession = this.willCloseEmitter.event;
   private readonly didCloseEmitter = new Emitter<SessionClosedEvent>();
   readonly onDidCloseSession = this.didCloseEmitter.event;
+  private readonly willDeleteEmitter = new Emitter<{ readonly sessionId: string } & IWaitUntil>();
+  readonly onWillDeleteSession = this.willDeleteEmitter.event;
   private readonly didArchiveEmitter = new Emitter<SessionArchivedEvent>();
   readonly onDidArchiveSession = this.didArchiveEmitter.event;
   private readonly didForkEmitter = new Emitter<SessionForkedEvent>();
@@ -66,9 +68,9 @@ export class SessionManager implements ISessionManager {
         ? { root: options.workDir }
         : { workspaceId: options.workspaceId, root: options.workDir },
     );
-    const controller = this.controllerForWorkspace(workspace.id);
-    if (options.sessionId === undefined) return controller.create(options);
-    return this.serializeLifecycle(options.sessionId, () => controller.create(options));
+    const create = () => this.controllerForWorkspace(workspace.id).create(options);
+    if (options.sessionId === undefined) return create();
+    return this.serializeLifecycle(options.sessionId, create);
   }
 
   async resume(sessionId: string, options?: ResumeSessionOptions): Promise<ISessionScopeHandle | undefined> {
@@ -169,6 +171,20 @@ export class SessionManager implements ISessionManager {
       if (controller === undefined) {
         throw new Error2(ErrorCodes.SESSION_NOT_FOUND, `session ${sessionId} does not exist`);
       }
+      await controller.close(sessionId);
+      const cleanups: Promise<unknown>[] = [];
+      this.willDeleteEmitter.fire({
+        sessionId,
+        signal: new AbortController().signal,
+        waitUntil: (cleanup) => {
+          if (Object.isFrozen(cleanups)) throw new Error('waitUntil must be called synchronously');
+          cleanups.push(cleanup);
+        },
+      });
+      void Object.freeze(cleanups);
+      const settled = await Promise.allSettled(cleanups);
+      const failed = settled.find((result) => result.status === 'rejected');
+      if (failed?.status === 'rejected') throw failed.reason;
       await controller.delete(sessionId);
     });
   }
@@ -218,6 +234,7 @@ export class SessionManager implements ISessionManager {
     this.didCreateEmitter.dispose();
     this.willCloseEmitter.dispose();
     this.didCloseEmitter.dispose();
+    this.willDeleteEmitter.dispose();
     this.didArchiveEmitter.dispose();
     this.didForkEmitter.dispose();
   }

--- a/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleEvents.ts
+++ b/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleEvents.ts
@@ -13,6 +13,18 @@ export interface SessionArchived {
   readonly payload: SessionArchivedPayload;
 }
 
+export interface SessionDeletedPayload {
+  readonly sessionId: string;
+  readonly workspaceId: string;
+}
+
+export class SessionDeleted extends Event2<{ readonly payload: SessionDeletedPayload }> {
+  static override readonly type = 'event.session.deleted';
+}
+export interface SessionDeleted {
+  readonly payload: SessionDeletedPayload;
+}
+
 export interface SessionCreatedPayload {
   readonly agentId: string;
   readonly sessionId: string;

--- a/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
+++ b/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
@@ -97,7 +97,7 @@ import { IWorkspaceMcpService } from '#/workspace/workspaceMcp/workspaceMcp';
 import { PLUGIN_SKILL_SOURCE_ID } from '#/features/skill/catalog/skillSource';
 
 import { agentScopeOf, sessionDirOf, sessionScopeOf } from './internal/addressing';
-import { SessionArchived } from './sessionLifecycleEvents';
+import { SessionArchived, SessionDeleted } from './sessionLifecycleEvents';
 import {
   assertForkTurnIndex,
   sliceMainRecordsAtTurn,
@@ -475,6 +475,11 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
     await dropFileHistorySession({ docs: this.docs, workspaceId: this.workspaceId, sessionId });
     this.appendLogStore.append('', 'session_index.jsonl', { sessionId, deleted: true });
     await this.appendLogStore.flush();
+    this.event.publish(
+      new SessionDeleted({
+        payload: { sessionId, workspaceId: this.workspaceContext.workspaceId },
+      }),
+    );
   }
 
   private async announceWillClose(event: SessionWillCloseEvent): Promise<void> {

--- a/packages/kap-server/src/openapi/transforms.ts
+++ b/packages/kap-server/src/openapi/transforms.ts
@@ -41,7 +41,10 @@ import {
   questionResolveRequestSchema,
   questionResolveResultSchema,
 } from '../protocol/rest-question';
-import { archiveSessionResponseSchema } from '../protocol/rest-session';
+import {
+  archiveSessionResponseSchema,
+  deleteSessionResponseSchema,
+} from '../protocol/rest-session';
 
 const binarySchema = {
   type: 'string',
@@ -183,18 +186,32 @@ function patchSessionAction(paths: Record<string, unknown>): void {
   const operation = asRecord(pathItem?.['post']);
   if (pathItem === undefined || operation === undefined) return;
 
+  projectSessionAction(paths, pathItem, 'archive', 'runSessionArchiveAction', {
+    description: 'Session archive response',
+    content: jsonContent(openApiDocumentEnvelopeJsonSchema(archiveSessionResponseSchema)),
+  });
+  projectSessionAction(paths, pathItem, 'delete', 'runSessionDeleteAction', {
+    description: 'Session delete response',
+    content: jsonContent(openApiDocumentEnvelopeJsonSchema(deleteSessionResponseSchema)),
+  });
+  delete paths[internalPath];
+}
+
+function projectSessionAction(
+  paths: Record<string, unknown>,
+  pathItem: Record<string, unknown>,
+  action: string,
+  operationId: string,
+  okResponse: Record<string, unknown>,
+): void {
   const cloned = cloneRecord(pathItem);
   replacePathParamName(cloned, 'tail', 'session_id');
   const clonedOperation = asRecord(cloned['post']);
   if (clonedOperation !== undefined) {
-    clonedOperation['operationId'] = 'runSessionArchiveAction';
-    setResponse(clonedOperation, '200', {
-      description: 'Session archive response',
-      content: jsonContent(openApiDocumentEnvelopeJsonSchema(archiveSessionResponseSchema)),
-    });
+    clonedOperation['operationId'] = operationId;
+    setResponse(clonedOperation, '200', okResponse);
   }
-  paths['/api/v1/sessions/{session_id}:archive'] = cloned;
-  delete paths[internalPath];
+  paths[`/api/v1/sessions/{session_id}:${action}`] = cloned;
 }
 
 function patchFsAction(paths: Record<string, unknown>): void {

--- a/packages/kap-server/src/protocol/events-zod.ts
+++ b/packages/kap-server/src/protocol/events-zod.ts
@@ -584,6 +584,11 @@ export const sessionArchivedEventSchema = z.object({
   workspace_id: z.string().min(1),
 });
 
+export const sessionDeletedEventSchema = z.object({
+  type: z.literal('event.session.deleted'),
+  workspace_id: z.string().min(1),
+});
+
 export const workspaceCreatedEventSchema = z.object({
   type: z.literal('event.workspace.created'),
   workspace: workspaceSchema,
@@ -1056,6 +1061,7 @@ export const agentEventSchema = z.discriminatedUnion('type', [
   sessionMetaUpdatedEventSchema,
   sessionCreatedEventSchema,
   sessionArchivedEventSchema,
+  sessionDeletedEventSchema,
   workspaceCreatedEventSchema,
   workspaceUpdatedEventSchema,
   workspaceDeletedEventSchema,

--- a/packages/kap-server/src/protocol/rest-session.ts
+++ b/packages/kap-server/src/protocol/rest-session.ts
@@ -162,8 +162,10 @@ export type ArchiveSessionResponse = z.infer<typeof archiveSessionResponseSchema
 export const restoreSessionResponseSchema = sessionSchema;
 export type RestoreSessionResponse = z.infer<typeof restoreSessionResponseSchema>;
 
-export const deleteSessionResponseSchema = archiveSessionResponseSchema;
-export type DeleteSessionResponse = ArchiveSessionResponse;
+export const deleteSessionResponseSchema = z.object({
+  deleted: z.literal(true),
+});
+export type DeleteSessionResponse = z.infer<typeof deleteSessionResponseSchema>;
 
 export const sessionAbortResponseSchema = z.object({
   aborted: z.boolean(),

--- a/packages/kap-server/src/routes/sessions.ts
+++ b/packages/kap-server/src/routes/sessions.ts
@@ -41,6 +41,7 @@ import {
   compactSessionResponseSchema,
   createSessionChildRequestSchema,
   createSessionRequestSchema,
+  deleteSessionResponseSchema,
   forkSessionRequestSchema,
   getSessionGoalResponseSchema,
   listSessionChildrenResponseSchema,
@@ -606,6 +607,7 @@ export function registerSessionsRoutes(
           sessionAbortResponseSchema,
           startBtwSessionResponseSchema,
           archiveSessionResponseSchema,
+          deleteSessionResponseSchema,
         ]),
       },
       errors: {
@@ -854,7 +856,15 @@ export function registerSessionsRoutes(
   );
 }
 
-type SessionAction = 'fork' | 'compact' | 'undo' | 'abort' | 'btw' | 'restore' | 'archive';
+type SessionAction =
+  | 'fork'
+  | 'compact'
+  | 'undo'
+  | 'abort'
+  | 'btw'
+  | 'restore'
+  | 'archive'
+  | 'delete';
 
 interface SessionActionExtra {
   readonly core: Scope;
@@ -875,6 +885,7 @@ const sessionActions: ActionTable<SessionAction, SessionActionExtra> = {
   btw: { handle: btwSessionAction },
   restore: { handle: restoreSessionAction },
   archive: { handle: archiveSessionAction },
+  delete: { handle: deleteSessionAction },
 };
 
 async function forkSessionAction(
@@ -988,6 +999,13 @@ async function archiveSessionAction(ctx: SessionActionCtx): Promise<void> {
   await setSessionArchived(core.accessor, id, true);
   requestLog(req)?.info({ session_id: id, action: 'archive' }, 'session action completed');
   reply.send(okEnvelope({ archived: true }, req.id));
+}
+
+async function deleteSessionAction(ctx: SessionActionCtx): Promise<void> {
+  const { core, req, reply, id } = ctx;
+  await core.accessor.get(ISessionManager).delete(id);
+  requestLog(req)?.info({ session_id: id, action: 'delete' }, 'session action completed');
+  reply.send(okEnvelope({ deleted: true }, req.id));
 }
 
 export interface SessionWireFields {

--- a/packages/kap-server/src/transport/ws/v1/events.ts
+++ b/packages/kap-server/src/transport/ws/v1/events.ts
@@ -48,6 +48,11 @@ export interface SessionArchivedEvent {
   readonly workspace_id: string;
 }
 
+export interface SessionDeletedEvent {
+  readonly type: 'event.session.deleted';
+  readonly workspace_id: string;
+}
+
 export interface WorkspaceCreatedEvent {
   readonly type: 'event.workspace.created';
   readonly workspace: Workspace;
@@ -218,6 +223,7 @@ export type AgentEvent =
   | SessionMetaUpdatedEvent
   | SessionCreatedEvent
   | SessionArchivedEvent
+  | SessionDeletedEvent
   | WorkspaceCreatedEvent
   | WorkspaceUpdatedEvent
   | WorkspaceDeletedEvent

--- a/packages/kap-server/src/transport/ws/v1/sessionEventBroadcaster.ts
+++ b/packages/kap-server/src/transport/ws/v1/sessionEventBroadcaster.ts
@@ -1,3 +1,5 @@
+import { rm } from 'node:fs/promises';
+
 import type {
   AgentActivityState,
   ApprovalResponse,
@@ -17,6 +19,7 @@ import {
   IEventService,
   ISessionActivityView,
   ISessionIndex,
+  ISessionManager,
   MAIN_AGENT_ID,
   getLiveSessionById,
   listSessionPendingInteractions,
@@ -140,6 +143,7 @@ export class SessionEventBroadcaster {
   private readonly pendingStates = new Map<string, Promise<SessionState | undefined>>();
   private readonly maxBufferSize: number;
   private readonly coreEventSubscription: IDisposable;
+  private readonly deletionSubscription: IDisposable | undefined;
   private closed = false;
 
   constructor(
@@ -152,6 +156,11 @@ export class SessionEventBroadcaster {
     },
   ) {
     this.maxBufferSize = opts.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
+    this.deletionSubscription = opts.core.accessor.get(ISessionManager).onWillDeleteSession?.(
+      (event) => {
+        event.waitUntil(this.purgeSession(event.sessionId));
+      },
+    );
     this.coreEventSubscription = opts.core.accessor
       .get(IEventService)
       .subscribe((event) => this.onCoreEvent(event));
@@ -510,6 +519,7 @@ export class SessionEventBroadcaster {
     if (this.closed) return;
     this.closed = true;
     this.coreEventSubscription.dispose();
+    this.deletionSubscription?.dispose();
     await Promise.all(
       [...this.pendingStates.values()].map((pending) => pending.catch(() => undefined)),
     );
@@ -518,6 +528,18 @@ export class SessionEventBroadcaster {
       this.opts.transcriptService?.dropSession(sessionId);
     }
     this.sessions.clear();
+  }
+
+  private async purgeSession(sessionId: string): Promise<void> {
+    await this.pendingStates.get(sessionId);
+    const state = this.sessions.get(sessionId);
+    if (state !== undefined) {
+      this.sessions.delete(sessionId);
+      state.targets.clear();
+      await disposeSessionState(state);
+    }
+    this.opts.transcriptService?.dropSession(sessionId);
+    await rm(sessionJournalPath(this.opts.eventsDir, sessionId), { force: true });
   }
 
   private ensureState(sessionId: string): Promise<SessionState | undefined> {
@@ -546,7 +568,7 @@ export class SessionEventBroadcaster {
       sessionJournalPath(this.opts.eventsDir, sessionId),
       this.opts.logger,
     );
-    if (this.closed) {
+    if (this.closed || getLiveSessionById(this.opts.core.accessor, sessionId) !== session) {
       await journal.close();
       return undefined;
     }
@@ -646,6 +668,19 @@ export class SessionEventBroadcaster {
         sessionId: payload.sessionId,
       } as Event).catch((error: unknown) =>
         this.logDispatchError(GLOBAL_SESSION_ID, 'event.session.archived', error),
+      );
+      return;
+    }
+    if (event.type === 'event.session.deleted') {
+      const payload = sessionDeletedPayload(corePayload);
+      if (payload === undefined) return;
+      void this.dispatchGlobal({
+        type: 'event.session.deleted',
+        workspace_id: payload.workspaceId,
+        agentId: 'main',
+        sessionId: payload.sessionId,
+      } as Event).catch((error: unknown) =>
+        this.logDispatchError(GLOBAL_SESSION_ID, 'event.session.deleted', error),
       );
       return;
     }
@@ -1361,6 +1396,20 @@ function sessionCreatedPayload(
 }
 
 function sessionArchivedPayload(
+  payload: unknown,
+): { sessionId: string; workspaceId: string } | undefined {
+  if (typeof payload !== 'object' || payload === null) return undefined;
+  const candidate = payload as { sessionId?: unknown; workspaceId?: unknown };
+  if (typeof candidate.sessionId !== 'string' || candidate.sessionId.length === 0) {
+    return undefined;
+  }
+  if (typeof candidate.workspaceId !== 'string' || candidate.workspaceId.length === 0) {
+    return undefined;
+  }
+  return { sessionId: candidate.sessionId, workspaceId: candidate.workspaceId };
+}
+
+function sessionDeletedPayload(
   payload: unknown,
 ): { sessionId: string; workspaceId: string } | undefined {
   if (typeof payload !== 'object' || payload === null) return undefined;

--- a/packages/kap-server/test/__snapshots__/apiSurface.snapshot.test.ts.snap
+++ b/packages/kap-server/test/__snapshots__/apiSurface.snapshot.test.ts.snap
@@ -426,6 +426,10 @@ exports[`API surface snapshot > matches the documented v2 route table and meta e
     ],
     [
       "POST",
+      "/api/v1/sessions/{session_id}:delete",
+    ],
+    [
+      "POST",
       "/api/v1/sessions/{session_id}/{tail}",
     ],
     [

--- a/packages/kap-server/test/openapi.test.ts
+++ b/packages/kap-server/test/openapi.test.ts
@@ -32,12 +32,13 @@ describe('server-v2 OpenAPI', () => {
     expect(paths['/api/v1/sessions/{session_id}/fs/{*}']).toBeDefined();
   });
 
-  it('projects the session-action dispatcher into archive only', async () => {
+  it('projects the session-action dispatcher into archive and delete only', async () => {
     const doc = await fetchOpenApi();
     const paths = asRecord(doc['paths']);
 
     expect(paths['/api/v1/sessions/{tail}']).toBeUndefined();
     expect(paths['/api/v1/sessions/{session_id}:archive']).toBeDefined();
+    expect(paths['/api/v1/sessions/{session_id}:delete']).toBeDefined();
     expect(paths['/api/v1/sessions/{session_id}:fork']).toBeUndefined();
     expect(paths['/api/v1/sessions/{session_id}:undo']).toBeUndefined();
 
@@ -46,6 +47,12 @@ describe('server-v2 OpenAPI', () => {
     const params = archiveOp['parameters'] as Array<Record<string, unknown>>;
     expect(params.some((p) => p['in'] === 'path' && p['name'] === 'session_id')).toBe(true);
     expect(params.some((p) => p['name'] === 'tail')).toBe(false);
+
+    const deleteOp = operation(doc, '/api/v1/sessions/{session_id}:delete', 'post');
+    expect(deleteOp['operationId']).toBe('runSessionDeleteAction');
+    const deleteParams = deleteOp['parameters'] as Array<Record<string, unknown>>;
+    expect(deleteParams.some((p) => p['in'] === 'path' && p['name'] === 'session_id')).toBe(true);
+    expect(deleteParams.some((p) => p['name'] === 'tail')).toBe(false);
   });
 
   it('describes the file upload as multipart/form-data', async () => {

--- a/packages/kap-server/test/sessionEventBroadcaster.test.ts
+++ b/packages/kap-server/test/sessionEventBroadcaster.test.ts
@@ -49,7 +49,7 @@ import {
   type BroadcastTarget,
   SessionEventBroadcaster,
 } from '../src/transport/ws/v1/sessionEventBroadcaster';
-import type { EventEnvelope } from '../src/transport/ws/v1/sessionEventJournal';
+import { SessionEventJournal, type EventEnvelope } from '../src/transport/ws/v1/sessionEventJournal';
 import { TranscriptService } from '../src/services/transcript/transcriptService';
 
 type FakeBusEvent = { type: string };
@@ -459,9 +459,12 @@ function makeCore(
   eventBus = new FakeEventBus(),
   metaAgents: Record<string, { type?: string; parentAgentId?: string }> = {},
 ): Scope {
+  const handles = new WeakMap<FakeLifecycle, IScopeHandle>();
   const sessionFor = (sid: string) => {
     const lifecycle = sessions.get(sid);
     if (lifecycle === undefined) return undefined;
+    const existing = handles.get(lifecycle);
+    if (existing !== undefined) return existing;
     const sessionAccessor = {
       get: (t: unknown) => {
         if (t === IAgentLifecycleService) return lifecycle;
@@ -470,7 +473,9 @@ function makeCore(
         return undefined;
       },
     };
-    return { id: sid, kind: LifecycleScope.Session, accessor: sessionAccessor, dispose: () => {} };
+    const handle = { id: sid, kind: LifecycleScope.Session, accessor: sessionAccessor, dispose: () => {} } as unknown as IScopeHandle;
+    handles.set(lifecycle, handle);
+    return handle;
   };
   const sessionLifecycle = {
     onDidCloseSession: () => ({ dispose: () => {} }),
@@ -552,6 +557,33 @@ describe('SessionEventBroadcaster', () => {
   afterEach(async () => {
     await bc.close();
     await rm(dir, { recursive: true, force: true });
+  });
+
+  it('does not install a pending state after its session disappears', async () => {
+    const lifecycle = new FakeLifecycle();
+    lifecycle.addAgent('main');
+    sessions.set('s1', lifecycle);
+    const journal = await SessionEventJournal.open(join(dir, 's1.jsonl'));
+    let enter!: () => void;
+    let release!: () => void;
+    const entered = new Promise<void>((resolve) => { enter = resolve; });
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const opening = vi.spyOn(SessionEventJournal, 'open').mockImplementation(async () => {
+      enter();
+      await gate;
+      return journal;
+    });
+    try {
+      const subscription = bc.subscribe('s1', collectingTarget().target);
+      await entered;
+      sessions.delete('s1');
+      release();
+      expect(await subscription).toBe(false);
+      expect(await bc.subscribe('s1', collectingTarget().target)).toBe(false);
+    } finally {
+      release();
+      opening.mockRestore();
+    }
   });
 
   it('preserves a real Event2 time in payload and derives the envelope timestamp from it', async () => {
@@ -1244,6 +1276,29 @@ describe('SessionEventBroadcaster', () => {
       session_id: '__global__',
       payload: {
         type: 'event.session.archived',
+        agentId: 'main',
+        sessionId: 'cold-1',
+        workspace_id: 'wd_cold',
+      },
+    });
+    expect(globalView.deliveries).toEqual(['immediate']);
+  });
+
+  it('fans out event.session.deleted to every connection, including for cold sessions', async () => {
+    const globalView = collectingTarget();
+    bc.addGlobalTarget(globalView.target);
+
+    eventBus.emit({
+      type: 'event.session.deleted',
+      payload: { sessionId: 'cold-1', workspaceId: 'wd_cold' },
+    });
+
+    await vi.waitFor(() => expect(globalView.envelopes).toHaveLength(1));
+    expect(globalView.envelopes[0]).toMatchObject({
+      type: 'event.session.deleted',
+      session_id: '__global__',
+      payload: {
+        type: 'event.session.deleted',
         agentId: 'main',
         sessionId: 'cold-1',
         workspace_id: 'wd_cold',

--- a/packages/kap-server/test/sessions.test.ts
+++ b/packages/kap-server/test/sessions.test.ts
@@ -28,6 +28,7 @@ import {
   sessionDirOf,
   type ScopeSeed,
 } from '@moonshot-ai/agent-core-v2';
+import { SessionMetaUpdated } from '@moonshot-ai/agent-core-v2/session/sessionMetadata/sessionMetaEvents';
 import { TurnStarted } from '@moonshot-ai/agent-core-v2/agent/loop/turnEvents';
 import { sessionWarningsResponseSchema } from '@moonshot-ai/agent-core-v2/app/sessionLegacy/sessionProtocol';
 import { encodeWorkDirKey } from '@moonshot-ai/agent-core-v2/_base/utils/workdir-slug';
@@ -950,6 +951,137 @@ describe('server-v2 /api/v1/sessions', () => {
 
   it('returns 40401 when restoring a missing session', async () => {
     const { body } = await postJson<null>('/api/v1/sessions/sess_missing:restore');
+    expect(body.code).toBe(40401);
+  });
+
+  it('deletes a session via :delete and publishes event.session.deleted', async () => {
+    const cwd = home as string;
+    const created = await postJson<SessionWire>('/api/v1/sessions', { metadata: { cwd } });
+    const id = created.body.data.id;
+    const workspaceId = created.body.data.workspace_id;
+
+    const events: Event2<any>[] = [];
+    const sub = (server as RunningServer).core.accessor
+      .get(IEventService)
+      .subscribe((event) => events.push(event));
+    try {
+      const deleted = await postJson<{ deleted: boolean }>(`/api/v1/sessions/${id}:delete`);
+      expect(deleted.body.code).toBe(0);
+      expect(deleted.body.data).toEqual({ deleted: true });
+
+      const got = await getJson<null>(`/api/v1/sessions/${id}`);
+      expect(got.body.code).toBe(40401);
+      await expect(readFile(join(home!, 'server', 'events', `${id}.jsonl`))).rejects.toMatchObject({ code: 'ENOENT' });
+
+      expect(
+        events
+          .filter((event) => event.type === 'event.session.deleted')
+          .map((event) => (event as { readonly payload?: unknown }).payload),
+      ).toEqual([{ sessionId: id, workspaceId }]);
+    } finally {
+      sub.dispose();
+    }
+  });
+
+  it('deletes a cold session via :delete and publishes event.session.deleted', async () => {
+    const cwd = home as string;
+    const created = await postJson<SessionWire>('/api/v1/sessions', { metadata: { cwd } });
+    const id = created.body.data.id;
+    const workspaceId = created.body.data.workspace_id;
+    await closeSessionById((server as RunningServer).core.accessor, id);
+    expect(getLiveSessionById((server as RunningServer).core.accessor, id)).toBeUndefined();
+
+    const events: Event2<any>[] = [];
+    const sub = (server as RunningServer).core.accessor
+      .get(IEventService)
+      .subscribe((event) => events.push(event));
+    try {
+      const deleted = await postJson<{ deleted: boolean }>(`/api/v1/sessions/${id}:delete`);
+      expect(deleted.body.code).toBe(0);
+      expect(deleted.body.data).toEqual({ deleted: true });
+
+      expect(
+        events
+          .filter((event) => event.type === 'event.session.deleted')
+          .map((event) => (event as { readonly payload?: unknown }).payload),
+      ).toEqual([{ sessionId: id, workspaceId }]);
+    } finally {
+      sub.dispose();
+    }
+  });
+
+  it('keeps failed journal cleanup retriable without publishing deletion', async () => {
+    const created = await postJson<SessionWire>('/api/v1/sessions', { metadata: { cwd: home } });
+    const id = created.body.data.id;
+    const journalPath = join(home!, 'server', 'events', `${id}.jsonl`);
+    await vi.waitFor(async () => expect(await readFile(journalPath, 'utf8')).toContain('journal_header'));
+    await closeSessionById(server!.core.accessor, id);
+    await rm(journalPath);
+    await mkdir(journalPath);
+    const events: Event2<any>[] = [];
+    const sub = server!.core.accessor.get(IEventService).subscribe((event) => events.push(event));
+    try {
+      const failed = await postJson(`/api/v1/sessions/${id}:delete`);
+      expect(failed.body.code).not.toBe(0);
+      expect(await server!.core.accessor.get(ISessionManager).status(id)).toBeDefined();
+      expect(events.filter((event) => event.type === 'event.session.deleted')).toEqual([]);
+      await rm(journalPath, { recursive: true });
+      const retried = await postJson<{ deleted: boolean }>(`/api/v1/sessions/${id}:delete`);
+      expect(retried.body.data).toEqual({ deleted: true });
+      expect(events.filter((event) => event.type === 'event.session.deleted')).toHaveLength(1);
+      await expect(readFile(journalPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      sub.dispose();
+    }
+  });
+
+  it.each(['closing', 'cleanup'] as const)('waits for %s before recreating an explicit session id', async (phase) => {
+    const manager = server!.core.accessor.get(ISessionManager);
+    const created = await postJson<SessionWire>('/api/v1/sessions', { metadata: { cwd: home } });
+    const id = created.body.data.id;
+    const journalPath = join(home!, 'server', 'events', `${id}.jsonl`);
+    await vi.waitFor(async () => expect(await readFile(journalPath, 'utf8')).toContain('journal_header'));
+    const oldJournal = await readFile(journalPath, 'utf8');
+    let enter!: () => void;
+    let release!: () => void;
+    const entered = new Promise<void>((resolve) => { enter = resolve; });
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const event = phase === 'closing' ? manager.onWillCloseSession! : manager.onWillDeleteSession!;
+    const sub = event((event) => {
+      if (event.sessionId !== id) return;
+      event.waitUntil(gate);
+      enter();
+    });
+    try {
+      const deletion = manager.delete(id);
+      await entered;
+      let recreated = false;
+      const creation = manager.create({ sessionId: id, workDir: home! }).then((handle) => {
+        recreated = true;
+        return handle;
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(recreated).toBe(false);
+      release();
+      await deletion;
+      await creation;
+      server!.core.accessor.get(IEventService).publish(new SessionMetaUpdated({
+        payload: { sessionId: id, agentId: 'main', patch: { title: 'Recreated session' } },
+      }));
+      await vi.waitFor(async () => {
+        const journal = await readFile(journalPath, 'utf8');
+        expect(journal).toContain('journal_header');
+        expect(JSON.parse(journal.split('\n')[0]!).epoch).not.toBe(JSON.parse(oldJournal.split('\n')[0]!).epoch);
+      });
+      expect(manager.get(id)).toBeDefined();
+    } finally {
+      release();
+      sub.dispose();
+    }
+  });
+
+  it('returns 40401 when deleting a missing session', async () => {
+    const { body } = await postJson<null>('/api/v1/sessions/sess_missing:delete');
     expect(body.code).toBe(40401);
   });
 


### PR DESCRIPTION
## Related Issue

Resolves #3543. Replaces the deletion API portion of #3544; indexed-search visibility is handled independently in #3631, which can merge first.

## Problem

The core and SDK support deleting sessions, but GUI clients have no REST delete action or deletion notification. Simply exposing the core operation leaves the broadcaster's cached transcript and event journal available, and detached journal retries can delete a newly created session that reuses the same ID.

## What changed

- Add `POST /api/v1/sessions/{id}:delete`, its response/OpenAPI schemas, `event.session.deleted` fan-out, and the Kimi Inspect activity handler. Missing sessions return `40401`.
- Run journal/cache cleanup inside the manager's existing per-session lifecycle serialization after closing the old session and before deleting its persisted data. Cleanup failure rejects the request while the session remains available for retry; no deletion event is emitted on that failure. There are no detached deletion timers.
- Resolve queued creation's controller when the operation actually runs, and reject pending broadcaster state creation if its session handle has disappeared or changed. Reusing an ID cannot race with the old session's cleanup within the manager.

This PR does not add a search deletion ledger or promise synchronous removal of every derived copy. Search-index visibility is handled separately. The existing core deletion operation's later persistence failures retain their existing error behavior; retryability here specifically covers journal cleanup before core deletion.

## Validation

- kap-server and related session-manager/lifecycle suites: 1,344 passed, 1 pre-existing skip; after adding the pending-state regression and finalizing the fixtures, both affected server suites passed again (171 tests).
- A combined integration smoke test with #3631 passed: real REST deletion, a stale read-only search worker, deleted journal removal, WebSocket notification/re-subscription, and same-ID recreation.
- Kimi Inspect activity store: 7 passed.
- TypeScript checks: kap-server, agent-core-v2, and Kimi Inspect passed.
- Root lint and comment policy passed (existing warnings, no errors).
- Deterministic regressions cover cleanup failure and retry, creation queued during close or cleanup, pending state creation, live/cold deletion, deleted journal removal, event payloads, and OpenAPI.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. No CLI invocation or CLI user guide changes; the REST operation is covered by the OpenAPI projection.
