### PR TITLE
chore: initialize husky git hooks

### DIFF
--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,0 +1,18 @@
+import { existsSync } from 'node:fs';
+
+if (
+  process.env.NODE_ENV === 'production' ||
+  process.env.CI === 'true' ||
+  process.env.npm_config_production === 'true' ||
+  !existsSync('.git')
+) {
+  process.exit(0);
+}
+
+try {
+  const husky = (await import('husky')).default;
+  console.log(husky());
+} catch (error) {
+  if (error && error.code === 'ERR_MODULE_NOT_FOUND') process.exit(0);
+  throw error;
+}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+set -e
+
+node scripts/check-no-comments.mjs
+pnpm lint-staged

--- a/flake.nix
+++ b/flake.nix
@@ -160,7 +160,7 @@
               inherit (finalAttrs) pname version src pnpmWorkspaces;
               inherit pnpm;
               fetcherVersion = 3;
-              hash = "sha256-iZs9Fgk5nokW4CQRmNYL3GO+v+MdjT6M7uCqBEu32zg=";
+              hash = "sha256-rKG18o/SNptyamq3LKveIEN/1LA0myX0JK/o6+yQ5Js=";
             };
 
             nativeBuildInputs = [

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "version": "changeset version",
     "version:release": "changeset version",
     "publish": "pnpm run typecheck && pnpm run lint && pnpm run sherif && pnpm run test && pnpm run build && pnpm run lint:pkg && changeset publish",
-    "prepare": "simple-git-hooks"
+    "prepare": "node .husky/install.mjs"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",
@@ -38,19 +38,17 @@
     "@microsoft/api-extractor": "7.58.7",
     "@types/node": "^22.15.3",
     "@vitest/coverage-v8": "4.1.4",
+    "husky": "^9.1.7",
     "lint-staged": "16.4.0",
     "oxlint": "1.59.0",
     "oxlint-tsgolint": "0.20.0",
     "pkg-pr-new": "0.0.75",
     "publint": "0.3.18",
     "sherif": "1.11.1",
-    "simple-git-hooks": "2.13.1",
     "tsdown": "0.22.0",
     "tsx": "^4.21.0",
     "typescript": "6.0.2",
     "vitest": "4.1.4"
-  },
-  "simple-git-hooks": {
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.4
         version: 4.1.4(vitest@4.1.4)
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       lint-staged:
         specifier: 16.4.0
         version: 16.4.0
@@ -56,9 +59,6 @@ importers:
       sherif:
         specifier: 1.11.1
         version: 1.11.1
-      simple-git-hooks:
-        specifier: 2.13.1
-        version: 2.13.1
       tsdown:
         specifier: 0.22.0
         version: 0.22.0(@arethetypeswrong/core@0.18.2)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.34(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(vue-tsc@3.2.9(typescript@6.0.2))
@@ -6225,6 +6225,11 @@ packages:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
 
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -8263,10 +8268,6 @@ packages:
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
-  simple-git-hooks@2.13.1:
-    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
-    hasBin: true
 
   simple-invariant@2.0.1:
     resolution: {integrity: sha512-1sbhsxqI+I2tqlmjbz99GXNmZtr6tKIyEgGGnJw/MKGblalqk/XoOYYFJlBzTKZCxx8kLaD3FD5s9BEEjx5Pyg==}
@@ -15033,6 +15034,8 @@ snapshots:
 
   human-signals@8.0.1: {}
 
+  husky@9.1.7: {}
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -17535,8 +17538,6 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
     optional: true
-
-  simple-git-hooks@2.13.1: {}
 
   simple-invariant@2.0.1: {}
 

--- a/scripts/check-no-comments.mjs
+++ b/scripts/check-no-comments.mjs
@@ -77,7 +77,7 @@ function checkFile(file) {
     if (seen.has(key)) continue;
     seen.add(key);
     const line = text.slice(0, c.pos).split('\n').length;
-    const snippet = text.slice(c.pos, Math.min(c.end, c.pos + 60)).replace(/\s+/g, ' ');
+    const snippet = text.slice(c.pos, Math.min(c.end, c.pos + 60)).replaceAll(/\s+/g, ' ');
     if (/(?:oxlint|eslint)-disable/.test(snippet)) continue;
     const isDirective = /@ts-(expect-error|ignore|nocheck)|prettier-ignore|istanbul|c8 ignore/.test(
       snippet,
@@ -93,7 +93,7 @@ for (const pkg of PACKAGES) {
     const root = path.join(ROOT, pkg, dir);
     if (!fs.existsSync(root)) continue;
     const stack = [root];
-    while (stack.length) {
+    while (stack.length > 0) {
       const d = stack.pop();
       for (const e of fs.readdirSync(d, { withFileTypes: true })) {
         const p = path.join(d, e.name);


### PR DESCRIPTION
## Related Issue

No linked issue — internal contributor-tooling change; the problem is described below.

## Problem

The repository's git-hooks setup was dead code: `simple-git-hooks` had been declared with an empty hooks table since the initial commit, and the existing `lint-staged` config was never invoked by anything. Commits therefore had zero local feedback — lint regressions only surfaced in CI, long after the fact.

## What changed

Replaces the dead setup with husky 9 (the same choice made by comparable open-source agent harnesses such as pi, opencode, and gemini-cli):

- **`.husky/install.mjs` + `prepare` script** — installs hooks on `pnpm install`; skips on production installs (`NODE_ENV=production` or pnpm's `npm_config_production=true`, verified empirically on pnpm 10.33), in CI, and in checkouts without `.git` (e.g. the Nix build sandbox); also tolerates husky being absent entirely. Follows and extends husky's documented CI/Docker pattern.
- **`.husky/pre-commit`** — `scripts/check-no-comments.mjs` (main 版本 + oxlint --fix 的两处格式化修正，same full-tree scan CI runs) followed by `pnpm lint-staged` (oxlint `--fix` and `--type-aware` on staged files). Total budget stays a few seconds. Note: because the checker scans the whole tree, comment-bearing dirty files in the comment-free packages will block a commit until stashed or removed (same behavior as `pnpm lint`).

A pre-push gate running affected unit tests (`vitest related`) was explored extensively on this branch and is **intentionally deferred**: making it correct (pushed-tree testing, deletion/export-map/fixture/asset coverage, workspace dispatch) and non-flaky turned out to be a much larger surface than budgeted. The follow-up is recorded: flaky local suites (stepRetry/idle-notification), minidb + kimi-inspect CI coverage, and evaluating clean-worktree test execution before gating pushes on tests.

Manual verification:

- pre-commit passes on a clean tree; blocks a staged comment violation in a comment-free package (including the partial-staging case where the comment exists only in the index); does not block commits when an unrelated untracked file in a comment-free package contains a comment.
- `install.mjs` guards each verified: `pnpm install --prod` completes with hooks skipped; `CI=true` skips; no-`.git` skips; a fresh clone + `pnpm install` sets `core.hooksPath=.husky/_`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [ ] I have added tests that prove my feature works. — N/A: hook glue, verified manually as described above.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — No changeset: dev-only tooling, not perceivable by CLI users.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — No doc update: contributor-facing tooling, CLI behavior unchanged.