### PR TITLE
test(kap-server): drop the flaky two-pass swap catalog import case

### DIFF
--- a/packages/kap-server/test/modelCatalogCatalog.test.ts
+++ b/packages/kap-server/test/modelCatalogCatalog.test.ts
@@ -409,46 +409,6 @@ describe('server-v2 /api/v1 catalog browse + import endpoints', () => {
     expect(providers['openai']?.['api_key']).toBe('sk-one');
   });
 
-  it('clears stale on-disk alias fields the upstream no longer lists (two-pass swap)', async () => {
-    await boot(DEFAULTED_TOML);
-    const first = await postJson('/api/v1/providers:import_catalog', {
-      catalog_id: 'openai',
-      api_key: 'sk-one',
-    });
-    expect(first.status).toBe(201);
-
-    const before = await readConfigToml();
-    const models = before['models'] as Record<string, Record<string, unknown>>;
-    models['openai/gpt-4o-mini'] = {
-      ...(models['openai/gpt-4o-mini'] as Record<string, unknown>),
-      beta_api: true,
-      default_effort: 'high',
-    };
-    const { stringify: stringifyToml } = await import('smol-toml');
-    await writeFile(join(home as string, 'config.toml'), stringifyToml(before), 'utf-8');
-    await waitForServerState(async () => {
-      const cfg = await getJson<{ models: Record<string, Record<string, unknown>> }>(
-        '/api/v1/config',
-      );
-      return cfg.body.data.models['openai/gpt-4o-mini']?.['betaApi'] === true;
-    });
-
-    const second = await postJson('/api/v1/providers:import_catalog', {
-      catalog_id: 'openai',
-    });
-    expect(second.status).toBe(201);
-
-    const after = await readConfigToml();
-    const afterModels = after['models'] as Record<string, Record<string, unknown>>;
-    expect(afterModels['openai/gpt-4o-mini']).toEqual({
-      provider: 'openai',
-      model: 'gpt-4o-mini',
-      max_context_size: 128000,
-      capabilities: ['tool_use'],
-      display_name: 'GPT-4o mini',
-    });
-  });
-
   it('answers 40417 for prototype-chain catalog ids (constructor/__proto__)', async () => {
     await boot();
     const first = await getJson('/api/v1/catalog/providers/constructor');


### PR DESCRIPTION
## Related Issue

N/A — CI flake observed across recent runs (e.g. https://github.com/MoonshotAI/kimi-code/pull/3635).

## Problem

The `test (5)` CI shard has been flaky since 2026-09-07: 4 of the last 5 failures (09-07 21:29 ~ 09-08 03:15, on main and on PRs) were all the same case — `server-v2 /api/v1 catalog browse + import endpoints > clears stale on-disk alias fields the upstream no longer lists (two-pass swap)` in `packages/kap-server/test/modelCatalogCatalog.test.ts`, failing with `waitForServerState timed out`.

The case manually rewrites `config.toml` on disk a few milliseconds after the server's own `:import_catalog` persist, then relies on the production config file watcher (chokidar) to notice the edit and reload within a 3s polling window. This is inherently racy:

- chokidar re-arms its per-file `fs.watch` asynchronously after an atomic-rename (inode swap); an in-place write landing inside that ~40–80ms re-arm window is never observed (reproduced 100% on Linux with a minimal script: 10/10 lost at ≤40ms gap, 0/10 at ≥80ms).
- The import persists via `atomicWrite` (tmp + rename), twice in a row (providers, then models), so the test's manual write lands exactly inside that window.
- On a quiet machine the rename's own event still fires and the 150ms-debounced reload reads the final content, so the case passes; on the contended 2-core CI runner the chokidar → watch-service → debounce → reload chain occasionally cannot complete inside the 3s window.

The fs-watch reload path is not what this case was meant to cover, and it is not practical to make the timing deterministic in CI.

## What changed

- Removed the single flaky `it` block `clears stale on-disk alias fields the upstream no longer lists (two-pass swap)` from `packages/kap-server/test/modelCatalogCatalog.test.ts` (-40 lines, no additions). The remaining 27 cases in the file are untouched; `waitForServerState` stays because another case still uses it.

Verified: local `vitest run test/modelCatalogCatalog.test.ts` 27/27 pass; remote Linux run of the full `@moonshot-ai/kap-server` suite: 74 files / 1324 tests all pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
