### PR TITLE
fix(telemetry): stop silently dropping key event attributes

### DIFF
--- a/apps/kimi-code/src/cli/telemetry.ts
+++ b/apps/kimi-code/src/cli/telemetry.ts
@@ -2,6 +2,7 @@ import { createKimiDeviceId, KIMI_CODE_PROVIDER_NAME } from '@moonshot-ai/kimi-c
 import {
   KimiAuthFacade,
   loadRuntimeConfigSafe,
+  log,
   resolveConfigPath,
   resolveKimiHome,
   type KimiConfig,
@@ -61,6 +62,7 @@ export function initializeCliTelemetry(options: InitializeCliTelemetryOptions): 
     endpoint: () => currentKimiProfile().telemetryEndpoint,
     getAccessToken: async () =>
       (await options.harness.auth.getCachedAccessToken(KIMI_CODE_PROVIDER_NAME)) ?? null,
+    onUnexpectedError: (error) => log.warn('telemetry property dropped', { error: String(error) }),
   });
   if (options.bootstrap.firstLaunch) {
     options.harness.track('first_launch');
@@ -104,6 +106,7 @@ export function initializeServerTelemetry(
     model: config.defaultModel,
     endpoint: () => currentKimiProfile().telemetryEndpoint,
     getAccessToken: async () => (await auth.getCachedAccessToken(KIMI_CODE_PROVIDER_NAME)) ?? null,
+    onUnexpectedError: (error) => log.warn('telemetry property dropped', { error: String(error) }),
   });
 
   return {

--- a/apps/kimi-code/src/cli/v2/run-v2-print.ts
+++ b/apps/kimi-code/src/cli/v2/run-v2-print.ts
@@ -274,6 +274,7 @@ export async function runV2Print(
         endpoint: () => currentKimiProfile().telemetryEndpoint,
         getAccessToken: async () =>
           (await auth.getCachedAccessToken(KIMI_CODE_PROVIDER_NAME)) ?? null,
+        onUnexpectedError: (error) => console.error('[unexpected]', error),
       });
     }
 

--- a/apps/kimi-code/test/cli/export.test.ts
+++ b/apps/kimi-code/test/cli/export.test.ts
@@ -426,6 +426,7 @@ describe('kimi export', () => {
       sessionId: undefined,
       endpoint: expect.any(Function),
       getAccessToken: expect.any(Function),
+      onUnexpectedError: expect.any(Function),
     });
     // The endpoint resolver defers to the active region profile at flush time.
     const telemetryOptions = mocks.initializeTelemetry.mock.calls[0]![0] as {

--- a/apps/kimi-code/test/cli/run-shell.test.ts
+++ b/apps/kimi-code/test/cli/run-shell.test.ts
@@ -307,6 +307,7 @@ describe('runShell', () => {
       sessionId: undefined,
       endpoint: expect.any(Function),
       getAccessToken: expect.any(Function),
+      onUnexpectedError: expect.any(Function),
     });
     // The endpoint resolver defers to the active region profile at flush time.
     const telemetryOptions = mocks.initializeTelemetry.mock.calls[0]![0] as {

--- a/apps/kimi-code/test/cli/v2-run-print.test.ts
+++ b/apps/kimi-code/test/cli/v2-run-print.test.ts
@@ -615,6 +615,7 @@ describe('runV2Print', () => {
       model: 'k2',
       endpoint: expect.any(Function),
       getAccessToken: expect.any(Function),
+      onUnexpectedError: expect.any(Function),
     });
     // The resolved session id is synced onto the v1 client so crash events and
     // system metrics carry it; the sink model is reconciled too (same value

--- a/packages/agent-core-v2/src/agent/loop/loopService.ts
+++ b/packages/agent-core-v2/src/agent/loop/loopService.ts
@@ -1444,6 +1444,7 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
       reason: result.type,
       duration_ms: durationMs,
       mode: turn.mode ?? 'agent',
+      error_type: error?.code,
       provider_type: turn.providerType,
       protocol: turn.protocol,
       trace_id: traceId,

--- a/packages/agent-core-v2/test/agent/loop/loop.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/loop.test.ts
@@ -1340,7 +1340,47 @@ describe('turn telemetry', () => {
           turn_id: 0,
           reason: 'failed',
           mode: 'agent',
+          error_type: 'provider.filtered',
           trace_id: 'trace-turn-2',
+        }),
+      });
+    } finally {
+      await local.dispose();
+    }
+  });
+
+  it('emits turn_ended with error_type for an uncoded failure', async () => {
+    const records: TelemetryRecord[] = [];
+    const local = createTestAgent({ telemetry: recordingTelemetry(records) });
+    try {
+      const workTool: ExecutableTool = {
+        name: 'Work',
+        description: 'Pretend to work.',
+        parameters: { type: 'object', properties: {}, additionalProperties: false },
+        resolveExecution: () => ({
+          approvalRule: 'Work',
+          execute: async () => ({ output: 'should never run' }),
+        }),
+      };
+      local.get(IAgentToolRegistryService).register(workTool);
+      local.get(IAgentProfileService).update({ activeToolNames: ['Work'] });
+      const subscription = local.get(IAgentToolExecutorService).onBeforeExecuteTool(() => {
+        throw new Error('beforeExecute blew up');
+      });
+      local.mockNextResponse(
+        { type: 'text', text: 'working' },
+        { type: 'function', id: 'call-work-1', name: 'Work', arguments: '{}' },
+      );
+      await local.rpc.prompt({ input: [{ type: 'text', text: 'use the tool' }] });
+      await local.untilTurnEnd();
+      subscription.dispose();
+
+      expect(records).toContainEqual({
+        event: 'turn_ended',
+        properties: expect.objectContaining({
+          turn_id: 0,
+          reason: 'failed',
+          error_type: 'internal',
         }),
       });
     } finally {

--- a/packages/node-sdk/src/kimi-harness.ts
+++ b/packages/node-sdk/src/kimi-harness.ts
@@ -640,13 +640,12 @@ export class KimiHarness {
       ...this.sessionStartedDynamicProperties?.(),
       // Canonical fields are owned by the harness and must win over any
       // caller-supplied sessionStartedProperties that happen to share a key.
-      // `client_id` is always null here: a single-process host has no
-      // per-connection client id (that concept only exists for daemon clients,
-      // see core-impl.ts). Kept as an explicit key so this row carries the
-      // same client-attribution shape as the daemon-client producer there.
-      client_id: null,
-      client_name: this.identity?.productName ?? null,
-      client_version: this.identity?.version ?? null,
+      // A single-process host has no per-connection client id, so `client_id`
+      // stays empty; empty strings (unlike null) survive payload flattening,
+      // keeping the client-attribution keys present on every row.
+      client_id: '',
+      client_name: this.identity?.productName ?? '',
+      client_version: this.identity?.version ?? '',
       ui_mode: this.uiMode,
       resumed,
     });

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -702,7 +702,7 @@ key = "${titleOAuthRef.key}"
       ]);
 
       const outcomes = [first, second].map((result) => result.status);
-      expect(outcomes.sort()).toEqual(['fulfilled', 'rejected']);
+      expect(outcomes.toSorted()).toEqual(['fulfilled', 'rejected']);
       const rejection = [first, second].find((result) => result.status === 'rejected');
       expect((rejection as PromiseRejectedResult).reason).toMatchObject({
         code: 'session.already_exists',
@@ -1422,6 +1422,7 @@ describe('SDKRpcClientV2 engine telemetry', () => {
       expect(started[0]).toMatchObject({
         sessionId: session.id,
         properties: {
+          client_id: '',
           client_name: 'kimi-code-cli',
           client_version: '0.0.0-test',
           ui_mode: 'shell',

--- a/packages/telemetry/src/bootstrap.ts
+++ b/packages/telemetry/src/bootstrap.ts
@@ -21,6 +21,11 @@ export interface TelemetryBootstrapOptions {
   readonly locale?: string;
   readonly getAccessToken?: () => string | null | Promise<string | null>;
   /**
+   * Invoked when a tracked property is dropped for not being a primitive.
+   * Telemetry stays silent by default; hosts wire this to their logger.
+   */
+  readonly onUnexpectedError?: (error: Error) => void;
+  /**
    * Region-aware endpoint derived by the composition root (this package stays
    * dependency-free and keeps the cn default in `TELEMETRY_ENDPOINT`). A
    * resolver is invoked per flush so an in-process region switch takes effect
@@ -42,6 +47,7 @@ export function shouldEnableTelemetry(
 
 export function initializeTelemetry(options: TelemetryBootstrapOptions): void {
   const client = getDefaultTelemetryClient();
+  client.setUnexpectedErrorHandler(options.onUnexpectedError ?? null);
   if (!shouldEnableTelemetry({ enabled: options.enabled })) {
     client.disable();
     return;

--- a/packages/telemetry/src/client.ts
+++ b/packages/telemetry/src/client.ts
@@ -62,7 +62,7 @@ export class TelemetryClient {
     }
     this.sink = sink;
     for (const event of this.queue) {
-      const record = toTelemetryEvent(event);
+      const record = toTelemetryEvent(event, this.unexpectedErrorHandler);
       if (record.device_id === null && event.contextOverrides?.deviceId !== true) {
         record.device_id = this.deviceId;
       }
@@ -106,14 +106,14 @@ export class TelemetryClient {
       session_id: context.sessionId === undefined ? this.sessionId : context.sessionId,
       event,
       timestamp: Date.now() / 1000,
-      properties: sanitizeProperties(properties, this.unexpectedErrorHandler),
+      properties,
       contextOverrides: {
         deviceId: context.deviceId !== undefined,
         sessionId: context.sessionId !== undefined,
       },
     };
     if (this.sink !== null) {
-      this.sink.accept(toTelemetryEvent(record));
+      this.sink.accept(toTelemetryEvent(record, this.unexpectedErrorHandler));
       return;
     }
     this.queue.push(record);
@@ -289,14 +289,17 @@ function mergeContext(base: TelemetryContextIds, patch: TelemetryContextIds): Te
   };
 }
 
-function toTelemetryEvent(event: PendingTelemetryEvent): TelemetryEvent {
+function toTelemetryEvent(
+  event: PendingTelemetryEvent,
+  onUnexpectedError?: ((error: Error) => void) | null,
+): TelemetryEvent {
   return {
     event_id: event.event_id,
     device_id: event.device_id,
     session_id: event.session_id,
     event: event.event,
     timestamp: event.timestamp,
-    properties: event.properties,
+    properties: sanitizeProperties(event.properties, onUnexpectedError),
   };
 }
 
@@ -309,9 +312,13 @@ function sanitizeProperties(
     if (isTelemetryPrimitive(value)) {
       out[key] = value;
     } else {
-      onUnexpectedError?.(
-        new Error(`telemetry property "${key}" is not a primitive and was dropped`),
-      );
+      try {
+        onUnexpectedError?.(
+          new Error(`telemetry property "${key}" is not a primitive and was dropped`),
+        );
+      } catch (handlerError) {
+        console.error('[unexpected] telemetry error handler threw', handlerError);
+      }
     }
   }
   return out;

--- a/packages/telemetry/src/client.ts
+++ b/packages/telemetry/src/client.ts
@@ -24,6 +24,7 @@ interface PendingTelemetryEvent extends TelemetryEvent {
     readonly deviceId?: boolean;
     readonly sessionId?: boolean;
   };
+  readonly droppedPropertyKeys?: readonly string[];
 }
 
 export class TelemetryClient {
@@ -62,7 +63,8 @@ export class TelemetryClient {
     }
     this.sink = sink;
     for (const event of this.queue) {
-      const record = toTelemetryEvent(event, this.unexpectedErrorHandler);
+      reportDroppedProperties(event.droppedPropertyKeys ?? [], this.unexpectedErrorHandler);
+      const record = toTelemetryEvent(event);
       if (record.device_id === null && event.contextOverrides?.deviceId !== true) {
         record.device_id = this.deviceId;
       }
@@ -100,20 +102,23 @@ export class TelemetryClient {
     context: TelemetryContextIds,
   ): void {
     if (this.disabled) return;
+    const { properties: sanitized, droppedKeys } = sanitizeProperties(properties);
     const record: PendingTelemetryEvent = {
       event_id: randomUUID().replaceAll('-', ''),
       device_id: context.deviceId === undefined ? this.deviceId : context.deviceId,
       session_id: context.sessionId === undefined ? this.sessionId : context.sessionId,
       event,
       timestamp: Date.now() / 1000,
-      properties,
+      properties: sanitized,
+      droppedPropertyKeys: droppedKeys.length > 0 ? droppedKeys : undefined,
       contextOverrides: {
         deviceId: context.deviceId !== undefined,
         sessionId: context.sessionId !== undefined,
       },
     };
     if (this.sink !== null) {
-      this.sink.accept(toTelemetryEvent(record, this.unexpectedErrorHandler));
+      reportDroppedProperties(droppedKeys, this.unexpectedErrorHandler);
+      this.sink.accept(toTelemetryEvent(record));
       return;
     }
     this.queue.push(record);
@@ -289,37 +294,44 @@ function mergeContext(base: TelemetryContextIds, patch: TelemetryContextIds): Te
   };
 }
 
-function toTelemetryEvent(
-  event: PendingTelemetryEvent,
-  onUnexpectedError?: ((error: Error) => void) | null,
-): TelemetryEvent {
+function toTelemetryEvent(event: PendingTelemetryEvent): TelemetryEvent {
   return {
     event_id: event.event_id,
     device_id: event.device_id,
     session_id: event.session_id,
     event: event.event,
     timestamp: event.timestamp,
-    properties: sanitizeProperties(event.properties, onUnexpectedError),
+    properties: event.properties,
   };
 }
 
-function sanitizeProperties(
-  input: TelemetryProperties,
-  onUnexpectedError?: ((error: Error) => void) | null,
-): TelemetryProperties {
-  const out: TelemetryProperties = {};
-  for (const [key, value] of Object.entries(input)) {
-    if (isTelemetryPrimitive(value)) {
-      out[key] = value;
-    } else {
-      try {
-        onUnexpectedError?.(
-          new Error(`telemetry property "${key}" is not a primitive and was dropped`),
-        );
-      } catch (handlerError) {
-        console.error('[unexpected] telemetry error handler threw', handlerError);
-      }
+function reportDroppedProperties(
+  keys: readonly string[],
+  onUnexpectedError: ((error: Error) => void) | null,
+): void {
+  for (const key of keys) {
+    try {
+      onUnexpectedError?.(
+        new Error(`telemetry property "${key}" is not a primitive and was dropped`),
+      );
+    } catch (handlerError) {
+      console.error('[unexpected] telemetry error handler threw', handlerError);
     }
   }
-  return out;
+}
+
+function sanitizeProperties(input: TelemetryProperties): {
+  readonly properties: TelemetryProperties;
+  readonly droppedKeys: string[];
+} {
+  const properties: TelemetryProperties = {};
+  const droppedKeys: string[] = [];
+  for (const [key, value] of Object.entries(input)) {
+    if (isTelemetryPrimitive(value)) {
+      properties[key] = value;
+    } else {
+      droppedKeys.push(key);
+    }
+  }
+  return { properties, droppedKeys };
 }

--- a/packages/telemetry/src/client.ts
+++ b/packages/telemetry/src/client.ts
@@ -33,10 +33,15 @@ export class TelemetryClient {
   private deviceId: string | null = null;
   private sessionId: string | null = null;
   private disabled = false;
+  private unexpectedErrorHandler: ((error: Error) => void) | null = null;
 
   setContext(input: TelemetryContextIds): void {
     if (input.deviceId !== undefined) this.deviceId = input.deviceId;
     if (input.sessionId !== undefined) this.sessionId = input.sessionId;
+  }
+
+  setUnexpectedErrorHandler(handler: ((error: Error) => void) | null): void {
+    this.unexpectedErrorHandler = handler;
   }
 
   withContext(input: TelemetryContextIds): TelemetryClient {
@@ -101,7 +106,7 @@ export class TelemetryClient {
       session_id: context.sessionId === undefined ? this.sessionId : context.sessionId,
       event,
       timestamp: Date.now() / 1000,
-      properties: sanitizeProperties(properties),
+      properties: sanitizeProperties(properties, this.unexpectedErrorHandler),
       contextOverrides: {
         deviceId: context.deviceId !== undefined,
         sessionId: context.sessionId !== undefined,
@@ -162,6 +167,7 @@ export class TelemetryClient {
     this.deviceId = null;
     this.sessionId = null;
     this.disabled = false;
+    this.unexpectedErrorHandler = null;
   }
 }
 
@@ -175,6 +181,10 @@ class ScopedTelemetryClient extends TelemetryClient {
 
   override setContext(input: TelemetryContextIds): void {
     this.parent.setContext(input);
+  }
+
+  override setUnexpectedErrorHandler(handler: ((error: Error) => void) | null): void {
+    this.parent.setUnexpectedErrorHandler(handler);
   }
 
   override withContext(input: TelemetryContextIds): TelemetryClient {
@@ -226,6 +236,10 @@ const defaultClient = new TelemetryClient();
 
 export function setContext(input: TelemetryContextIds): void {
   defaultClient.setContext(input);
+}
+
+export function setUnexpectedErrorHandler(handler: ((error: Error) => void) | null): void {
+  defaultClient.setUnexpectedErrorHandler(handler);
 }
 
 export function attachSink(sink: EventSink): void {
@@ -286,11 +300,18 @@ function toTelemetryEvent(event: PendingTelemetryEvent): TelemetryEvent {
   };
 }
 
-function sanitizeProperties(input: TelemetryProperties): TelemetryProperties {
+function sanitizeProperties(
+  input: TelemetryProperties,
+  onUnexpectedError?: ((error: Error) => void) | null,
+): TelemetryProperties {
   const out: TelemetryProperties = {};
   for (const [key, value] of Object.entries(input)) {
     if (isTelemetryPrimitive(value)) {
       out[key] = value;
+    } else {
+      onUnexpectedError?.(
+        new Error(`telemetry property "${key}" is not a primitive and was dropped`),
+      );
     }
   }
   return out;

--- a/packages/telemetry/test/telemetry.test.ts
+++ b/packages/telemetry/test/telemetry.test.ts
@@ -210,6 +210,8 @@ describe('TelemetryClient', () => {
     const client = new TelemetryClient();
     const properties = { nested: { a: 1 }, keep: 1 } as unknown as TelemetryProperties;
     client.track('early_bad', properties);
+    (properties as Record<string, unknown>)['keep'] = 2;
+    (properties as Record<string, unknown>)['added'] = 'later';
 
     const onUnexpectedError = vi.fn();
     client.setUnexpectedErrorHandler(onUnexpectedError);
@@ -218,6 +220,7 @@ describe('TelemetryClient', () => {
     await client.flush();
 
     expect(onUnexpectedError).toHaveBeenCalledTimes(1);
+    expect(String(onUnexpectedError.mock.calls[0]?.[0])).toContain('"nested"');
     expect(transport.sent[0]?.[0]?.properties).toEqual({ keep: 1 });
   });
 

--- a/packages/telemetry/test/telemetry.test.ts
+++ b/packages/telemetry/test/telemetry.test.ts
@@ -206,6 +206,39 @@ describe('TelemetryClient', () => {
     expect(transport.sent[0]?.[1]?.properties).toEqual({ keep: 1 });
   });
 
+  it('reports drops for events queued before the handler is attached', async () => {
+    const client = new TelemetryClient();
+    const properties = { nested: { a: 1 }, keep: 1 } as unknown as TelemetryProperties;
+    client.track('early_bad', properties);
+
+    const onUnexpectedError = vi.fn();
+    client.setUnexpectedErrorHandler(onUnexpectedError);
+    const transport = new RecordingTransport();
+    client.attachSink(makeSink(transport));
+    await client.flush();
+
+    expect(onUnexpectedError).toHaveBeenCalledTimes(1);
+    expect(transport.sent[0]?.[0]?.properties).toEqual({ keep: 1 });
+  });
+
+  it('contains exceptions thrown by the unexpected error handler', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const client = new TelemetryClient();
+    const transport = new RecordingTransport();
+    client.attachSink(makeSink(transport));
+    client.setUnexpectedErrorHandler(() => {
+      throw new Error('handler blew up');
+    });
+
+    const properties = { nested: { a: 1 }, keep: 1 } as unknown as TelemetryProperties;
+    expect(() => client.track('bad_props', properties)).not.toThrow();
+    await client.flush();
+
+    expect(transport.sent[0]?.[0]?.properties).toEqual({ keep: 1 });
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
   it('stops the previous system metrics collector when replacing it', () => {
     const client = new TelemetryClient();
     const first = { stop: vi.fn() };

--- a/packages/telemetry/test/telemetry.test.ts
+++ b/packages/telemetry/test/telemetry.test.ts
@@ -29,7 +29,12 @@ import {
   applyServerPrefix,
   buildPayload,
 } from '../src/transport';
-import type { EnrichedTelemetryEvent, TelemetryEvent, TelemetryTransport } from '../src/types';
+import type {
+  EnrichedTelemetryEvent,
+  TelemetryEvent,
+  TelemetryProperties,
+  TelemetryTransport,
+} from '../src/types';
 
 const tempDirs: string[] = [];
 
@@ -179,6 +184,26 @@ describe('TelemetryClient', () => {
     expect(event.event).toBe('big_number');
     expect(event.properties).not.toHaveProperty('big');
     expect(event.properties['keep']).toBe(true);
+  });
+
+  it('reports dropped non-primitive properties to the unexpected error handler', async () => {
+    const client = new TelemetryClient();
+    const transport = new RecordingTransport();
+    client.attachSink(makeSink(transport));
+    const onUnexpectedError = vi.fn();
+    client.setUnexpectedErrorHandler(onUnexpectedError);
+
+    const properties = { nested: { a: 1 }, list: [1, 2], keep: 1 } as unknown as TelemetryProperties;
+    client.track('bad_props', properties);
+    client.withContext({ sessionId: 'scoped' }).track('bad_props_scoped', properties);
+    await client.flush();
+
+    expect(onUnexpectedError).toHaveBeenCalledTimes(4);
+    const first = onUnexpectedError.mock.calls[0]?.[0];
+    expect(first).toBeInstanceOf(Error);
+    expect(String(first)).toContain('"nested"');
+    expect(transport.sent[0]?.[0]?.properties).toEqual({ keep: 1 });
+    expect(transport.sent[0]?.[1]?.properties).toEqual({ keep: 1 });
   });
 
   it('stops the previous system metrics collector when replacing it', () => {
@@ -590,7 +615,7 @@ describe('AsyncTransport', () => {
 
   it('resolves a function endpoint per send, so an in-process switch needs no rebuild', async () => {
     const fetchImpl = vi.fn(async (_url: string | URL, _init?: RequestInit) =>
-      Promise.resolve(new Response('', { status: 200 })),
+      new Response('', { status: 200 }),
     );
     let endpoint = 'https://cn.test/events';
     const transport = new AsyncTransport({
@@ -925,6 +950,25 @@ describe('telemetry bootstrap', () => {
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(fetchImpl.mock.calls[0]?.[0]).toBe('https://mock.test/events');
+  });
+
+  it('wires onUnexpectedError to property sanitization on the singleton', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', fetchImpl);
+    const onUnexpectedError = vi.fn();
+
+    initializeTelemetry({
+      homeDir: await tempHome(),
+      deviceId: 'dev',
+      appName: 'kimi-code-cli',
+      version: '1.2.3',
+      onUnexpectedError,
+    });
+    track('bad_props', { nested: { a: 1 } } as unknown as TelemetryProperties);
+    await shutdownTelemetry();
+
+    expect(onUnexpectedError).toHaveBeenCalledTimes(1);
+    expect(String(onUnexpectedError.mock.calls[0]?.[0])).toContain('"nested"');
   });
 
   it('reconciles the singleton sink model for subsequently tracked events', async () => {
@@ -1331,7 +1375,7 @@ function numberProperty(
 ): number {
   const value = properties[key];
   if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new Error(`Expected property ${key} to be a finite number, got ${String(value)}`);
+    throw new TypeError(`Expected property ${key} to be a finite number, got ${String(value)}`);
   }
   return value;
 }


### PR DESCRIPTION
## Related Issue

No linked issue — internal PR. Gaps found in a telemetry pipeline audit; see Problem.

## Problem

Several key telemetry attributes never reach the server:

1. **Failed turns carry no error classification.** The v2 event catalog defines `turn_ended.error_type` ("Classified error category when reason is failed"), but the sole emitter never sets it — a failed turn only reports `reason: 'failed'`, so error attribution is impossible.
2. **Non-primitive properties vanish silently.** `sanitizeProperties` drops objects/arrays/NaN with no signal anywhere, so a caller passing a bad property is invisible forever. (The v2 `CloudAppender` already reports such drops via `onUnexpectedError`; the v1 client did not.)
3. **`session_started` client-attribution keys never arrive.** They are emitted as `null` placeholders to keep a "stable schema", but payload flattening drops all null values — the stated intent and the pipeline behavior contradict each other.

## What changed

- `turn_ended` now carries `error_type` (the engine error code, e.g. `provider.filtered`, `internal`) when a turn fails (agent-core-v2).
- `TelemetryClient` gains an `onUnexpectedError` hook invoked for every property dropped by sanitize, aligned with the v2 `CloudAppender` behavior; wired to the CLI, web, and v2-print logs via `initializeTelemetry` (telemetry, apps/kimi-code).
- `session_started` client attribution keys emit empty strings instead of `null`, so the keys survive flattening (node-sdk).

Tests: new cases for failed-turn `error_type` (v2 loop), sanitize drop reporting (client + bootstrap wiring), and `client_id: ''` in the harness `session_started` row; exact-match telemetry option assertions updated. Full suites pass in telemetry / node-sdk / apps-kimi-code; agent-core-v2 shows 11 pre-existing failures in `test/app/plugin/*` because this machine lacks the `zip` binary (unrelated to this change).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`). — internal PR, no issue
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — no changeset: changes are not user-perceivable
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — telemetry internals only