### PR TITLE
feat(cli): give the /btw panel a dedicated input editor

### DIFF
--- a/.changeset/btw-panel-input.md
+++ b/.changeset/btw-panel-input.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Give the /btw panel its own input box: the panel now mounts a dedicated editor (image paste included) instead of sharing the main input, so typing there never touches the main prompt's queue, steer, or bash mode.

--- a/apps/kimi-code/src/tui/components/editor/custom-editor.ts
+++ b/apps/kimi-code/src/tui/components/editor/custom-editor.ts
@@ -116,6 +116,11 @@ function stripSgr(s: string): string {
 
 interface CustomEditorOptions {
   disablePasteBurst?: boolean;
+  /**
+   * Opt out of the `!` shell-command mode (e.g. the /btw side-panel editor,
+   * where `!` is ordinary text and there is no shell dispatch behind it).
+   */
+  disableBashMode?: boolean;
 }
 
 export class CustomEditor extends Editor {
@@ -163,6 +168,7 @@ export class CustomEditor extends Editor {
 
   private consumingPaste = false;
   private consumeBuffer = '';
+  private readonly bashModeEnabled: boolean;
   /** Serialize paste callbacks so Enter/typing cannot overtake an image paste. */
   private pasteInFlight = false;
   private readonly pasteInputQueue: string[] = [];
@@ -189,6 +195,7 @@ export class CustomEditor extends Editor {
       disablePasteBurst: options.disablePasteBurst,
       inlineSlashTrigger: true,
     });
+    this.bashModeEnabled = options.disableBashMode !== true;
 
     // pi-tui keeps `createAutocompleteList` private; shadow it with an
     // instance property so slash command menus render descriptions wrapped
@@ -538,6 +545,7 @@ export class CustomEditor extends Editor {
     // not inserted into the buffer — it becomes the mode + prompt symbol, so the
     // cursor never has to skip over it and submit never has to strip it.
     if (
+      this.bashModeEnabled &&
       this.inputMode === 'prompt' &&
       printableChar(normalized) === '!' &&
       this.getText().length === 0
@@ -554,7 +562,12 @@ export class CustomEditor extends Editor {
     // above handles the single `!` keystroke; this catches bracketed / Ctrl-V
     // pastes whose content starts with `!`. Strip the leading `!` so the buffer
     // holds only the command, exactly like the typed path.
-    if (emptyPromptBeforeInput && this.inputMode === 'prompt' && this.getText().startsWith('!')) {
+    if (
+      this.bashModeEnabled &&
+      emptyPromptBeforeInput &&
+      this.inputMode === 'prompt' &&
+      this.getText().startsWith('!')
+    ) {
       this.inputMode = 'bash';
       this.onInputModeChange?.('bash');
       this.setText(this.getText().slice(1));

--- a/apps/kimi-code/src/tui/controllers/btw-panel.ts
+++ b/apps/kimi-code/src/tui/controllers/btw-panel.ts
@@ -9,8 +9,11 @@ import type {
 
 import { NO_ACTIVE_SESSION_MESSAGE } from '../constant/kimi-tui';
 import { BtwPanelComponent } from '../components/panes/btw-panel';
+import { CustomEditor } from '../components/editor/custom-editor';
+import { DEFAULT_TUI_CONFIG } from '../config';
 import { formatErrorMessage } from '../utils/event-payload';
 import { formatHookResultPlain } from '../utils/hook-result-format';
+import { extractInlineSkillActivations } from '../utils/inline-skill-tokens';
 import { createMarkdownTheme } from '../theme/pi-tui-theme';
 import type { InlineSkillActivation } from '../types';
 import type { TUIState } from '../tui-state';
@@ -31,6 +34,7 @@ export interface BtwPanelHost {
   state: TUIState;
   session: Session | undefined;
   readonly harness: KimiHarness;
+  readonly skillCommandMap: ReadonlyMap<string, string>;
 
   showError(msg: string): void;
   /**
@@ -49,6 +53,11 @@ export interface BtwPanelHost {
     request: Promise<unknown>,
     onError: (error: unknown) => void,
   ): void;
+  /**
+   * Paste the clipboard's image/video into the panel's dedicated editor as an
+   * imageStore placeholder (the same ingestion path the main editor uses).
+   */
+  pasteImageIntoEditor(editor: CustomEditor): Promise<boolean>;
 }
 
 export class BtwPanelController {
@@ -56,6 +65,7 @@ export class BtwPanelController {
     | {
         readonly agentId: string;
         readonly panel: BtwPanelComponent;
+        readonly editor: CustomEditor;
       }
     | undefined;
   private readonly panelsByAgentId = new Map<string, BtwPanelComponent>();
@@ -67,18 +77,28 @@ export class BtwPanelController {
     initialPrompt: string,
     inlineSkillActivations?: readonly InlineSkillActivation[],
   ): void {
-    let panel: BtwPanelComponent;
-    panel = new BtwPanelComponent({
+    // The panel owns a dedicated editor instance — the same CustomEditor
+    // component class as the main input, but trimmed to plain prompts plus
+    // file/image paste: no queue, no steer, no bash mode, no slash-command
+    // autocomplete, no history. Esc/↑↓/Ctrl+C keep the panel semantics.
+    const editor = new CustomEditor(this.host.state.ui, {
+      disablePasteBurst:
+        this.host.state.appState.disablePasteBurst ?? DEFAULT_TUI_CONFIG.disablePasteBurst,
+      disableBashMode: true,
+    });
+    const panel = new BtwPanelComponent({
       markdownTheme: createMarkdownTheme(),
-      canUseScrollKeys: () => this.host.state.editor.getText().length === 0,
+      canUseScrollKeys: () =>
+        this.host.state.editor.getText().length === 0 && editor.getText().length === 0,
       terminalRows: () => this.host.state.terminal.rows,
       onPrompt: (prompt, inlineSkillActivations) => {
         this.promptAgent(agentId, prompt, panel, inlineSkillActivations);
       },
     });
-    this.active = { agentId, panel };
+    this.wireEditor(panel, editor);
+    this.active = { agentId, panel, editor };
     this.panelsByAgentId.set(agentId, panel);
-    this.mount(panel);
+    this.mount(panel, editor);
     panel.submit(initialPrompt, inlineSkillActivations);
   }
 
@@ -94,7 +114,11 @@ export class BtwPanelController {
     this.active = undefined;
     this.panelsByAgentId.clear();
     this.host.state.btwPanelContainer.clear();
-    this.host.state.editor.connectedAbove = false;
+    // The panel's editor is gone with the container; never leave focus on a
+    // detached component.
+    if (active !== undefined && active.editor.focused) {
+      this.host.state.ui.setFocus(this.host.state.editor);
+    }
   }
 
   closeOrCancel(): boolean {
@@ -112,19 +136,6 @@ export class BtwPanelController {
     const active = this.active;
     if (active === undefined || !active.panel.isRunning()) return false;
     void this.cancelAgent(active.agentId);
-    return true;
-  }
-
-  sendUserInput(text: string, inlineSkillActivations?: readonly InlineSkillActivation[]): boolean {
-    const active = this.active;
-    if (active === undefined) return false;
-    if (active.panel.isRunning()) {
-      this.showBusyNotice(active, text);
-      return true;
-    }
-    active.panel.submit(text, inlineSkillActivations);
-    this.host.state.ui.setFocus(this.host.state.editor);
-    this.host.state.ui.requestRender();
     return true;
   }
 
@@ -165,12 +176,50 @@ export class BtwPanelController {
     }
   }
 
-  private mount(panel: BtwPanelComponent): void {
+  /**
+   * Wire the panel's dedicated editor. Only the panel-relevant bindings are
+   * set: submit routes straight to the side agent (never through the main
+   * send path's queue/steer interception), Esc closes, ↑↓ scroll the panel,
+   * Ctrl+C cancels/closes, and image paste lands as imageStore placeholders.
+   */
+  private wireEditor(panel: BtwPanelComponent, editor: CustomEditor): void {
+    editor.onSubmit = (text) => {
+      if (text.trim().length === 0) return;
+      if (panel.isRunning()) {
+        // One side question at a time: restore the submitted draft and point
+        // at the in-flight turn instead of dropping the input.
+        editor.setText(text);
+        panel.addTransientNotice(BTW_BUSY_NOTICE);
+        this.host.state.ui.requestRender();
+        return;
+      }
+      const activations = extractInlineSkillActivations(text, this.host.skillCommandMap);
+      panel.submit(text, activations.length > 0 ? activations : undefined);
+      this.host.state.ui.requestRender();
+    };
+    editor.onEscape = () => {
+      this.closeOrCancel();
+    };
+    editor.onCtrlC = () => {
+      if (!this.cancelRunning()) {
+        this.closeOrCancel();
+      }
+    };
+    editor.onUpArrowEmpty = () => this.scroll('up');
+    editor.onDownArrowEmpty = () => this.scroll('down');
+    editor.onPasteImage = () => this.host.pasteImageIntoEditor(editor);
+  }
+
+  private mount(panel: BtwPanelComponent, editor: CustomEditor): void {
     this.host.state.btwPanelContainer.clear();
     this.host.state.btwPanelContainer.addChild(new Spacer(1));
     this.host.state.btwPanelContainer.addChild(panel);
-    this.host.state.editor.connectedAbove = true;
-    this.host.state.ui.setFocus(this.host.state.editor);
+    // The panel renders an open bottom edge; the editor's connected top
+    // border stitches the two into one box, exactly like the main editor
+    // used to when it doubled as the panel's input.
+    editor.connectedAbove = true;
+    this.host.state.btwPanelContainer.addChild(editor);
+    this.host.state.ui.setFocus(editor);
     this.host.state.ui.requestRender();
   }
 
@@ -178,7 +227,6 @@ export class BtwPanelController {
     if (!this.host.state.btwPanelContainer.children.includes(panel)) return;
     this.unregister(panel);
     this.host.state.btwPanelContainer.clear();
-    this.host.state.editor.connectedAbove = false;
     this.host.state.ui.setFocus(this.host.state.editor);
     this.host.state.ui.requestRender(true);
   }
@@ -190,15 +238,6 @@ export class BtwPanelController {
       }
     }
     if (this.active?.panel === panel) this.active = undefined;
-  }
-
-  private showBusyNotice(
-    active: { readonly panel: BtwPanelComponent },
-    input: string,
-  ): void {
-    this.host.state.editor.setText(input);
-    active.panel.addTransientNotice(BTW_BUSY_NOTICE);
-    this.host.state.ui.requestRender();
   }
 
   private promptAgent(

--- a/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
+++ b/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
@@ -20,6 +20,7 @@ import {
 } from '../constant/kimi-tui';
 import { Key, matchesKey } from '@moonshot-ai/pi-tui';
 import { MEDIA_STAGING_TTL_SECONDS } from '../constant/media';
+import type { CustomEditor } from '../components/editor/custom-editor';
 import { formatErrorMessage } from '../utils/event-payload';
 import type {
   ImageAttachment,
@@ -472,7 +473,7 @@ export class EditorKeyboardController {
 
     editor.onDownArrowEmpty = () => host.btwPanelController.scroll('down');
 
-    editor.onPasteImage = async () => this.handleClipboardImagePaste();
+    editor.onPasteImage = async () => this.pasteClipboardImage(editor);
   }
 
   clearPendingExit(): void {
@@ -541,7 +542,13 @@ export class EditorKeyboardController {
     });
   }
 
-  private async handleClipboardImagePaste(): Promise<boolean> {
+  /**
+   * Paste the clipboard's image/video into `target` as an imageStore
+   * placeholder; background ingestion (compression, daemon upload) continues
+   * off the keystroke path. Shared by the main editor and the /btw panel's
+   * dedicated editor.
+   */
+  async pasteClipboardImage(target: CustomEditor): Promise<boolean> {
     let media;
     try {
       media = await readClipboardMedia();
@@ -563,7 +570,7 @@ export class EditorKeyboardController {
       // whose upload has not landed (or failed) refuses the submission at
       // extraction time.
       const attachment = this.imageStore.addVideo(media.mimeType, media.sourcePath, media.filename);
-      this.host.state.editor.insertTextAtCursor?.(`${attachment.placeholder} `);
+      target.insertTextAtCursor?.(`${attachment.placeholder} `);
       this.host.state.ui.requestRender();
       this.host.track('shortcut_paste', { kind: 'video' });
       attachment.pending = this.finishClipboardVideoPaste(attachment, media).catch(
@@ -590,7 +597,7 @@ export class EditorKeyboardController {
       meta.width,
       meta.height,
     );
-    this.host.state.editor.insertTextAtCursor?.(`${attachment.placeholder} `);
+    target.insertTextAtCursor?.(`${attachment.placeholder} `);
     this.host.state.ui.requestRender();
     this.host.track('shortcut_paste', { kind: 'image' });
 

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -83,6 +83,7 @@ import {
   FileMentionProvider,
   type SlashAutocompleteCommand,
 } from './components/editor/file-mention-provider';
+import type { CustomEditor } from './components/editor/custom-editor';
 import { AssistantMessageComponent } from './components/messages/assistant-message';
 import { BackgroundAgentStatusComponent } from './components/messages/background-agent-status';
 import { CronMessageComponent } from './components/messages/cron-message';
@@ -1328,7 +1329,6 @@ export class KimiTUI {
   }
 
   async sendNormalUserInput(text: string, preExtracted?: ExtractionResult): Promise<void> {
-    if (this.btwPanelController.sendUserInput(text)) return;
     if (this.state.appState.model.trim().length === 0) {
       this.showError(LLM_NOT_SET_MESSAGE);
       return;
@@ -1426,7 +1426,6 @@ export class KimiTUI {
     activations: readonly InlineSkillActivation[],
     preExtracted?: ExtractionResult,
   ): Promise<void> {
-    if (this.btwPanelController.sendUserInput(text, activations)) return;
     if (this.state.appState.model.trim().length === 0) {
       this.showError(LLM_NOT_SET_MESSAGE);
       return;
@@ -1579,6 +1578,15 @@ export class KimiTUI {
     onError: (error: unknown) => void,
   ): void {
     this.staging.trackDispatch(lease, request, onError);
+  }
+
+  /**
+   * Clipboard image/video paste for the /btw panel's dedicated editor —
+   * delegates to the shared paste path so placeholders, ingestion, and the
+   * imageStore are identical to the main editor's.
+   */
+  pasteImageIntoEditor(editor: CustomEditor): Promise<boolean> {
+    return this.editorKeyboard.pasteClipboardImage(editor);
   }
 
   validateMediaCapabilities(extraction: {

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -36,6 +36,7 @@ import {
   TRANSCRIPT_KEEP_RECENT_STEPS,
 } from '#/tui/utils/transcript-window';
 import { BtwPanelComponent } from '#/tui/components/panes/btw-panel';
+import { CustomEditor } from '#/tui/components/editor/custom-editor';
 import { ThinkingComponent } from '#/tui/components/messages/thinking';
 import { WelcomeComponent } from '#/tui/components/chrome/welcome';
 import { ModelSelectorComponent } from '#/tui/components/dialogs/model-selector';
@@ -424,6 +425,14 @@ function getMountedBtwPanel(driver: MessageDriver): BtwPanelComponent {
   return panel;
 }
 
+function getBtwEditor(driver: MessageDriver): CustomEditor {
+  const editor = driver.state.btwPanelContainer.children.find(
+    (child) => child instanceof CustomEditor,
+  );
+  if (editor === undefined) throw new Error('Expected a mounted /btw editor.');
+  return editor;
+}
+
 async function openBtwPanel(
   driver: MessageDriver,
   session: ReturnType<typeof makeSession>,
@@ -432,7 +441,7 @@ async function openBtwPanel(
   driver.handleUserInput(`/btw ${prompt}`);
   await vi.waitFor(() => {
     expect(session.startBtw).toHaveBeenCalled();
-    expect(driver.state.btwPanelContainer.children).toHaveLength(2);
+    expect(driver.state.btwPanelContainer.children).toHaveLength(3);
   });
 }
 
@@ -4699,7 +4708,7 @@ command = "vim"
     expect(session.prompt).not.toHaveBeenCalled();
     expect(stripSgr(renderBtwPanel(driver))).toContain('Ready for a side question…');
 
-    driver.handleUserInput('What are you working on right now?');
+    getBtwEditor(driver).onSubmit?.('What are you working on right now?');
 
     await vi.waitFor(() => {
       expect(session.prompt).toHaveBeenCalledWith('What are you working on right now?');
@@ -4740,12 +4749,12 @@ command = "vim"
     driver.handleUserInput('/btw');
     await vi.waitFor(() => {
       expect(session.startBtw).toHaveBeenCalled();
-      expect(driver.state.btwPanelContainer.children).toHaveLength(2);
+      expect(driver.state.btwPanelContainer.children).toHaveLength(3);
     });
     const imageStore = (driver as unknown as { imageStore: ImageAttachmentStore }).imageStore;
     const attachment = stagedImage(imageStore, 'file-btw-2');
 
-    driver.handleUserInput(`look at ${attachment.placeholder}`);
+    getBtwEditor(driver).onSubmit?.(`look at ${attachment.placeholder}`);
 
     await vi.waitFor(() => {
       expect(session.prompt).toHaveBeenCalledWith(
@@ -4789,7 +4798,7 @@ command = "vim"
     });
     expect(stripSgr(renderBtwPanel(driver))).toContain('Ready for a side question…');
 
-    driver.handleUserInput('check /skill:review');
+    getBtwEditor(driver).onSubmit?.('check /skill:review');
 
     await vi.waitFor(() => {
       expect(session.promptWithSkills).toHaveBeenCalledWith('check /skill:review', [
@@ -4951,18 +4960,24 @@ command = "vim"
       () => {},
     );
 
-    expect(driver.state.btwPanelContainer.children).toHaveLength(2);
+    expect(driver.state.btwPanelContainer.children).toHaveLength(3);
     expect(driver.state.btwPanelContainer.render(120)[0]?.trim()).toBe('');
     expect(getMountedBtwPanel(driver).isRunning()).toBe(false);
-    expect(driver.state.editor.focused).toBe(true);
+    expect(getBtwEditor(driver).focused).toBe(true);
+    expect(driver.state.editor.focused).toBe(false);
 
     const transcript = stripSgr(renderTranscript(driver));
     const panel = stripSgr(renderBtwPanel(driver));
+    const btwEditorTopBorder = stripSgr(getBtwEditor(driver).render(80)[0] ?? '');
     const editorTopBorder = stripSgr(driver.state.editor.render(80)[0] ?? '');
     expect(panel).toContain('BTW ─ Esc close');
     expect(panel).not.toContain('ctrl+o expand');
-    expect(editorTopBorder.startsWith('├')).toBe(true);
-    expect(editorTopBorder.endsWith('┤')).toBe(true);
+    // The panel stitches onto its own dedicated editor; the main editor keeps
+    // its plain rounded top border.
+    expect(btwEditorTopBorder.startsWith('├')).toBe(true);
+    expect(btwEditorTopBorder.endsWith('┤')).toBe(true);
+    expect(editorTopBorder.startsWith('╭')).toBe(true);
+    expect(editorTopBorder.endsWith('╮')).toBe(true);
 
     driver.state.editor.handleInput('/');
     const highlightedEditorTopBorder = stripSgr(driver.state.editor.render(80)[0] ?? '');
@@ -5200,12 +5215,14 @@ command = "vim"
     await openBtwPanel(driver, session);
 
     const panel = getMountedBtwPanel(driver);
+    const btwEditor = getBtwEditor(driver);
     expect(panel.isRunning()).toBe(true);
-    expect(driver.state.editor.focused).toBe(true);
+    expect(btwEditor.focused).toBe(true);
+    expect(driver.state.editor.focused).toBe(false);
 
     const requestRender = vi.mocked(driver.state.ui.requestRender);
     requestRender.mockClear();
-    driver.state.editor.onEscape?.();
+    btwEditor.onEscape?.();
 
     expect(session.cancel).toHaveBeenCalledOnce();
     expect(driver.state.btwPanelContainer.children).toHaveLength(0);
@@ -5230,13 +5247,13 @@ command = "vim"
     const panel = getMountedBtwPanel(driver);
     expect(panel.isRunning()).toBe(true);
 
-    driver.state.editor.onCtrlC?.();
+    getBtwEditor(driver).onCtrlC?.();
 
     expect(session.cancel).toHaveBeenCalledOnce();
     expect(cancelledAgentIds).toEqual(['agent-btw']);
     expect(getMountedBtwPanel(driver)).toBe(panel);
-    expect(driver.state.btwPanelContainer.children).toHaveLength(2);
-    expect(driver.state.editor.focused).toBe(true);
+    expect(driver.state.btwPanelContainer.children).toHaveLength(3);
+    expect(getBtwEditor(driver).focused).toBe(true);
     expect(driver.state.editor.getText()).toBe('draft main input');
     expect(driver.state.appState.streamingPhase).toBe('waiting');
   });
@@ -5342,7 +5359,7 @@ command = "vim"
 
     const panel = getMountedBtwPanel(driver);
     expect(panel.isRunning()).toBe(false);
-    expect(driver.state.editor.focused).toBe(true);
+    expect(getBtwEditor(driver).focused).toBe(true);
 
     driver.state.editor.onEscape?.();
 
@@ -5369,17 +5386,17 @@ command = "vim"
 
     const panel = getMountedBtwPanel(driver);
     expect(panel.isRunning()).toBe(false);
-    driver.handleUserInput('follow up');
+    getBtwEditor(driver).onSubmit?.('follow up');
 
     await vi.waitFor(() => {
       expect(session.prompt).toHaveBeenCalledWith('follow up');
     });
     expect(session.prompt).toHaveBeenCalledTimes(2);
-    expect(driver.state.btwPanelContainer.children).toHaveLength(2);
-    expect(driver.state.editor.focused).toBe(true);
+    expect(driver.state.btwPanelContainer.children).toHaveLength(3);
+    expect(getBtwEditor(driver).focused).toBe(true);
   });
 
-  it('keeps main input pointed at /btw while the panel is open', async () => {
+  it('keeps /btw panel input pointed at the side agent while the panel is open', async () => {
     let resolveBtwPrompt: (() => void) | undefined;
     const session = makeSession({
       prompt: vi.fn(
@@ -5394,12 +5411,14 @@ command = "vim"
     await openBtwPanel(driver, session, 'slow side question');
 
     expect(harness.interactiveAgentId).toBe('main');
-    driver.handleUserInput('follow-up while btw prompt is pending');
-    driver.handleUserInput('another follow-up while btw prompt is pending');
+    const btwEditor = getBtwEditor(driver);
+    btwEditor.onSubmit?.('follow-up while btw prompt is pending');
+    btwEditor.onSubmit?.('another follow-up while btw prompt is pending');
 
     expect(session.prompt).toHaveBeenCalledTimes(1);
+    expect(session.steer).not.toHaveBeenCalled();
     expect(driver.state.queuedMessages).toEqual([]);
-    expect(driver.state.editor.getText()).toBe('another follow-up while btw prompt is pending');
+    expect(btwEditor.getText()).toBe('another follow-up while btw prompt is pending');
     expect(stripSgr(renderTranscript(driver))).not.toContain(
       'Wait for /btw to finish before sending another question.',
     );
@@ -5478,6 +5497,93 @@ command = "vim"
     const renderedPanel = stripSgr(renderBtwPanel(driver));
     expect(renderedPanel).not.toContain('answer from old side agent');
     expect(renderedPanel).toContain('answer from new side agent');
+  });
+
+  it('trims the /btw editor to plain prompts: no bash mode, no steer, no queue', async () => {
+    const session = makeSession();
+    const { driver } = await makeDriver(session);
+    await openBtwPanel(driver, session);
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.ended',
+        agentId: 'agent-btw',
+        sessionId: 'ses-1',
+        turnId: 0,
+        reason: 'completed',
+      } as Event,
+      () => {},
+    );
+
+    const btwEditor = getBtwEditor(driver);
+    expect(btwEditor).not.toBe(driver.state.editor);
+
+    // No bash mode: a leading `!` stays literal text.
+    btwEditor.handleInput('!');
+    expect(btwEditor.inputMode).toBe('prompt');
+    expect(btwEditor.getText()).toBe('!');
+
+    // No steer: Ctrl+S is swallowed without touching the session or the queue.
+    btwEditor.handleInput('\x13');
+    expect(session.steer).not.toHaveBeenCalled();
+    expect(driver.state.queuedMessages).toEqual([]);
+    expect(btwEditor.getText()).toBe('!');
+
+    // Enter submits straight to the side agent; the main editor and its send
+    // path (queue included) stay out of it.
+    btwEditor.handleInput('\r');
+    await vi.waitFor(() => {
+      expect(session.prompt).toHaveBeenCalledWith('!');
+    });
+    expect(driver.state.queuedMessages).toEqual([]);
+    expect(driver.state.editor.getText()).toBe('');
+  });
+
+  it('closes the /btw panel on a real Escape keypress and refocuses the main editor', async () => {
+    const session = makeSession();
+    const { driver } = await makeDriver(session);
+    await openBtwPanel(driver, session);
+
+    const btwEditor = getBtwEditor(driver);
+    expect(btwEditor.focused).toBe(true);
+    expect(driver.state.editor.focused).toBe(false);
+
+    btwEditor.handleInput('\u001B');
+
+    expect(session.cancel).toHaveBeenCalledOnce();
+    expect(driver.state.btwPanelContainer.children).toHaveLength(0);
+    expect(driver.state.editor.focused).toBe(true);
+  });
+
+  it('scrolls the /btw panel with arrow keys from its own editor', async () => {
+    const session = makeSession();
+    const { driver } = await makeDriver(session);
+    setTerminalRows(driver, 15);
+    await openBtwPanel(driver, session, 'question 1');
+
+    const panel = getMountedBtwPanel(driver);
+    panel.appendAnswer('answer 1');
+    panel.markDone();
+    for (let i = 2; i <= 8; i++) {
+      panel.submit(`question ${String(i)}`);
+      panel.appendAnswer(`answer ${String(i)}`);
+      panel.markDone();
+    }
+    expect(panel.render(80).map(stripSgr).join('\n')).not.toContain('question 1');
+
+    const btwEditor = getBtwEditor(driver);
+    for (let i = 0; i < 20; i++) {
+      btwEditor.handleInput('\u001B[A');
+    }
+    const scrolledUp = panel.render(80).map(stripSgr);
+    expect(scrolledUp.join('\n')).toContain('question 1');
+    expect(scrolledUp.join('\n')).not.toContain('answer 8');
+
+    for (let i = 0; i < 20; i++) {
+      btwEditor.handleInput('\u001B[B');
+    }
+    const scrolledDown = panel.render(80).map(stripSgr);
+    expect(scrolledDown.join('\n')).toContain('question 8');
+    expect(scrolledDown.join('\n')).toContain('answer 8');
   });
 
   it('does not run /btw without a selected model', async () => {


### PR DESCRIPTION
## Related Issue

Stacks on #3619 (which stacks on #3613). This PR is the follow-up that gives the /btw panel its own input box; base is set to `feat/btw-image-support` because the media path added there (`prepareBtwPrompt` / `trackBtwDispatch`, plus the daemon-side `ReadMediaFile` whitelist) is exactly what the dedicated editor reuses for pasted images.

## Problem

The /btw panel had no input of its own: it visually borrowed the main editor (`connectedAbove` stitching) and intercepted the main send path (`sendUserInput`) to reroute keystrokes to the side agent. That coupling meant the panel inherited every main-input semantic (queue, steer, bash mode, …) through a fragile interception layer, and pasted images only worked because the shared editor happened to write into the same buffer.

## What changed

**Design decisions**

- **Stacking**: branched from `feat/btw-image-support` (#3619) and based this PR on it. The dedicated editor's image support is a thin reuse of #3619's `prepareBtwPrompt` (placeholder → imageStore → daemon file-ref parts at submit); going self-contained would mean duplicating that media chain.
- **Layout**: kept the existing visual structure with the smallest UX delta. The panel stays where it is; the new editor mounts inside `btwPanelContainer` directly under the panel with `connectedAbove = true`, so the panel stitches onto *its own* editor exactly the way it used to stitch onto the main one. The main editor simply reverts to its plain rounded top border — input and visuals are now fully decoupled.
- **Capability trim**: the panel's editor is the same `CustomEditor` class as the main input, but wired with only what a side panel needs:
  - **Kept**: plain text submit, clipboard image/video paste (same `imageStore` placeholder → ingestion → `prepareBtwPrompt` expansion path as the main editor), inline-skill token extraction on submit (existing follow-up behavior), Esc close, ↑↓ panel scroll, Ctrl+C cancel/close.
  - **Dropped**: no QueuePane/queueing, no Ctrl+S steer, no bash mode (new `disableBashMode` option on `CustomEditor` — a leading `!` stays literal text), no slash-command/@-mention autocomplete provider, no Ctrl+B/T/P/N bindings, no input history. Placeholder hint stays in the panel body ("Ready for a side question…") and the border hint ("Esc close · ↑↓ scroll") rather than inventing an editor placeholder concept.
- **Focus**: opening the panel focuses its editor; Esc/close (including `clear()` on session reset) returns focus to the main editor.

**By file**

- `components/editor/custom-editor.ts` — new `disableBashMode` option guarding both `!`-mode entry paths (typed and pasted).
- `controllers/btw-panel.ts` — `open()` now constructs and wires a dedicated `CustomEditor`; `sendUserInput` interception is deleted, replaced by the editor's own `onSubmit` (busy → restore draft + transient notice; idle → `panel.submit` with inline-skill extraction); mount/close/clear manage the editor and focus.
- `controllers/editor-keyboard.ts` — `handleClipboardImagePaste` became public `pasteClipboardImage(target)` so both editors share one paste/ingestion path and one `imageStore`.
- `kimi-tui.ts` — removed the two `btwPanelController.sendUserInput` interception calls from `sendNormalUserInput` / `sendInlineSkillUserInput`; added `pasteImageIntoEditor` (BtwPanelHost) delegating to the shared paste path.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
