### PR TITLE
fix(acp): correct misleading compaction-blocked message wording

### DIFF
--- a/.changeset/fix-compaction-blocked-wording.md
+++ b/.changeset/fix-compaction-blocked-wording.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix misleading "compaction is blocked" message during automatic context compaction — the turn is waiting for compaction to finish and continues automatically; the old wording incorrectly told users to retry.

--- a/packages/acp-server/src/session.ts
+++ b/packages/acp-server/src/session.ts
@@ -324,7 +324,7 @@ export class AcpSession {
       }),
       events.on('compaction.blocked', () => {
         this.emitLocalChunk(
-          'Compaction is blocked by the current turn; retry when the turn is idle.',
+          'Waiting for context compaction to finish; the turn will continue automatically.',
         );
       }),
     );


### PR DESCRIPTION
## Related Issue

Resolve #3629

## Problem

During a successful automatic compaction, the ACP client receives "Compaction is blocked by the current turn; retry when the turn is idle." as an `agent_message_chunk`. This is misleading because:

1. The `compaction.blocked` event fires when the **turn** is waiting for an active compaction to finish — not when compaction is blocked by the turn. The causality is reversed in the message.
2. The turn continues automatically after compaction completes — no user action or retry is needed.
3. The misleading text is retained as assistant text by clients that persist `agent_message_chunk`.

The engine's own test ([`blocks the turn until auto compaction finishes`](https://github.com/MoonshotAI/kimi-code/blob/main/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts#L1662-L1704)) already demonstrates the correct lifecycle: `compaction.blocked` → `full_compaction.complete` → `turn.step.started` → `turn.ended`.

## What changed

One string change in `packages/acp-server/src/session.ts`: the `compaction.blocked` handler now emits "Waiting for context compaction to finish; the turn will continue automatically." instead of the reversed/misleading retry instruction.

This accurately describes the actual state: the turn is paused while compaction runs and will resume on its own.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.