### PR TITLE
fix(agent-core-v2): fall back to the configured default model for image format gating

### DIFF
--- a/.changeset/kimi-default-model-image-gate.md
+++ b/.changeset/kimi-default-model-image-gate.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Accept HEIC, HEIF, and BMP images on a session's first prompt when the configured default model is served by Kimi and no model has been selected yet.

--- a/packages/agent-core-v2/src/agent/profile/profileService.ts
+++ b/packages/agent-core-v2/src/agent/profile/profileService.ts
@@ -484,7 +484,8 @@ export class AgentProfileService extends Disposable implements IAgentProfileServ
   }
 
   getModelProviderType(alias?: string): string | undefined {
-    return this.resolveModelForThinking(alias ?? this.modelAlias)?.providerType;
+    const effective = alias ?? this.modelAlias ?? this.config.get<string>('defaultModel');
+    return this.resolveModelForThinking(effective)?.providerType;
   }
 
   getMaxOutputSize(): number | undefined {

--- a/packages/agent-core-v2/test/agent/profile/profileOps.test.ts
+++ b/packages/agent-core-v2/test/agent/profile/profileOps.test.ts
@@ -561,6 +561,35 @@ describe('AgentProfileService (wire-backed config.update)', () => {
     expect(host.svc.getModel()).toBe('claude-code');
   });
 
+  it('falls back to the configured default model when nothing binds and no alias is given', () => {
+    modelCatalog = createModelCatalogStub({
+      'kimi-code': createTestModel({ providerType: 'kimi' }),
+      'claude-code': createTestModel({ id: 'claude-code', protocol: 'anthropic' }),
+    });
+    configValues['defaultModel'] = 'kimi-code';
+    const host = buildHost('profile-provider-type-default-fallback');
+    host.svc.configure({ emitStatusUpdated: () => undefined });
+
+    expect(host.svc.getModelProviderType()).toBe('kimi');
+    host.svc.update({ modelAlias: 'claude-code' });
+    expect(host.svc.getModelProviderType()).toBeUndefined();
+    expect(host.svc.getModelProviderType('kimi-code')).toBe('kimi');
+  });
+
+  it('stays undefined when the configured default model resolves outside the kimi set or nowhere', () => {
+    modelCatalog = createModelCatalogStub({
+      'claude-code': createTestModel({ id: 'claude-code', protocol: 'anthropic' }),
+    });
+    configValues['defaultModel'] = 'claude-code';
+    const host = buildHost('profile-provider-type-default-outside');
+    host.svc.configure({ emitStatusUpdated: () => undefined });
+
+    expect(host.svc.getModelProviderType()).toBeUndefined();
+
+    configValues['defaultModel'] = 'missing-model';
+    expect(host.svc.getModelProviderType()).toBeUndefined();
+  });
+
   it('uses the resolved Kimi effort instead of the configured default', () => {
     modelCatalog = createModelCatalogStub({
       'kimi-code': createTestModel({ providerType: 'kimi' }),

--- a/packages/kap-server/test/prompts.test.ts
+++ b/packages/kap-server/test/prompts.test.ts
@@ -101,6 +101,11 @@ const PROMPT_TOML_KIMI_VISION = [
   '',
 ].join('\n');
 
+const PROMPT_TOML_KIMI_VISION_DEFAULT = PROMPT_TOML_KIMI_VISION.replace(
+  'default_model = "stub"',
+  'default_model = "kimi-vision"',
+);
+
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const CRC32_TABLE = makeCrc32Table();
 
@@ -1043,6 +1048,57 @@ describe('server-v2 /api/v1 prompts', () => {
 
     const submitted = await call<PromptItemWire>('POST', `/api/v1/sessions/${id}/prompts`, {
       model: 'kimi-vision',
+      content: [
+        {
+          type: 'image',
+          source: {
+            kind: 'base64',
+            media_type: 'image/heic',
+            data: heicBytes().toString('base64'),
+          },
+        },
+      ],
+    });
+    expect(submitted.body.code).toBe(0);
+
+    const content = submitted.body.data.content as PromptContentPart[];
+    expect(content).toHaveLength(1);
+    expect(content[0]?.type).toBe('image');
+  });
+
+  it('gates a first-prompt image against the configured default model before any model binds', async () => {
+    await writeConfigToml(home as string, PROMPT_TOML_KIMI_VISION_DEFAULT);
+    await (server as RunningServer).core.accessor.get(IConfigService).reload();
+    const id = await createSession(home as string);
+    await createMainAgent(id);
+
+    const submitted = await call<PromptItemWire>('POST', `/api/v1/sessions/${id}/prompts`, {
+      content: [
+        {
+          type: 'image',
+          source: {
+            kind: 'base64',
+            media_type: 'image/heic',
+            data: heicBytes().toString('base64'),
+          },
+        },
+      ],
+    });
+    expect(submitted.body.code).toBe(0);
+
+    const content = submitted.body.data.content as PromptContentPart[];
+    expect(content).toHaveLength(1);
+    expect(content[0]?.type).toBe('image');
+  });
+
+  it('gates media against the default model a same-request profile selection binds', async () => {
+    await writeConfigToml(home as string, PROMPT_TOML_KIMI_VISION_DEFAULT);
+    await (server as RunningServer).core.accessor.get(IConfigService).reload();
+    const id = await createSession(home as string);
+    await createMainAgent(id);
+
+    const submitted = await call<PromptItemWire>('POST', `/api/v1/sessions/${id}/prompts`, {
+      profile: 'agent',
       content: [
         {
           type: 'image',


### PR DESCRIPTION
## Related Issue

Follow-up to #3649 (no tracking issue; gap found during end-to-end smoke testing of that PR).

## Problem

#3649 made image format acceptance provider-aware, but every gate resolved the provider type only from the *bound* model. A fresh session that has not explicitly bound a model yet (no per-request `model`, no `agent_config` selection) has an empty profile alias, so `getModelProviderType()` returned `undefined` and every gate fell back to the baseline PNG/JPEG/GIF/WebP set. Two supported flows hit this:

- A first prompt with a HEIC/HEIF/BMP attachment on a session whose `default_model` is served by Kimi: the image was persisted as an attachment and replaced by a text notice even though the turn's effective model is the Kimi default.
- A first prompt that selects a `profile` without naming a `model`: `bind()` falls back to the configured `default_model`, but the kap-server route runs media resolution before the bind, so the gate saw `undefined` again.

## What changed

`IAgentProfileService.getModelProviderType(alias?)` now resolves `alias ?? boundModelAlias ?? config defaultModel` before consulting the catalog, mirroring the fallback `bind()` itself applies. One change covers every consumer (prompt-entry gate, kap-server prompt/skill routes, MCP tool results). Explicit alias and bound-model resolution are unchanged; when neither a bound model nor a resolvable default exists, the method still returns `undefined` and gates keep the baseline set.

Tests (red-first): profile-level fallback including precedence and non-Kimi/missing defaults (`profileOps.test.ts`); kap-server route regressions for both flows above (`prompts.test.ts`). Verified with the full agent-core-v2 / kap-server / acp-server / klient suites plus a live end-to-end smoke (real server process, mock OpenAI-compatible provider, sips-generated HEIC/BMP files): 20/20 checks pass, including the previously failing unbound-first-prompt case.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.