### PR TITLE
refactor(agent-core-v2): split telemetry admin surface and snapshot scope bindings

### DIFF
--- a/apps/kimi-code/src/cli/v2/run-v2-print.ts
+++ b/apps/kimi-code/src/cli/v2/run-v2-print.ts
@@ -39,6 +39,7 @@ import {
   PRINT_MAX_TURNS_DEFAULT,
   PRINT_WAIT_CEILING_S_DEFAULT,
   applyPrintModeConfigDefaults,
+  asTelemetryAdmin,
   bootstrap,
   createCloudAppender,
   ensureMainAgent,
@@ -54,6 +55,7 @@ import {
   type Event2,
   type IAgentScopeHandle,
   type ISessionScopeHandle,
+  type ITelemetryAdminService,
   type LoopRunResult,
   type McpServerConfig,
   type PrintBackgroundMode,
@@ -211,6 +213,7 @@ export async function runV2Print(
   let removeTerminationCleanup: (() => void) | undefined;
   let cleanupPromise: Promise<void> | undefined;
   let telemetryService: ITelemetryService | undefined;
+  let telemetryAdmin: ITelemetryAdminService | undefined;
   const cleanup = async (): Promise<void> => {
     const pending = (cleanupPromise ??= (async () => {
       removeTerminationCleanup?.();
@@ -226,8 +229,8 @@ export async function runV2Print(
             // The turn's tail records reach the journal only via the wire's
             // async persist queue; process.exit must not cut off that queue.
             raceWithTimeout(flushWires(), CLI_SHUTDOWN_TIMEOUT_MS).catch(() => {}),
-            telemetryService !== undefined
-              ? raceWithTimeout(telemetryService.shutdown(), CLI_SHUTDOWN_TIMEOUT_MS)
+            telemetryAdmin !== undefined
+              ? raceWithTimeout(telemetryAdmin.shutdown(), CLI_SHUTDOWN_TIMEOUT_MS)
               : Promise.resolve(),
             shutdownTelemetry({ timeoutMs: CLI_SHUTDOWN_TIMEOUT_MS }).catch(() => {}),
           ]);
@@ -252,8 +255,9 @@ export async function runV2Print(
     // process-wide crash handlers report through its default client, so its
     // sink must be attached before the run can crash.
     telemetryService = app.accessor.get(ITelemetryService);
+    telemetryAdmin = asTelemetryAdmin(telemetryService);
     if (telemetryEnabled) {
-      telemetryService.addAppender(
+      telemetryAdmin?.addAppender(
         createCloudAppender(app.accessor, {
           deviceId,
           appName: CLI_USER_AGENT_PRODUCT,

--- a/packages/agent-core-v2/src/app/telemetry/telemetry.ts
+++ b/packages/agent-core-v2/src/app/telemetry/telemetry.ts
@@ -26,6 +26,10 @@ export interface ITelemetryAppender {
   shutdown?(): Promise<void> | void;
 }
 
+export interface TelemetryScopeBinding extends IDisposable {
+  readonly telemetry: ITelemetryService;
+}
+
 export interface ITelemetryService {
   readonly _serviceBrand: undefined;
 
@@ -36,11 +40,23 @@ export interface ITelemetryService {
   withContext(patch: TelemetryContextPatch): ITelemetryService;
   setContext(patch: TelemetryContextPatch): void;
   getContext(): Readonly<TelemetryContextPatch>;
+  createScopeBinding(seed: TelemetryContextPatch): TelemetryScopeBinding;
+}
+
+export interface ITelemetryAdminService {
   addAppender(appender: ITelemetryAppender): IDisposable;
   removeAppender(appender: ITelemetryAppender): void;
   setEnabled(enabled: boolean): void;
   flush(): Promise<void>;
   shutdown(): Promise<void>;
+}
+
+export function asTelemetryAdmin(service: ITelemetryService): ITelemetryAdminService | undefined {
+  const candidate = service as ITelemetryService & Partial<ITelemetryAdminService>;
+  if (typeof candidate.addAppender !== 'function') {
+    return undefined;
+  }
+  return candidate as ITelemetryAdminService;
 }
 
 export const nullTelemetryAppender: ITelemetryAppender = {
@@ -57,11 +73,12 @@ export const noopTelemetryService: ITelemetryService = {
   withContext: () => noopTelemetryService,
   setContext: () => {},
   getContext: () => EMPTY_CONTEXT,
-  addAppender: () => ({ dispose: () => {} }),
-  removeAppender: () => {},
-  setEnabled: () => {},
-  flush: async () => {},
-  shutdown: async () => {},
+  createScopeBinding: () => noopTelemetryScopeBinding,
+};
+
+const noopTelemetryScopeBinding: TelemetryScopeBinding = {
+  telemetry: noopTelemetryService,
+  dispose: () => {},
 };
 
 export const ITelemetryService = createDecorator<ITelemetryService>(

--- a/packages/agent-core-v2/src/app/telemetry/telemetryService.ts
+++ b/packages/agent-core-v2/src/app/telemetry/telemetryService.ts
@@ -14,10 +14,12 @@ import {
   type TelemetryEventPayload,
 } from './events';
 import {
+  type ITelemetryAdminService,
   type ITelemetryAppender,
   ITelemetryService,
   nullTelemetryAppender,
   type TelemetryAppenderRecord,
+  type TelemetryScopeBinding,
 } from './telemetry';
 
 type MutableContext = Record<string, TelemetryPrimitive>;
@@ -59,31 +61,12 @@ export function composeTelemetryProperties(
   return properties;
 }
 
-export interface TelemetryScopeBinding extends IDisposable {
-  readonly telemetry: ITelemetryService;
-}
-
 interface TelemetryAmbientSource {
   ambient(): TelemetryProperties;
 }
 
-export interface ITelemetryScopeBindingHost {
-  createScopeBinding(seed: TelemetryContextPatch): TelemetryScopeBinding;
-}
-
-export function bindTelemetryScope(
-  parent: ITelemetryService,
-  seed: TelemetryContextPatch,
-): TelemetryScopeBinding {
-  const host = parent as ITelemetryService & Partial<ITelemetryScopeBindingHost>;
-  if (host.createScopeBinding !== undefined) {
-    return host.createScopeBinding(seed);
-  }
-  return { telemetry: parent.withContext(seed), dispose: () => {} };
-}
-
 export class TelemetryService
-  implements ITelemetryService, ITelemetryScopeBindingHost, TelemetryAmbientSource
+  implements ITelemetryService, ITelemetryAdminService, TelemetryAmbientSource
 {
   declare readonly _serviceBrand: undefined;
 
@@ -164,32 +147,32 @@ export class TelemetryService
     for (const appender of this.appenders) {
       try {
         appender.track(record);
-      } catch (err) {
-        onUnexpectedError(err);
+      } catch (error) {
+        onUnexpectedError(error);
       }
     }
   }
 }
 
-class BoundTelemetryService
-  implements ITelemetryService, ITelemetryScopeBindingHost, TelemetryAmbientSource
-{
+class BoundTelemetryService implements ITelemetryService, TelemetryAmbientSource {
   declare readonly _serviceBrand: undefined;
 
   private disposed = false;
+  private readonly base: TelemetryProperties;
 
   constructor(
     private readonly root: TelemetryService,
-    private readonly parent: TelemetryAmbientSource,
+    parent: TelemetryAmbientSource,
     private readonly fragment: MutableContext,
-  ) {}
+  ) {
+    this.base = parent.ambient();
+  }
 
   ambient(): TelemetryProperties {
-    const inherited = this.parent.ambient();
     if (this.disposed) {
-      return inherited;
+      return { ...this.base };
     }
-    return { ...inherited, ...this.fragment };
+    return { ...this.base, ...this.fragment };
   }
 
   track2<K extends TelemetryEventName, E extends TelemetryEventPayload<K> = never>(
@@ -200,10 +183,7 @@ class BoundTelemetryService
   }
 
   withContext(patch: TelemetryContextPatch): ITelemetryService {
-    return new TelemetrySnapshotView(
-      this.root,
-      applyPatch(this.ambient(), patch),
-    );
+    return new TelemetrySnapshotView(this.root, applyPatch(this.ambient(), patch));
   }
 
   setContext(patch: TelemetryContextPatch): void {
@@ -221,32 +201,12 @@ class BoundTelemetryService
     return { telemetry: bound, dispose: () => bound.dispose() };
   }
 
-  addAppender(appender: ITelemetryAppender): IDisposable {
-    return this.root.addAppender(appender);
-  }
-
-  removeAppender(appender: ITelemetryAppender): void {
-    this.root.removeAppender(appender);
-  }
-
-  setEnabled(enabled: boolean): void {
-    this.root.setEnabled(enabled);
-  }
-
-  flush(): Promise<void> {
-    return this.root.flush();
-  }
-
-  shutdown(): Promise<void> {
-    return this.root.shutdown();
-  }
-
   dispose(): void {
     this.disposed = true;
   }
 }
 
-class TelemetrySnapshotView implements ITelemetryService {
+class TelemetrySnapshotView implements ITelemetryService, TelemetryAmbientSource {
   declare readonly _serviceBrand: undefined;
   private context: MutableContext;
 
@@ -257,15 +217,19 @@ class TelemetrySnapshotView implements ITelemetryService {
     this.context = { ...context };
   }
 
+  ambient(): TelemetryProperties {
+    return { ...this.context };
+  }
+
   track2<K extends TelemetryEventName, E extends TelemetryEventPayload<K> = never>(
     event: K,
     properties?: StrictPropertyCheck<TelemetryEventPayload<K>, E>,
   ): void {
-    this.root.dispatch(event, this.context, properties as TelemetryProperties | undefined);
+    this.root.dispatch(event, this.ambient(), properties as TelemetryProperties | undefined);
   }
 
   withContext(patch: TelemetryContextPatch): ITelemetryService {
-    return new TelemetrySnapshotView(this.root, applyPatch({ ...this.context }, patch));
+    return new TelemetrySnapshotView(this.root, applyPatch(this.ambient(), patch));
   }
 
   setContext(patch: TelemetryContextPatch): void {
@@ -273,27 +237,12 @@ class TelemetrySnapshotView implements ITelemetryService {
   }
 
   getContext(): Readonly<TelemetryContextPatch> {
-    return { ...this.context };
+    return this.ambient();
   }
 
-  addAppender(appender: ITelemetryAppender): IDisposable {
-    return this.root.addAppender(appender);
-  }
-
-  removeAppender(appender: ITelemetryAppender): void {
-    this.root.removeAppender(appender);
-  }
-
-  setEnabled(enabled: boolean): void {
-    this.root.setEnabled(enabled);
-  }
-
-  flush(): Promise<void> {
-    return this.root.flush();
-  }
-
-  shutdown(): Promise<void> {
-    return this.root.shutdown();
+  createScopeBinding(seed: TelemetryContextPatch): TelemetryScopeBinding {
+    const bound = new BoundTelemetryService(this.root, this, applyPatch({}, seed));
+    return { telemetry: bound, dispose: () => bound.dispose() };
   }
 }
 

--- a/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
+++ b/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
@@ -52,7 +52,6 @@ import { IWireService } from '#/wire/wire';
 import { IAgentStateService } from '#/agent/state/agentState';
 import { IEventDispatcher } from '#/state/eventDispatcher';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
-import { bindTelemetryScope } from '#/app/telemetry/telemetryService';
 import type { AgentContext } from '#/agent/agentContext/agentContext';
 
 import { ManagedAgent } from './managedAgent';
@@ -171,7 +170,7 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
     let stage = 'scope';
     let containerRef: InstantiationService | undefined;
     let createdHandle: IAgentScopeHandle | undefined;
-    const telemetryBinding = bindTelemetryScope(this.telemetry, {
+    const telemetryBinding = this.telemetry.createScopeBinding({
       agent_id: agentId,
       mode: 'agent',
     });

--- a/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
+++ b/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
@@ -34,7 +34,6 @@ import { CHILD_SESSION_KIND,
 } from '#/app/sessionIndex/sessionIndex';
 import { buildSessionSummary } from '#/app/sessionIndex/sessionIndexSource';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
-import { bindTelemetryScope } from '#/app/telemetry/telemetryService';
 import { ErrorCodes, Error2, isError2 } from '#/errors';
 import { IHostFileSystem, type HostDirEntry } from '#/os/interface/hostFileSystem';
 import {
@@ -257,7 +256,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
       scope: (subKey?: string): string =>
         subKey === undefined || subKey === '' ? sessionScope : `${sessionScope}/${subKey}`,
     };
-    const telemetryBinding = bindTelemetryScope(this.telemetry, {
+    const telemetryBinding = this.telemetry.createScopeBinding({
       session_id: opts.sessionId,
     });
     let handle: ISessionScopeHandle;

--- a/packages/agent-core-v2/test/agent/mcp/output.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/output.test.ts
@@ -42,11 +42,7 @@ function recordingTelemetry(records: TelemetryRecord[]): ITelemetryService {
     withContext: () => telemetry,
     setContext: () => {},
     getContext: () => ({}),
-    addAppender: () => ({ dispose: () => {} }),
-    removeAppender: () => {},
-    setEnabled: () => {},
-    flush: async () => {},
-    shutdown: async () => {},
+    createScopeBinding: () => ({ telemetry, dispose: () => {} }),
   };
   return telemetry;
 }

--- a/packages/agent-core-v2/test/agent/media/tools/read-media.test.ts
+++ b/packages/agent-core-v2/test/agent/media/tools/read-media.test.ts
@@ -112,11 +112,7 @@ function recordingTelemetry(records: TelemetryRecord[]): ITelemetryService {
     withContext: () => telemetry,
     setContext: () => {},
     getContext: () => ({}),
-    addAppender: () => ({ dispose: () => {} }),
-    removeAppender: () => {},
-    setEnabled: () => {},
-    flush: async () => {},
-    shutdown: async () => {},
+    createScopeBinding: () => ({ telemetry, dispose: () => {} }),
   };
   return telemetry;
 }

--- a/packages/agent-core-v2/test/app/telemetry/stubs.ts
+++ b/packages/agent-core-v2/test/app/telemetry/stubs.ts
@@ -13,11 +13,9 @@ export function recordingTelemetry(
   context: TelemetryProperties = {},
 ): ITelemetryService {
   let currentContext = context;
-  let enabled = true;
   const service: ITelemetryService = {
     _serviceBrand: undefined,
     track2: (event, properties) => {
-      if (!enabled) return;
       records.push({
         event,
         properties: composeTelemetryProperties(
@@ -33,13 +31,10 @@ export function recordingTelemetry(
       currentContext = { ...currentContext, ...patch };
     },
     getContext: () => currentContext,
-    addAppender: () => ({ dispose: () => {} }),
-    removeAppender: () => {},
-    setEnabled(next) {
-      enabled = next;
-    },
-    flush: () => Promise.resolve(),
-    shutdown: () => Promise.resolve(),
+    createScopeBinding: (seed: TelemetryContextPatch) => ({
+      telemetry: recordingTelemetry(records, { ...currentContext, ...seed }),
+      dispose: () => {},
+    }),
   };
   return service;
 }

--- a/packages/agent-core-v2/test/app/telemetry/telemetryService.test.ts
+++ b/packages/agent-core-v2/test/app/telemetry/telemetryService.test.ts
@@ -8,11 +8,13 @@ import {
 } from '#/_base/errors/unexpectedError';
 import type { TelemetryProperties } from '#/app/telemetry/context';
 import type { TurnStartedEvent as TurnStartedTelemetryEvent } from '#/app/telemetry/events';
-import { type ITelemetryAppender, ITelemetryService } from '#/app/telemetry/telemetry';
 import {
-  type ITelemetryScopeBindingHost,
-  TelemetryService,
-} from '#/app/telemetry/telemetryService';
+  asTelemetryAdmin,
+  type ITelemetryAppender,
+  ITelemetryService,
+  noopTelemetryService,
+} from '#/app/telemetry/telemetry';
+import { TelemetryService } from '#/app/telemetry/telemetryService';
 
 interface CapturedRecord {
   readonly event: string;
@@ -228,8 +230,7 @@ describe('TelemetryService (layered ambient)', () => {
     root.setContext({ session_id: 'app-level', model: 'm1' });
 
     const session = root.createScopeBinding({ session_id: 's1' });
-    const agent = (session.telemetry as ITelemetryService & ITelemetryScopeBindingHost)
-      .createScopeBinding({ agent_id: 'a1', mode: 'agent' });
+    const agent = session.telemetry.createScopeBinding({ agent_id: 'a1', mode: 'agent' });
 
     agent.telemetry.track2('session_ended', { reason: 'exit' });
     expect(appender.records[0]?.properties).toEqual({
@@ -263,8 +264,7 @@ describe('TelemetryService (layered ambient)', () => {
     const appender = new CapturingAppender();
     const root = serviceWithAppenders(appender);
     const session = root.createScopeBinding({ session_id: 's1' });
-    const agent = (session.telemetry as ITelemetryService & ITelemetryScopeBindingHost)
-      .createScopeBinding({ agent_id: 'a1', mode: 'agent' });
+    const agent = session.telemetry.createScopeBinding({ agent_id: 'a1', mode: 'agent' });
     agent.telemetry.setContext({ turn_id: 3 });
     agent.telemetry.track2('tool_call_dedup_detected', {
       step_no: 1,
@@ -435,8 +435,7 @@ describe('TelemetryService (layered ambient)', () => {
     const appender = new CapturingAppender();
     const root = serviceWithAppenders(appender);
     const session = root.createScopeBinding({ session_id: 's1' });
-    const agent = (session.telemetry as ITelemetryService & ITelemetryScopeBindingHost)
-      .createScopeBinding({ agent_id: 'a1' });
+    const agent = session.telemetry.createScopeBinding({ agent_id: 'a1' });
 
     agent.dispose();
     agent.telemetry.track2('session_ended', { reason: 'exit' });
@@ -519,6 +518,104 @@ describe('TelemetryService (layered ambient)', () => {
       mode: 'agent',
       provider_type: 'old-provider',
     });
+  });
+});
+
+describe('TelemetryService (scope binding snapshots)', () => {
+  it('a binding snapshots the parent context at creation and ignores later parent writes', () => {
+    const appender = new CapturingAppender();
+    const root = serviceWithAppenders(appender);
+    root.setContext({ model: 'm1' });
+    const session = root.createScopeBinding({ session_id: 's1' });
+
+    root.setContext({ model: 'm2', session_id: 'other-session' });
+    session.telemetry.track2('session_ended', { reason: 'exit' });
+
+    expect(appender.records[0]?.properties).toEqual({
+      sessionId: 's1',
+      model: 'm1',
+      reason: 'exit',
+    });
+  });
+
+  it('a binding created after a parent write captures the written context', () => {
+    const appender = new CapturingAppender();
+    const root = serviceWithAppenders(appender);
+    root.setContext({ model: 'm1' });
+    const session = root.createScopeBinding({ session_id: 's1' });
+
+    session.telemetry.track2('session_ended', { reason: 'exit' });
+
+    expect(appender.records[0]?.properties).toEqual({
+      sessionId: 's1',
+      model: 'm1',
+      reason: 'exit',
+    });
+  });
+
+  it('a nested binding does not observe fragment writes made to its parent after creation', () => {
+    const appender = new CapturingAppender();
+    const root = serviceWithAppenders(appender);
+    const session = root.createScopeBinding({ session_id: 's1' });
+    const agent = session.telemetry.createScopeBinding({ agent_id: 'a1', mode: 'agent' });
+
+    session.telemetry.setContext({ model: 'late-model' });
+    agent.telemetry.track2('session_ended', { reason: 'exit' });
+
+    expect(appender.records[0]?.properties).toEqual({
+      sessionId: 's1',
+      agent_id: 'a1',
+      mode: 'agent',
+      reason: 'exit',
+    });
+  });
+
+  it('a disposed binding degrades to the context captured at creation', () => {
+    const appender = new CapturingAppender();
+    const root = serviceWithAppenders(appender);
+    root.setContext({ model: 'm1' });
+    const session = root.createScopeBinding({ session_id: 's1' });
+    root.setContext({ model: 'm2' });
+
+    session.dispose();
+    session.telemetry.track2('session_ended', { reason: 'exit' });
+
+    expect(appender.records[0]?.properties).toEqual({ model: 'm1', reason: 'exit' });
+  });
+});
+
+describe('asTelemetryAdmin', () => {
+  it('exposes the admin surface of a concrete TelemetryService', () => {
+    const svc = new TelemetryService();
+    const admin = asTelemetryAdmin(svc);
+    const appender = new CapturingAppender();
+
+    admin?.addAppender(appender);
+    svc.track2('session_ended', { reason: 'exit' });
+
+    expect(admin).toBeDefined();
+    expect(appender.records).toHaveLength(1);
+  });
+
+  it('returns undefined for services without an admin surface', () => {
+    expect(asTelemetryAdmin(noopTelemetryService)).toBeUndefined();
+  });
+
+  it('is not exposed by scope bindings or snapshot views', () => {
+    const root = new TelemetryService();
+    const binding = root.createScopeBinding({ session_id: 's1' });
+
+    expect(asTelemetryAdmin(binding.telemetry)).toBeUndefined();
+    expect(asTelemetryAdmin(root.withContext({ session_id: 's1' }))).toBeUndefined();
+  });
+});
+
+describe('noopTelemetryService', () => {
+  it('creates an inert scope binding', () => {
+    const binding = noopTelemetryService.createScopeBinding({ session_id: 's1' });
+
+    expect(() => binding.telemetry.track2('session_ended', { reason: 'exit' })).not.toThrow();
+    expect(() => binding.dispose()).not.toThrow();
   });
 });
 

--- a/packages/agent-core-v2/test/features/plan/tools/exit-plan-mode.test.ts
+++ b/packages/agent-core-v2/test/features/plan/tools/exit-plan-mode.test.ts
@@ -44,11 +44,7 @@ function recordingTelemetry(): ITelemetryService {
     withContext: () => recordingTelemetry(),
     setContext: () => {},
     getContext: () => ({}),
-    addAppender: () => ({ dispose: () => {} }),
-    removeAppender: () => {},
-    setEnabled: () => {},
-    flush: () => Promise.resolve(),
-    shutdown: () => Promise.resolve(),
+    createScopeBinding: () => ({ telemetry: recordingTelemetry(), dispose: () => {} }),
   };
 }
 

--- a/packages/agent-core-v2/test/features/plan/tools/plan-tools-telemetry.test.ts
+++ b/packages/agent-core-v2/test/features/plan/tools/plan-tools-telemetry.test.ts
@@ -48,11 +48,7 @@ function recordingTelemetry(): {
       withContext: () => recordingTelemetry().telemetry,
       setContext: () => {},
       getContext: () => ({}),
-      addAppender: () => ({ dispose: () => {} }),
-      removeAppender: () => {},
-      setEnabled: () => {},
-      flush: () => Promise.resolve(),
-      shutdown: () => Promise.resolve(),
+      createScopeBinding: () => ({ telemetry: recordingTelemetry().telemetry, dispose: () => {} }),
     },
     track2,
   };

--- a/packages/agent-core-v2/test/os/backends/node-local/tools/glob.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/tools/glob.test.ts
@@ -173,11 +173,7 @@ function telemetryStub(
     withContext: () => telemetryStub(events),
     setContext: () => {},
     getContext: () => ({}),
-    addAppender: () => ({ dispose: () => {} }),
-    removeAppender: () => {},
-    setEnabled: () => {},
-    flush: async () => {},
-    shutdown: async () => {},
+    createScopeBinding: () => ({ telemetry: telemetryStub(events), dispose: () => {} }),
   };
 }
 

--- a/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
+++ b/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
@@ -91,7 +91,7 @@ import { IAgentToolExecutorService } from '#/agent/toolExecutor/toolExecutor';
 import { IAgentLoopService } from '#/agent/loop/loop';
 import { IAgentPromptService } from '#/agent/prompt/prompt';
 import { IAgentFullCompactionService } from '#/agent/fullCompaction/fullCompaction';
-import { ITelemetryService } from '#/app/telemetry/telemetry';
+import { ITelemetryService, noopTelemetryService } from '#/app/telemetry/telemetry';
 import { IHostEnvironment } from '#/os/interface/hostEnvironment';
 import { IHostFileSystem } from '#/os/interface/hostFileSystem';
 import { ISessionAgentProfileCatalog } from '#/session/sessionAgentProfileCatalog/sessionAgentProfileCatalog';
@@ -367,14 +367,7 @@ describe('AgentLifecycleService', () => {
       drain: promptDrain,
       list: () => ({ launching: false, active: undefined, pending: [] }),
     } as unknown as IAgentPromptService);
-    ix.stub(ITelemetryService, {
-      _serviceBrand: undefined,
-      track2: () => {},
-      withContext: () => ({
-        _serviceBrand: undefined,
-        track2: () => {},
-      }) as unknown as ITelemetryService,
-    } as unknown as ITelemetryService);
+    ix.stub(ITelemetryService, noopTelemetryService);
     ix.stub(IHostEnvironment, { _serviceBrand: undefined } as IHostEnvironment);
     ix.stub(IHostFileSystem, { _serviceBrand: undefined } as IHostFileSystem);
     ix.stub(IHostClock, { _serviceBrand: undefined } as IHostClock);

--- a/packages/agent-core-v2/test/workspace/workspaceFs/fsService.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceFs/fsService.test.ts
@@ -317,11 +317,7 @@ function telemetryStub(events: Array<{ event: string; properties: Record<string,
     withContext: () => telemetryStub(events),
     setContext: () => {},
     getContext: () => ({}),
-    addAppender: () => ({ dispose: () => {} }),
-    removeAppender: () => {},
-    setEnabled: () => {},
-    flush: async () => {},
-    shutdown: async () => {},
+    createScopeBinding: () => ({ telemetry: telemetryStub(events), dispose: () => {} }),
   };
 }
 
@@ -1335,7 +1331,7 @@ describe('WorkspaceFsService.list', () => {
       sort: 'name_asc',
       include_git_status: false,
     });
-    const names = result.items.map((i) => i.name).sort();
+    const names = result.items.map((i) => i.name).toSorted();
     expect(names).toEqual(['README.md', 'src']);
     expect(result.items.find((i) => i.name === 'src')?.kind).toBe('directory');
   });
@@ -1351,7 +1347,7 @@ describe('WorkspaceFsService.list', () => {
       sort: 'name_asc',
       include_git_status: false,
     });
-    expect(result.children_by_path?.['src']?.map((i) => i.name).sort()).toEqual([
+    expect(result.children_by_path?.['src']?.map((i) => i.name).toSorted()).toEqual([
       'a.ts',
       'sub',
     ]);
@@ -1399,15 +1395,15 @@ describe('WorkspaceFsService.read', () => {
   });
 
   it('returns base64 for binary content in auto mode', async () => {
-    const fs = makeSession({ 'bin.dat': 'abc\x00def' }, emptyHandler);
+    const fs = makeSession({ 'bin.dat': 'abc\u0000def' }, emptyHandler);
     const result = await fs.read({ path: 'bin.dat', offset: 0, length: 1024, encoding: 'auto' });
     expect(result.encoding).toBe('base64');
     expect(result.is_binary).toBe(true);
-    expect(result.content).toBe(Buffer.from('abc\x00def').toString('base64'));
+    expect(result.content).toBe(Buffer.from('abc\u0000def').toString('base64'));
   });
 
   it('throws fs.is_binary for binary content in utf-8 mode', async () => {
-    const fs = makeSession({ 'bin.dat': 'abc\x00def' }, emptyHandler);
+    const fs = makeSession({ 'bin.dat': 'abc\u0000def' }, emptyHandler);
     await expect(
       fs.read({ path: 'bin.dat', offset: 0, length: 1024, encoding: 'utf-8' }),
     ).rejects.toMatchObject({ code: 'fs.is_binary' });

--- a/packages/kap-server/src/services/telemetry.ts
+++ b/packages/kap-server/src/services/telemetry.ts
@@ -1,6 +1,7 @@
 import {
   type CloudAppender,
   createCloudAppender,
+  asTelemetryAdmin,
   IBootstrapService,
   IConfigService,
   type IDisposable,
@@ -37,6 +38,9 @@ export async function initializeServerTelemetry(
   const enabled = config.get('telemetry') !== false;
   if (!enabled || isTelemetryDisabledByEnv(core)) return {};
 
+  const admin = asTelemetryAdmin(service);
+  if (admin === undefined) return {};
+
   const auth = core.accessor.get(IOAuthToolkit);
   const appender = createCloudAppender(core.accessor, {
     deviceId: createKimiDeviceId(homeDir),
@@ -45,7 +49,7 @@ export async function initializeServerTelemetry(
     model: config.get<string>('defaultModel') ?? undefined,
     getAccessToken: async () => (await auth.getCachedAccessToken()) ?? null,
   });
-  const registration = service.addAppender(appender);
+  const registration = admin.addAppender(appender);
   try {
     appender.startPeriodicFlush();
   } catch (error) {

--- a/packages/kap-server/test/telemetry.test.ts
+++ b/packages/kap-server/test/telemetry.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import {
+  asTelemetryAdmin,
   bootstrap,
   type ITelemetryAppender,
   ITelemetryService,
@@ -96,7 +97,7 @@ describe('server telemetry', () => {
 
     await shutdownServerTelemetry(telemetry);
     service.track2('session_ended', { reason: 'archive' });
-    await service.flush();
+    await asTelemetryAdmin(service)?.flush();
 
     expect(cloudFetch).toHaveBeenCalledOnce();
     expect(hostEvents).toEqual(['session_ended', 'session_ended']);

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -197,6 +197,7 @@ import {
   IWorkspaceAliases,
   ISessionActivityView,
   IWorkspaceInstanceManager,
+  asTelemetryAdmin,
   closeSessionById,
   followSessionLifecycles,
   getLiveSessionById,
@@ -545,15 +546,16 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
    */
   private installEngineTelemetry(client: TelemetryClient | undefined): void {
     if (client === undefined) return;
-    const telemetry = this.app.accessor.get(ITelemetryService);
-    telemetry.addAppender({
+    const admin = asTelemetryAdmin(this.app.accessor.get(ITelemetryService));
+    if (admin === undefined) return;
+    admin.addAppender({
       track: (record) => {
         if (this.engineSessionStartedSuppressed && record.event === 'session_started') return;
         client.track(record.event, record.properties);
       },
     });
     void this.configReady.then(() => {
-      telemetry.setEnabled(this.engineAccessor.get(IConfigService).get('telemetry') !== false);
+      admin.setEnabled(this.engineAccessor.get(IConfigService).get('telemetry') !== false);
     });
   }
 
@@ -956,9 +958,9 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
    * cannot deadlock.
    */
   private runSessionAccessAll<T>(sessionIds: readonly string[], work: () => Promise<T>): Promise<T> {
-    const keys = [...new Set(sessionIds)].sort();
+    const keys = [...new Set(sessionIds)].toSorted();
     let chained: () => Promise<T> = work;
-    for (const key of [...keys].reverse()) {
+    for (const key of [...keys].toReversed()) {
       const inner = chained;
       chained = () => this.runSessionAccess(key, inner);
     }


### PR DESCRIPTION
## Related Issue

无关联 issue — 这是对 v2 埋点架构内部问题的重构（问题在下方说明）。

## Problem

v2 埋点（`packages/agent-core-v2/src/app/telemetry/`）存在三个架构缺陷：

1. **接口职责未分离**：`ITelemetryService` 同时提供生产侧 API（`track2`/`withContext`）和管理侧 API（`addAppender`/`setEnabled`/`flush`/`shutdown`）。每个注入该接口的会话或 Agent 作用域消费者（80+ 调用点）都能对全局埋点调用 `shutdown()`；`BoundTelemetryService`/`TelemetrySnapshotView` 也不得不把 6 个管理方法转发到根服务。
2. **上下文绑定实时继承父级上下文**：`BoundTelemetryService.ambient()` 每次都会实时读取父级上下文。根服务上下文一旦被写入（如 print 模式把 `session_id` 写到 App 根服务），该写入就会追溯性地影响所有已创建的 session/agent 绑定——在多会话宿主（kap-server）中，这会造成会话间上下文污染。
3. **`bindTelemetryScope` 通过强制类型转换调用可选方法**：通过 `as Partial<ITelemetryScopeBindingHost>` 判断宿主是否支持绑定，不支持时回退为返回不可释放的快照；同一个函数因此可能返回两种生命周期语义不同的对象。

## What changed

- `ITelemetryService` 精简为生产侧接口（`track2`/`withContext`/`setContext`/`getContext`），并将 `createScopeBinding` 改为接口的必需成员；`bindTelemetryScope` 与 `ITelemetryScopeBindingHost` 删除，`sessionLifecycle`/`agentLifecycle` 直接调用 `createScopeBinding`。
- 新增 `ITelemetryAdminService`（`addAppender`/`removeAppender`/`setEnabled`/`flush`/`shutdown`），通过 `asTelemetryAdmin()` 对已解析的服务进行类型收窄——保留 kap-server 在测试中注入的宿主自有 `TelemetryService` 实例，仍可接收 cloud appender 的行为（`kap-server/test/telemetry.test.ts` 已覆盖）；noop/绑定/快照视图不再暴露管理方法。
- `BoundTelemetryService` 改为在创建时生成父级上下文快照，销毁后回退到创建时的基础上下文；新增了 4 个快照语义测试和 3 个 `asTelemetryAdmin` 测试（TDD：先确认失败，再实现）。
- 更新了 `kap-server`、`node-sdk`、`run-v2-print` 三处管理侧调用方，以及实现旧版完整接口的 7 个测试桩。

验证：`agent-core-v2` 全部测试通过（仍有 12 个失败，已通过 origin/main 基线确认是环境问题——缺少 `zip`、依赖 GitHub 网络或 thinking trait，均与本改动无关）；`kap-server` 全部测试通过；`node-sdk`/`kimi-code` 类型检查通过；CLI print 测试通过；lint 和 check-no-comments 检查通过；没有发现任何内部标识符。

行为变化说明：快照语义下，绑定创建后对根上下文的写入不再影响既有绑定。引擎内所有 `setContext` 调用方（loop/profile/plan/llmRequester）写入的都是自身 agent 片段，不受影响；print 模式的根写入只用于根级事件，语义保持不变。

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
