### PR TITLE
fix(agent-core-v2): only send prompt_cache_key to official OpenAI endpoints

### DIFF
--- a/.changeset/prompt-cache-key-official-openai-only.md
+++ b/.changeset/prompt-cache-key-official-openai-only.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core-v2": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Only send the OpenAI prompt cache key to the official OpenAI API; custom OpenAI-compatible endpoints no longer receive the unknown parameter and stop rejecting requests with HTTP 400.

--- a/packages/agent-core-v2/src/human/llm/requester/bases/openai-base-url.ts
+++ b/packages/agent-core-v2/src/human/llm/requester/bases/openai-base-url.ts
@@ -1,0 +1,11 @@
+export function isOfficialOpenAIBaseUrl(baseUrl: string | undefined): boolean {
+  if (baseUrl === undefined) {
+    return true;
+  }
+  try {
+    const hostname = new URL(baseUrl).hostname;
+    return hostname === 'api.openai.com' || hostname.endsWith('.api.openai.com');
+  } catch {
+    return false;
+  }
+}

--- a/packages/agent-core-v2/src/human/llm/requester/bases/openai-responses/format.ts
+++ b/packages/agent-core-v2/src/human/llm/requester/bases/openai-responses/format.ts
@@ -11,6 +11,7 @@ import { encodeReasoningEffortFallback } from '#/llm/thinking';
 import type { TokenUsage } from '#/llm/usage';
 
 import { isContextOverflowErrorCode, isOpenAIInsufficientQuotaCode } from '../openai/format';
+import { isOfficialOpenAIBaseUrl } from '../openai-base-url';
 import { lowerMessage, type ResponsesInputItem } from './lower';
 
 type RawObject = Record<string, unknown>;
@@ -365,7 +366,9 @@ function resolveRequestKwargs(input: FormatRequestInput): Record<string, unknown
   } = input;
   let kwargs: Record<string, unknown> = {};
   if (cacheKey !== undefined) {
-    kwargs = trait?.cacheKey?.(cacheKey, ctx) ?? { prompt_cache_key: cacheKey };
+    kwargs =
+      trait?.cacheKey?.(cacheKey, ctx) ??
+      (isOfficialOpenAIBaseUrl(ctx.model.baseUrl) ? { prompt_cache_key: cacheKey } : {});
   }
   if (thinking !== undefined) {
     kwargs = applyThinking(kwargs, thinking, trait, ctx, (t) =>

--- a/packages/agent-core-v2/src/human/llm/requester/bases/openai/format.ts
+++ b/packages/agent-core-v2/src/human/llm/requester/bases/openai/format.ts
@@ -42,6 +42,7 @@ import {
   extractReasoning,
   extractReasoningDetails,
 } from './reasoning-key';
+import { isOfficialOpenAIBaseUrl } from '../openai-base-url';
 
 function responseFormatToOpenAI(format: ResponseFormat): Record<string, unknown> {
   if (format.type === 'json_object') {
@@ -181,7 +182,9 @@ function resolveRequestKwargs(input: FormatRequestInput): ResolvedRequestKwargs 
   } = input;
   let kwargs: Record<string, unknown> = {};
   if (cacheKey !== undefined) {
-    kwargs = trait?.cacheKey?.(cacheKey, ctx) ?? { prompt_cache_key: cacheKey };
+    kwargs =
+      trait?.cacheKey?.(cacheKey, ctx) ??
+      (isOfficialOpenAIBaseUrl(ctx.model.baseUrl) ? { prompt_cache_key: cacheKey } : {});
   }
   let preserveThinking = false;
   if (thinking !== undefined) {

--- a/packages/agent-core-v2/src/human/test/llm/cache-key.test.ts
+++ b/packages/agent-core-v2/src/human/test/llm/cache-key.test.ts
@@ -11,7 +11,7 @@ const model: LlmModel = {
   provider: 'test',
   model: 'test-model',
   capability: UNKNOWN_CAPABILITY,
-  baseUrl: 'https://example.test/v1',
+  baseUrl: 'https://api.openai.com/v1',
 };
 const messages: readonly Message[] = [createUserMessage('hi')];
 
@@ -119,6 +119,20 @@ describe('openai requester cacheKey', () => {
     expect(client.body()['stop']).toEqual(['END']);
     expect(client.body()['presence_penalty']).toBe(0.5);
     expect(client.body()['extra_body']).toEqual({ trace_id: 't1' });
+  });
+
+  it('omits prompt_cache_key for third-party OpenAI endpoints', async () => {
+    const client = stubOpenAIClient(chatCompletionChunks);
+    const requester = createOpenAIRequester(undefined, { clientFactory: client.clientFactory });
+    await requester.generate(
+      {
+        model: { ...model, baseUrl: 'https://integrate.api.nvidia.com/v1' },
+        cacheKey: 'session-1',
+      },
+      { messages },
+      { signal: new AbortController().signal },
+    );
+    expect(client.body()['prompt_cache_key']).toBeUndefined();
   });
 
   it('lets a trait override the cache key params', async () => {

--- a/packages/agent-core-v2/src/human/test/llm/response-format.test.ts
+++ b/packages/agent-core-v2/src/human/test/llm/response-format.test.ts
@@ -195,6 +195,22 @@ describe('openai requester responseFormat', () => {
 });
 
 describe('openai-responses requester responseFormat', () => {
+  it('omits prompt_cache_key for third-party endpoints', async () => {
+    const client = stubResponsesClient(responsesStreamEvents);
+    const requester = createOpenAIResponsesRequester(undefined, {
+      clientFactory: client.clientFactory,
+    });
+    await requester.generate(
+      {
+        model: { ...model, baseUrl: 'https://integrate.api.nvidia.com/v1' },
+        cacheKey: 'session-1',
+      },
+      { messages },
+      { signal: new AbortController().signal },
+    );
+    expect(client.body()['prompt_cache_key']).toBeUndefined();
+  });
+
   it('maps json_schema to text.format', async () => {
     const client = stubResponsesClient(responsesStreamEvents);
     const requester = createOpenAIResponsesRequester(undefined, {


### PR DESCRIPTION
## Related Issue

Resolves #2166 (NVIDIA NIM: `400 Validation: Unsupported parameter(s): prompt_cache_key`). Related: #2611 (Azure Foundry: `400 Unrecognized request argument supplied: prompt_cache_key`).

Supersedes and replaces #2240 and #2761, which are closed in favor of this single reconciled branch.

## Problem

Since v0.29.0 (#1970), every OpenAI-compatible provider receives the session `prompt_cache_key` in the request body. Strictly-validating endpoints (e.g. NVIDIA NIM, Azure Foundry) reject the unknown parameter with HTTP 400, making custom `openai` / `openai_responses` providers unusable for agent sessions.

## What changed

The field is now only sent when the effective base URL targets the official OpenAI API (`api.openai.com` or a regional `*.api.openai.com` variant, or unset → client default):

- Added `isOfficialOpenAIBaseUrl()` helper in `packages/agent-core-v2/src/human/llm/requester/bases/openai-base-url.ts`.
- Gated the `prompt_cache_key` fallback behind it in both the OpenAI chat-completions and Responses bases (`openai/format.ts`, `openai-responses/format.ts`). A vendor that supports the field on other hosts keeps encoding it via the `cacheKey` trait hook (e.g. Kimi), which is unaffected.
- Tests: `cache-key.test.ts` (official endpoint keeps the key; third-party endpoint omits it) and `response-format.test.ts` (Responses base omits it for third-party endpoints).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.