### PR TITLE
fix(updater): support zstd manifest entries

### DIFF
--- a/.changeset/native-zstd-manifest.md
+++ b/.changeset/native-zstd-manifest.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Support compressed downloads from updated native release manifests.

--- a/apps/kimi-code/src/cli/update/native-manifest.ts
+++ b/apps/kimi-code/src/cli/update/native-manifest.ts
@@ -5,7 +5,8 @@
  * staged updater reuses the same file so checksums and file names have a
  * single source of truth. Entries point at the bare platform binary
  * (`kimi-code-<target>[.exe]`), not an archive; an entry may additionally
- * carry `compressed`, pointing at the zstd-compressed variant of that binary.
+ * carry `zstd` (or the legacy `compressed` field), pointing at the
+ * zstd-compressed variant of that binary.
  */
 
 import { valid } from 'semver';
@@ -18,6 +19,12 @@ const MANIFEST_FETCH_TIMEOUT_MS = 10_000;
 const PlatformEntrySchema = z.object({
   filename: z.string().min(1),
   checksum: z.string().regex(/^[a-f0-9]{64}$/, { error: 'invalid sha256' }),
+  zstd: z
+    .object({
+      file: z.string().min(1),
+      sha256: z.string().regex(/^[a-f0-9]{64}$/, { error: 'invalid sha256' }),
+    })
+    .optional(),
   compressed: z
     .object({
       filename: z.string().min(1),

--- a/apps/kimi-code/src/cli/update/native-stage.ts
+++ b/apps/kimi-code/src/cli/update/native-stage.ts
@@ -488,17 +488,20 @@ export async function stageNativeUpdate(
   try {
     const manifest = await fetchNativeReleaseManifest(options.version, fetchImpl);
     const entry = selectPlatformEntry(manifest, platform, arch);
+    const compressed = entry.zstd === undefined
+      ? entry.compressed
+      : { filename: entry.zstd.file, checksum: entry.zstd.sha256 };
     // Prefer the zstd-compressed artifact when the manifest carries one and
     // the runtime can inflate it (~4x smaller than the bare binary). Any
     // failure in the compressed path falls back to the bare download below.
     let size: number | undefined;
-    if (entry.compressed !== undefined && typeof createZstdDecompress === 'function') {
+    if (compressed !== undefined && typeof createZstdDecompress === 'function') {
       const zstPartPath = join(stagingDir, `${exeFileName}.zst.part`);
       try {
         await downloadAndHash(
-          nativeBinaryUrl(options.version, entry.compressed.filename),
+          nativeBinaryUrl(options.version, compressed.filename),
           zstPartPath,
-          entry.compressed.checksum,
+          compressed.checksum,
           fetchImpl,
           options.onProgress,
           options.idleTimeoutMs,

--- a/apps/kimi-code/test/cli/update/native-manifest.test.ts
+++ b/apps/kimi-code/test/cli/update/native-manifest.test.ts
@@ -77,6 +77,40 @@ describe('fetchNativeReleaseManifest', () => {
     });
   });
 
+  it('parses a platform entry carrying a zstd artifact pointer', async () => {
+    const body = JSON.stringify({
+      version: VERSION,
+      platforms: {
+        'linux-x64': {
+          filename: 'kimi-code-linux-x64',
+          checksum: 'a'.repeat(64),
+          zstd: { file: 'kimi-code-linux-x64.zst', sha256: 'b'.repeat(64) },
+        },
+      },
+    });
+    const manifest = await fetchNativeReleaseManifest(VERSION, mockFetch({ ok: true, status: 200, body }));
+    expect(manifest.platforms['linux-x64']).toEqual({
+      filename: 'kimi-code-linux-x64',
+      checksum: 'a'.repeat(64),
+      zstd: { file: 'kimi-code-linux-x64.zst', sha256: 'b'.repeat(64) },
+    });
+  });
+
+  it.each([
+    { file: '', sha256: 'b'.repeat(64) },
+    { file: 'kimi-code-linux-x64.zst', sha256: 'invalid' },
+  ])('rejects an invalid zstd artifact pointer: %j', async (zstd) => {
+    const body = JSON.stringify({
+      version: VERSION,
+      platforms: {
+        'linux-x64': { filename: 'kimi-code-linux-x64', checksum: 'a'.repeat(64), zstd },
+      },
+    });
+    await expect(
+      fetchNativeReleaseManifest(VERSION, mockFetch({ ok: true, status: 200, body })),
+    ).rejects.toThrow();
+  });
+
   it('rejects a non-semver version argument before hitting the network', async () => {
     const f = mockFetch({ ok: true, status: 200, body: MANIFEST_BODY });
     await expect(fetchNativeReleaseManifest('nope', f)).rejects.toThrow(/invalid semver/);

--- a/apps/kimi-code/test/cli/update/native-stage.test.ts
+++ b/apps/kimi-code/test/cli/update/native-stage.test.ts
@@ -96,7 +96,11 @@ interface MockCdnOptions {
    * When set, the manifest entry advertises a compressed artifact; the .zst
    * URL serves `payload` (null → 404, a CDN without the artifact yet).
    */
-  readonly compressed?: { readonly payload: Buffer | null; readonly checksum?: string };
+  readonly compressed?: {
+    readonly payload: Buffer | null;
+    readonly checksum?: string;
+    readonly field?: 'compressed' | 'zstd';
+  };
 }
 
 function mockCdnFetch(options: MockCdnOptions): typeof fetch {
@@ -106,11 +110,13 @@ function mockCdnFetch(options: MockCdnOptions): typeof fetch {
     checksum: options.checksum ?? sha256Hex(options.payload),
   };
   if (options.compressed !== undefined) {
-    platformEntry['compressed'] = {
-      filename: COMPRESSED_FILENAME,
-      checksum:
-        options.compressed.checksum ?? sha256Hex(options.compressed.payload ?? Buffer.alloc(0)),
-    };
+    const checksum =
+      options.compressed.checksum ?? sha256Hex(options.compressed.payload ?? Buffer.alloc(0));
+    if (options.compressed.field === 'zstd') {
+      platformEntry['zstd'] = { file: COMPRESSED_FILENAME, sha256: checksum };
+    } else {
+      platformEntry['compressed'] = { filename: COMPRESSED_FILENAME, checksum };
+    }
   }
   const manifestBody = JSON.stringify({
     version,
@@ -201,10 +207,10 @@ describe('stageNativeUpdate', () => {
     expect(leftovers).toEqual([]);
   });
 
-  it('downloads the compressed artifact and stages the decompressed binary', async () => {
+  it.each(['compressed', 'zstd'] as const)('downloads the %s artifact and stages the decompressed binary', async (field) => {
     const fetchImpl = mockCdnFetch({
       payload: PAYLOAD,
-      compressed: { payload: zstdCompressSync(PAYLOAD) },
+      compressed: { payload: zstdCompressSync(PAYLOAD), field },
     });
     const result = await stageNativeUpdate({
       version: VERSION,
@@ -232,11 +238,11 @@ describe('stageNativeUpdate', () => {
     expect(leftovers).toEqual([]);
   });
 
-  it('falls back to the bare binary when the compressed artifact is missing', async () => {
+  it.each(['compressed', 'zstd'] as const)('falls back to the bare binary when the compressed artifact is missing (%s)', async (field) => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const fetchImpl = mockCdnFetch({
       payload: PAYLOAD,
-      compressed: { payload: null },
+      compressed: { payload: null, field },
     });
     const result = await stageNativeUpdate({
       version: VERSION,
@@ -255,12 +261,12 @@ describe('stageNativeUpdate', () => {
     expect(exeBytes.equals(PAYLOAD)).toBe(true);
   });
 
-  it('falls back to the bare binary when the compressed artifact fails verification', async () => {
+  it.each(['compressed', 'zstd'] as const)('falls back to the bare binary when the compressed artifact fails verification (%s)', async (field) => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const fetchImpl = mockCdnFetch({
       payload: PAYLOAD,
       // The .zst bytes do not hash to the advertised compressed checksum.
-      compressed: { payload: zstdCompressSync(PAYLOAD), checksum: 'f'.repeat(64) },
+      compressed: { payload: zstdCompressSync(PAYLOAD), checksum: 'f'.repeat(64), field },
     });
     const result = await stageNativeUpdate({
       version: VERSION,
@@ -279,13 +285,13 @@ describe('stageNativeUpdate', () => {
     expect(exeBytes.equals(PAYLOAD)).toBe(true);
   });
 
-  it('falls back to the bare binary when the decompressed content fails verification', async () => {
+  it.each(['compressed', 'zstd'] as const)('falls back to the bare binary when the decompressed content fails verification (%s)', async (field) => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     // The .zst verifies against its own checksum but inflates to something
     // other than the bare binary the manifest checksum covers.
     const fetchImpl = mockCdnFetch({
       payload: PAYLOAD,
-      compressed: { payload: zstdCompressSync(Buffer.from('other-content')) },
+      compressed: { payload: zstdCompressSync(Buffer.from('other-content')), field },
     });
     const result = await stageNativeUpdate({
       version: VERSION,
@@ -299,6 +305,47 @@ describe('stageNativeUpdate', () => {
     expect(result.staged.sha256).toBe(sha256Hex(PAYLOAD));
     const exeBytes = await readFile(stagedExePath(exePath, result.staged));
     expect(exeBytes.equals(PAYLOAD)).toBe(true);
+  });
+
+  it('prefers zstd when both manifest formats are present', async () => {
+    const compressedPayload = zstdCompressSync(PAYLOAD);
+    const fetchImpl = mockCdnFetch({
+      payload: PAYLOAD,
+      compressed: { payload: compressedPayload, field: 'zstd' },
+    });
+    vi.mocked(fetchImpl).mockResolvedValueOnce(new Response(JSON.stringify({
+      version: VERSION,
+      platforms: {
+        'linux-x64': {
+          filename: BINARY_FILENAME,
+          checksum: sha256Hex(PAYLOAD),
+          zstd: { file: COMPRESSED_FILENAME, sha256: sha256Hex(compressedPayload) },
+          compressed: { filename: 'legacy.zst', checksum: 'a'.repeat(64) },
+        },
+      },
+    })));
+
+    const result = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl,
+    });
+
+    expect(await readFile(stagedExePath(exePath, result.staged))).toEqual(PAYLOAD);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      nativeBinaryUrl(VERSION, COMPRESSED_FILENAME),
+      expect.anything(),
+    );
+    expect(fetchImpl).not.toHaveBeenCalledWith(
+      nativeBinaryUrl(VERSION, 'legacy.zst'),
+      expect.anything(),
+    );
+    expect(fetchImpl).not.toHaveBeenCalledWith(
+      nativeBinaryUrl(VERSION, BINARY_FILENAME),
+      expect.anything(),
+    );
   });
 
   it('marks the staged exe executable', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue; this is a native release manifest compatibility change.

## Problem

Native release manifests need to advertise compressed artifacts without repeating the bare binary's `filename` and `checksum` keys inside a nested object. Older shell installers parse those keys with a regular expression and can otherwise select the compressed file as the executable. The new publisher format uses `zstd: { file, sha256 }`, which existing CLI versions ignore and therefore download the bare binary.

## What changed

Accept the optional `zstd` entry and prefer it over the existing `compressed` entry. Keep support for existing manifests and reuse the current download, compressed checksum verification, decompression, bare checksum verification, and bare-download fallback.

Tests cover both formats, missing artifacts, checksum failures before and after decompression, invalid new fields, and precedence when both formats are present.

Validation: all 51 tests in `native-manifest.test.ts` and `native-stage.test.ts` passed; CLI typecheck passed; focused type-aware lint passed with only the existing `console.warn` warning. A patch changeset is included. CLI usage is unchanged, so no user documentation update is needed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`). Not applicable: collaborator change with no linked issue.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
