### PR TITLE
chore: translate and polish pending changeset entries

### DIFF
--- a/.changeset/database-config-section.md
+++ b/.changeset/database-config-section.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-minidb 读模型和全局搜索 worker 目前从实验特性转换为正式特性引入。
+The minidb session-index read model and global search worker are now always on; the experimental flags have been replaced by the `[database]` config section and the `KIMI_CODE_PERSISTENCE_MINIDB_READMODEL` / `KIMI_CODE_SEARCH_WORKER` env vars.

--- a/.changeset/notify-updates-channels.md
+++ b/.changeset/notify-updates-channels.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": minor
----
-
-Improve the experimental Updates panel: remind the agent to post progress updates after long silent stretches, group the panel into per-agent channels with Ctrl+N keyboard navigation, and mirror subagent delegations into the panel; enable it with `KIMI_CODE_EXPERIMENTAL_NOTIFY_USER=1`.

--- a/.changeset/remote-control-always-available.md
+++ b/.changeset/remote-control-always-available.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Remote Control 目前从实验特性转换为正式特性引入。
+Remote Control is now always on; the experimental `KIMI_CODE_EXPERIMENTAL_REMOTE_CONTROL` flag has been removed.

--- a/.changeset/session-delete-action.md
+++ b/.changeset/session-delete-action.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": minor
----
-
-Add session deletion to the server API via `POST /api/v1/sessions/{id}:delete`.

--- a/.changeset/tower-mode-fixes.md
+++ b/.changeset/tower-mode-fixes.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Tower worker and reviewer briefings now carry the mission's user-verbatim context, and reviewers also see the full mission text and the worker's review request. Tower worker and reviewer agent timeouts now follow the subagent timeout setting (`[subagent] timeout_ms` or `KIMI_SUBAGENT_TIMEOUT_MS`), still defaulting to 2 hours. Fix the /tasks list not showing the model for tower-spawned worker and reviewer agents.
+Tower worker and reviewer briefings now carry the full mission context, and tower agent timeouts follow the subagent timeout setting (`[subagent] timeout_ms` or `KIMI_SUBAGENT_TIMEOUT_MS`), defaulting to 2 hours. Fix the /tasks list not showing the model for tower-spawned agents.


### PR DESCRIPTION
## Related Issue

N/A — wording cleanup of pending changesets before the 0.42.0 release.

## Problem

Two pending changeset entries were written in Chinese, but changeset entries must be English; they blocked the changelog preview for the open release PR (#3574). Two other entries were redundant next to entries announcing the same surface, and the experimental-to-GA entries used inconsistent phrasing.

## What changed

- Translated the minidb read model / search worker and Remote Control graduation entries into English.
- Unified the experimental-to-GA entries on the "now always on; the experimental flag has been removed" phrasing already used by the secondary-model entry.
- Dropped the Updates panel follow-up entry; the panel is already announced by `notify-user-panel.md`.
- Dropped the session-deletion server API entry; it is covered by the web context-menu deletion entry.
- Simplified the tower briefings entry.

No behavior changes. After this merges, the changesets action will regenerate the changelog in the release PR (#3574).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — changeset wording only)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No new changeset — this PR only edits pending changeset text)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No behavior change)