### PR TITLE
fix(transcript): project only a fork's own turns into its transcript

### DIFF
--- a/.changeset/fork-transcript-own-turns.md
+++ b/.changeset/fork-transcript-own-turns.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix /btw side-chat transcripts showing inherited main-conversation turns with mismatched prompts and answers.

--- a/packages/agent-core-v2/docs/state-manifest.d.ts
+++ b/packages/agent-core-v2/docs/state-manifest.d.ts
@@ -1241,6 +1241,7 @@ export interface AgentStateSnapshot {
       detail?: unknown;
     }>;
     readonly note?: string;
+    readonly inherited?: boolean;
   })[];
   // src/agent/contextProjector/contextProjectorService.ts
   'contextProjector.lastRepairSignature': string | null;

--- a/packages/agent-core-v2/docs/wire-manifest.d.ts
+++ b/packages/agent-core-v2/docs/wire-manifest.d.ts
@@ -140,6 +140,7 @@ interface ContextAppendMessagePayload {
     isError?: boolean;
     toolCallDisplays?: Record<string, ToolInputDisplay>;
     note?: string;
+    inherited?: boolean;
   };
 }
 

--- a/packages/agent-core-v2/src/agent/contextMemory/contextTranscript.ts
+++ b/packages/agent-core-v2/src/agent/contextMemory/contextTranscript.ts
@@ -30,6 +30,7 @@ interface MutableMessage {
   isError?: boolean;
   note?: string;
   origin?: ContextMessage['origin'];
+  inherited?: boolean;
 }
 
 interface MutableEntry {
@@ -175,6 +176,7 @@ function toMutableEntry(message: ContextMessage, time: number | undefined): Muta
       ...(message.toolCallId !== undefined ? { toolCallId: message.toolCallId } : {}),
       ...(message.isError !== undefined ? { isError: message.isError } : {}),
       ...(message.origin !== undefined ? { origin: message.origin } : {}),
+      ...(message.inherited !== undefined ? { inherited: message.inherited } : {}),
     },
     time,
   };

--- a/packages/agent-core-v2/src/agent/contextMemory/contextTranscript.ts
+++ b/packages/agent-core-v2/src/agent/contextMemory/contextTranscript.ts
@@ -176,7 +176,7 @@ function toMutableEntry(message: ContextMessage, time: number | undefined): Muta
       ...(message.toolCallId !== undefined ? { toolCallId: message.toolCallId } : {}),
       ...(message.isError !== undefined ? { isError: message.isError } : {}),
       ...(message.origin !== undefined ? { origin: message.origin } : {}),
-      ...(message.inherited !== undefined ? { inherited: message.inherited } : {}),
+      inherited: message.inherited,
     },
     time,
   };

--- a/packages/agent-core-v2/src/agent/contextMemory/types.ts
+++ b/packages/agent-core-v2/src/agent/contextMemory/types.ts
@@ -126,6 +126,7 @@ export type ContextMessage = Message & {
   readonly isError?: boolean;
   toolCallDisplays?: Record<string, ToolInputDisplay>;
   readonly note?: string;
+  readonly inherited?: boolean;
 };
 
 export interface UserMessageRecord {

--- a/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
+++ b/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
@@ -320,9 +320,11 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
 
     const sourceMessages = source.accessor.get(IAgentContextMemoryService)?.get();
     if (sourceMessages !== undefined && sourceMessages.length > 0) {
-      child.accessor
-        .get(IAgentContextMemoryService)
-        ?.append(...closeTrailingOpenToolExchange(sourceMessages));
+      const inherited = closeTrailingOpenToolExchange(sourceMessages).map((message) => ({
+        ...message,
+        inherited: true,
+      }));
+      child.accessor.get(IAgentContextMemoryService)?.append(...inherited);
     }
     return childContext;
   }

--- a/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
+++ b/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
@@ -1258,6 +1258,29 @@ describe('AgentLifecycleService', () => {
     });
   });
 
+  it('fork marks the seeded context messages as inherited without touching the source', async () => {
+    const svc = ix.get(IAgentLifecycleService);
+    const source = await svc.create({ agentId: 'main' });
+    const sourceHandle = svc.handleOf('main')!;
+    const history: ContextMessage[] = [
+      { role: 'user', content: [{ type: 'text', text: 'analyze this repo' }], toolCalls: [] },
+      { role: 'assistant', content: [{ type: 'text', text: 'done' }], toolCalls: [] },
+    ];
+    sourceHandle.accessor.get(IAgentContextMemoryService).append(...history);
+
+    const child = await svc.fork(agentContextOf(sourceHandle), { agentId: 'forked' });
+
+    const seeded = svc.handleOf(child.agentId)!.accessor.get(IAgentContextMemoryService).get();
+    expect(seeded).toHaveLength(2);
+    expect(seeded.every((message) => message.inherited === true)).toBe(true);
+    expect(
+      sourceHandle.accessor
+        .get(IAgentContextMemoryService)
+        .get()
+        .every((message) => message.inherited === undefined),
+    ).toBe(true);
+  });
+
   it('fork leaves the child context empty when the source history is empty', async () => {
     const svc = ix.get(IAgentLifecycleService);
     const source = await svc.create({ agentId: 'main' });

--- a/packages/kap-server/src/services/transcript/transcriptService.ts
+++ b/packages/kap-server/src/services/transcript/transcriptService.ts
@@ -475,12 +475,12 @@ export class TranscriptService {
       throw error;
     }
     const meta = await this.readSessionMeta(summary.workspaceId, sessionId);
-    const projectionRecords = stripLegacyInheritedRecords(
-      records,
-      meta?.agents?.[agentId]?.forkedFrom,
-    );
+    const forkedFrom = meta?.agents?.[agentId]?.forkedFrom;
+    const projectionRecords = stripLegacyInheritedRecords(records, forkedFrom);
     const messages = [...reduceContextTranscript(projectionRecords).entries].filter(
-      (message) => message.inherited !== true,
+      (message) =>
+        message.inherited !== true &&
+        (forkedFrom === undefined || message.origin?.kind !== 'compaction_summary'),
     );
     const taskOriginTurnTaskIds = new Set<string>();
     const steeredContents = new Map<string, Map<string, number>>();

--- a/packages/kap-server/src/services/transcript/transcriptService.ts
+++ b/packages/kap-server/src/services/transcript/transcriptService.ts
@@ -425,19 +425,26 @@ export class TranscriptService {
   async readColdRoster(sessionId: string): Promise<AgentDescriptor[] | undefined> {
     const summary = await this.deps.core.accessor.get(ISessionIndex).get(sessionId);
     if (summary === undefined) return undefined;
-    let meta: SessionMeta;
-    try {
-      const raw = await readFile(
-        join(this.deps.homeDir, SESSIONS_ROOT, summary.workspaceId, sessionId, STATE_FILE),
-        'utf-8',
-      );
-      meta = JSON.parse(raw) as SessionMeta;
-    } catch {
-      return [];
-    }
+    const meta = await this.readSessionMeta(summary.workspaceId, sessionId);
+    if (meta === undefined) return [];
     return Object.entries(meta.agents ?? {}).map(([agentId, agentMeta]) =>
       descriptorFromMeta(agentId, agentMeta),
     );
+  }
+
+  private async readSessionMeta(
+    workspaceId: string,
+    sessionId: string,
+  ): Promise<SessionMeta | undefined> {
+    try {
+      const raw = await readFile(
+        join(this.deps.homeDir, SESSIONS_ROOT, workspaceId, sessionId, STATE_FILE),
+        'utf-8',
+      );
+      return JSON.parse(raw) as SessionMeta;
+    } catch {
+      return undefined;
+    }
   }
 
   async readColdSnapshot(
@@ -467,7 +474,12 @@ export class TranscriptService {
       }
       throw error;
     }
-    const messages = [...reduceContextTranscript(records).entries].filter(
+    const meta = await this.readSessionMeta(summary.workspaceId, sessionId);
+    const projectionRecords = stripLegacyInheritedRecords(
+      records,
+      meta?.agents?.[agentId]?.forkedFrom,
+    );
+    const messages = [...reduceContextTranscript(projectionRecords).entries].filter(
       (message) => message.inherited !== true,
     );
     const taskOriginTurnTaskIds = new Set<string>();
@@ -475,7 +487,7 @@ export class TranscriptService {
     const anchorStack: { taskIdsSnapshot: Set<string> }[] = [];
     let anchorFloor = 0;
     let sawTurnPrompt = false;
-    for (const record of records) {
+    for (const record of projectionRecords) {
       if (record.type === 'context.undo') {
         const count = typeof record['count'] === 'number' ? (record['count'] as number) : 0;
         for (let i = 0; i < count && anchorStack.length > anchorFloor; i++) {
@@ -523,7 +535,7 @@ export class TranscriptService {
       messages,
       sawTurnPrompt || steeredContents.size > 0 ? { taskOriginTurnTaskIds, steeredContents } : undefined,
     );
-    const folded = foldWireRecordFacts(projectQuestionInteractionRecords(records, sessionId), base, {
+    const folded = foldWireRecordFacts(projectQuestionInteractionRecords(projectionRecords, sessionId), base, {
       resolvePlanRevisionKey: (key) =>
         join(SESSIONS_ROOT, summary.workspaceId, sessionId, AGENTS_DIR, agentId, key),
     });
@@ -630,6 +642,24 @@ const TERMINAL_TURN_STATES: ReadonlySet<TranscriptTurn['state']> = new Set([
   'failed',
   'cancelled',
 ]);
+
+function stripLegacyInheritedRecords(
+  records: readonly ContextRecord[],
+  forkedFrom: string | undefined,
+): readonly ContextRecord[] {
+  if (forkedFrom === undefined) return records;
+  const marked = records.some(
+    (record) =>
+      record.type === 'context.append_message' &&
+      (record as { message?: ContextMessage }).message?.inherited === true,
+  );
+  if (marked) return records;
+  const firstPrompt = records.findIndex((record) => record.type === 'turn.prompt');
+  const cutoff = firstPrompt === -1 ? records.length : firstPrompt;
+  return records.filter(
+    (record, index) => index >= cutoff || record.type !== 'context.append_message',
+  );
+}
 
 function projectQuestionInteractionRecords(
   records: readonly ContextRecord[],

--- a/packages/kap-server/src/services/transcript/transcriptService.ts
+++ b/packages/kap-server/src/services/transcript/transcriptService.ts
@@ -467,7 +467,9 @@ export class TranscriptService {
       }
       throw error;
     }
-    const messages = [...reduceContextTranscript(records).entries];
+    const messages = [...reduceContextTranscript(records).entries].filter(
+      (message) => message.inherited !== true,
+    );
     const taskOriginTurnTaskIds = new Set<string>();
     const steeredContents = new Map<string, Map<string, number>>();
     const anchorStack: { taskIdsSnapshot: Set<string> }[] = [];

--- a/packages/kap-server/test/services/transcript.test.ts
+++ b/packages/kap-server/test/services/transcript.test.ts
@@ -2382,6 +2382,86 @@ describe('AgentTranscriptProjector', () => {
     }
   });
 
+  it('readColdSnapshot excludes fork-inherited messages from the fork transcript', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'transcript-fork-inherited-'));
+    try {
+      const wireDir = join(home, 'sessions', 'ws', 's1', 'agents', 'agent-1');
+      await mkdir(wireDir, { recursive: true });
+      const records = [
+        {
+          type: 'context.append_message',
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: 'main question' }],
+            toolCalls: [],
+            origin: { kind: 'user' },
+            inherited: true,
+          },
+          time: 1000,
+        },
+        {
+          type: 'context.append_message',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'main answer' }],
+            toolCalls: [],
+            inherited: true,
+          },
+          time: 2000,
+        },
+        {
+          type: 'turn.prompt',
+          promptId: 'prompt-side',
+          origin: { kind: 'user' },
+          input: [{ type: 'text', text: 'side question' }],
+          time: 3000,
+        },
+        {
+          type: 'context.append_message',
+          message: {
+            id: 'msg-side',
+            role: 'user',
+            content: [{ type: 'text', text: 'side question' }],
+            toolCalls: [],
+            origin: { kind: 'user' },
+          },
+          time: 3001,
+        },
+        {
+          type: 'context.append_message',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'side answer' }],
+            toolCalls: [],
+          },
+          time: 4000,
+        },
+      ];
+      await writeFile(join(wireDir, 'wire.jsonl'), `${records.map((r) => JSON.stringify(r)).join('\n')}\n`);
+
+      const snapshot = await coldTranscriptService(home).readColdSnapshot('s1', 'agent-1');
+
+      expect(snapshot).toBeDefined();
+      const turns = snapshot!.items.filter((item) => item.kind === 'turn');
+      expect(turns).toHaveLength(1);
+      expect(turns[0]).toMatchObject({
+        turnId: 't0',
+        ordinal: 0,
+        state: 'completed',
+        prompt: 'side question',
+        origin: { kind: 'user' },
+      });
+      const frames = turns[0]!.kind === 'turn' ? turns[0]!.steps.flatMap((step) => step.frames) : [];
+      expect(frames).toContainEqual(
+        expect.objectContaining({ kind: 'text', role: 'assistant', text: 'side answer' }),
+      );
+      expect(JSON.stringify(snapshot!.items)).not.toContain('main question');
+      expect(JSON.stringify(snapshot!.items)).not.toContain('main answer');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
   it('readColdSnapshot folds task/todo/goal/plan/interaction records into the cold snapshot', async () => {
     const home = await mkdtemp(join(tmpdir(), 'transcript-cold-facts-'));
     try {
@@ -3756,6 +3836,90 @@ describe('bindSessionTranscript', () => {
         output: 'a.txt',
         display: { kind: 'command', command: 'ls' },
       });
+      service.dropSession('s1');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it('backfills a fork transcript with only its own turns, keeping prompt and answer paired', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'transcript-fork-backfill-'));
+    try {
+      const wireDir = join(home, 'sessions', 'ws', 's1', 'agents', 'agent-1');
+      await mkdir(wireDir, { recursive: true });
+      const records = [
+        {
+          type: 'context.append_message',
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: 'main question' }],
+            toolCalls: [],
+            origin: { kind: 'user' },
+            inherited: true,
+          },
+          time: 1000,
+        },
+        {
+          type: 'context.append_message',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'main answer' }],
+            toolCalls: [],
+            inherited: true,
+          },
+          time: 2000,
+        },
+        {
+          type: 'context.append_message',
+          message: {
+            id: 'msg-side',
+            role: 'user',
+            content: [{ type: 'text', text: 'side question' }],
+            toolCalls: [],
+            origin: { kind: 'user' },
+          },
+          time: 3000,
+        },
+        {
+          type: 'context.append_message',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'side answer' }],
+            toolCalls: [],
+          },
+          time: 4000,
+        },
+      ];
+      await writeFile(join(wireDir, 'wire.jsonl'), `${records.map((r) => JSON.stringify(r)).join('\n')}\n`);
+
+      const agents = new FakeAgents();
+      agents.add('main');
+      const fork = agents.add('agent-1', { loopStatus: { state: 'running', activeTurnId: 0 } });
+      const service = new TranscriptService({
+        homeDir: home,
+        core: fakeCoreWithAgents(agents),
+      });
+      const store = service.forSessionLive('s1');
+      fork.bus.emit(ev({ type: 'turn.started', turnId: 0, origin: { kind: 'user' }, prompt: 'side question' }));
+      fork.bus.emit(ev({ type: 'turn.step.started', turnId: 0, step: 1 }));
+      fork.bus.emit(ev({ type: 'assistant.delta', turnId: 0, delta: 'side answer' }));
+      await service.whenReady('s1');
+      await service.ensureAgentHistory('s1', 'agent-1');
+
+      const items = store?.getAgent('agent-1')?.getItems() ?? [];
+      const turns = items.filter((item) => item.kind === 'turn');
+      expect(turns).toHaveLength(1);
+      expect(turns[0]).toMatchObject({
+        turnId: 't0',
+        ordinal: 0,
+        prompt: 'side question',
+        origin: { kind: 'user' },
+      });
+      expect(turns.map((turn) => turn.ordinal)).toEqual([0]);
+      const serialized = JSON.stringify(items);
+      expect(serialized).toContain('side answer');
+      expect(serialized).not.toContain('main question');
+      expect(serialized).not.toContain('main answer');
       service.dropSession('s1');
     } finally {
       await rm(home, { recursive: true, force: true });

--- a/packages/kap-server/test/services/transcript.test.ts
+++ b/packages/kap-server/test/services/transcript.test.ts
@@ -2550,6 +2550,85 @@ describe('AgentTranscriptProjector', () => {
     }
   });
 
+  it('readColdSnapshot excludes compaction summaries from a fork transcript', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'transcript-fork-compaction-'));
+    try {
+      const records = [
+        {
+          type: 'context.append_message',
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: 'main question' }],
+            toolCalls: [],
+            origin: { kind: 'user' },
+            inherited: true,
+          },
+          time: 1000,
+        },
+        {
+          type: 'turn.prompt',
+          promptId: 'prompt-side',
+          origin: { kind: 'user' },
+          input: [{ type: 'text', text: 'side question' }],
+          time: 3000,
+        },
+        {
+          type: 'context.append_message',
+          message: {
+            id: 'msg-side',
+            role: 'user',
+            content: [{ type: 'text', text: 'side question' }],
+            toolCalls: [],
+            origin: { kind: 'user' },
+          },
+          time: 3001,
+        },
+        {
+          type: 'context.apply_compaction',
+          summary: 'compacted: the user asked main question and then side question',
+          compactedCount: 2,
+          time: 4000,
+        },
+      ];
+      for (const agentId of ['agent-1', 'main']) {
+        const wireDir = join(home, 'sessions', 'ws', 's1', 'agents', agentId);
+        await mkdir(wireDir, { recursive: true });
+        await writeFile(join(wireDir, 'wire.jsonl'), `${records.map((r) => JSON.stringify(r)).join('\n')}\n`);
+      }
+      await writeFile(
+        join(home, 'sessions', 'ws', 's1', 'state.json'),
+        JSON.stringify({
+          id: 's1',
+          createdAt: 1,
+          updatedAt: 1,
+          archived: false,
+          agents: { 'agent-1': { type: 'sub', forkedFrom: 'main' } },
+        }),
+      );
+
+      const service = coldTranscriptService(home);
+      const forkSnapshot = await service.readColdSnapshot('s1', 'agent-1');
+      expect(forkSnapshot).toBeDefined();
+      expect(JSON.stringify(forkSnapshot!.items)).not.toContain('compacted:');
+      expect(JSON.stringify(forkSnapshot!.items)).not.toContain('main question');
+      expect(
+        forkSnapshot!.items.some((item) => item.kind === 'marker' && item.marker === 'compaction'),
+      ).toBe(false);
+      const forkTurns = forkSnapshot!.items.filter((item) => item.kind === 'turn');
+      expect(forkTurns).toHaveLength(1);
+      expect(forkTurns[0]).toMatchObject({ prompt: 'side question' });
+
+      const mainSnapshot = await service.readColdSnapshot('s1', 'main');
+      expect(mainSnapshot).toBeDefined();
+      expect(
+        mainSnapshot!.items.some((item) => item.kind === 'marker' && item.marker === 'compaction'),
+      ).toBe(true);
+      expect(JSON.stringify(mainSnapshot!.items)).toContain('compacted:');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
   it('readColdSnapshot keeps unmarked leading messages when the agent is not a fork', async () => {
     const home = await mkdtemp(join(tmpdir(), 'transcript-fork-legacy-main-'));
     try {

--- a/packages/kap-server/test/services/transcript.test.ts
+++ b/packages/kap-server/test/services/transcript.test.ts
@@ -2462,6 +2462,149 @@ describe('AgentTranscriptProjector', () => {
     }
   });
 
+  it('readColdSnapshot drops the unmarked inherited prefix of a legacy fork transcript', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'transcript-fork-legacy-'));
+    try {
+      const wireDir = join(home, 'sessions', 'ws', 's1', 'agents', 'agent-1');
+      await mkdir(wireDir, { recursive: true });
+      const records = [
+        {
+          type: 'context.append_message',
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: 'main question' }],
+            toolCalls: [],
+            origin: { kind: 'user' },
+          },
+          time: 1000,
+        },
+        {
+          type: 'context.append_message',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'main answer' }],
+            toolCalls: [],
+          },
+          time: 2000,
+        },
+        {
+          type: 'turn.prompt',
+          promptId: 'prompt-side',
+          origin: { kind: 'user' },
+          input: [{ type: 'text', text: 'side question' }],
+          time: 3000,
+        },
+        {
+          type: 'context.append_message',
+          message: {
+            id: 'msg-side',
+            role: 'user',
+            content: [{ type: 'text', text: 'side question' }],
+            toolCalls: [],
+            origin: { kind: 'user' },
+          },
+          time: 3001,
+        },
+        {
+          type: 'context.append_message',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'side answer' }],
+            toolCalls: [],
+          },
+          time: 4000,
+        },
+      ];
+      await writeFile(join(wireDir, 'wire.jsonl'), `${records.map((r) => JSON.stringify(r)).join('\n')}\n`);
+      await writeFile(
+        join(home, 'sessions', 'ws', 's1', 'state.json'),
+        JSON.stringify({
+          id: 's1',
+          createdAt: 1,
+          updatedAt: 1,
+          archived: false,
+          agents: { 'agent-1': { type: 'sub', forkedFrom: 'main' } },
+        }),
+      );
+
+      const snapshot = await coldTranscriptService(home).readColdSnapshot('s1', 'agent-1');
+
+      expect(snapshot).toBeDefined();
+      const turns = snapshot!.items.filter((item) => item.kind === 'turn');
+      expect(turns).toHaveLength(1);
+      expect(turns[0]).toMatchObject({
+        turnId: 't0',
+        ordinal: 0,
+        state: 'completed',
+        prompt: 'side question',
+        origin: { kind: 'user' },
+      });
+      const frames = turns[0]!.kind === 'turn' ? turns[0]!.steps.flatMap((step) => step.frames) : [];
+      expect(frames).toContainEqual(
+        expect.objectContaining({ kind: 'text', role: 'assistant', text: 'side answer' }),
+      );
+      expect(JSON.stringify(snapshot!.items)).not.toContain('main question');
+      expect(JSON.stringify(snapshot!.items)).not.toContain('main answer');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it('readColdSnapshot keeps unmarked leading messages when the agent is not a fork', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'transcript-fork-legacy-main-'));
+    try {
+      const wireDir = join(home, 'sessions', 'ws', 's1', 'agents', 'main');
+      await mkdir(wireDir, { recursive: true });
+      const records = [
+        {
+          type: 'context.append_message',
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: 'main question' }],
+            toolCalls: [],
+            origin: { kind: 'user' },
+          },
+          time: 1000,
+        },
+        {
+          type: 'turn.prompt',
+          promptId: 'prompt-main',
+          origin: { kind: 'user' },
+          input: [{ type: 'text', text: 'main question' }],
+          time: 2000,
+        },
+        {
+          type: 'context.append_message',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'main answer' }],
+            toolCalls: [],
+          },
+          time: 3000,
+        },
+      ];
+      await writeFile(join(wireDir, 'wire.jsonl'), `${records.map((r) => JSON.stringify(r)).join('\n')}\n`);
+      await writeFile(
+        join(home, 'sessions', 'ws', 's1', 'state.json'),
+        JSON.stringify({
+          id: 's1',
+          createdAt: 1,
+          updatedAt: 1,
+          archived: false,
+          agents: { main: { type: 'main' } },
+        }),
+      );
+
+      const snapshot = await coldTranscriptService(home).readColdSnapshot('s1', 'main');
+
+      expect(snapshot).toBeDefined();
+      expect(JSON.stringify(snapshot!.items)).toContain('main question');
+      expect(JSON.stringify(snapshot!.items)).toContain('main answer');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
   it('readColdSnapshot folds task/todo/goal/plan/interaction records into the cold snapshot', async () => {
     const home = await mkdtemp(join(tmpdir(), 'transcript-cold-facts-'));
     try {


### PR DESCRIPTION
## Related Issue

Fixes #3672

## Problem

Every `/btw` fork's transcript came out misaligned: the fork's own turn sat at ordinal 0, followed by the inherited main-conversation turns, followed by the fork's own turn again as a duplicate (empty frames). By agent-12 the turn's prompt was paired with the main conversation's answer, and the real answer was missing from the transcript. Any consumer that rebuilds from the transcript (e.g. the desktop side-chat panel resync) received the wrong content.

Root cause: `AgentLifecycleService.fork` seeds the child agent's context memory with the source agent's messages, and those inherited messages are persisted in the child's wire log as ordinary `context.append_message` records, indistinguishable from the child's own messages. The cold transcript projection (`TranscriptService.readColdSnapshot` → `reduceContextTranscript` → `groupMessagesIntoSnapshot`) rebuilt them as the fork's own turns: inherited turns took ordinals 0..N-1 and the fork's own turn ordinal N, while the live projection numbers the fork's own turns from 0 — so backfill merged by `turnId` paired the fork's prompt with the main conversation's answer and appended the fork's real turn as a duplicate.

## What changed

- `agent-core-v2`: `ContextMessage` gains an `inherited` flag; `AgentLifecycleService.fork` marks the messages it seeds into the child as `inherited: true` (LLM context is unchanged — the child still sees the inherited conversation). `reduceContextTranscript` preserves the flag.
- `kap-server`: `readColdSnapshot` excludes inherited messages from the transcript snapshot projection, so a fork's transcript contains only its own turns, ordinals stay contiguous from 0 and match the live projection, and prompt/response pairing heals correctly on backfill.
- Tests: fork seeding marks messages inherited (agent-core-v2); cold snapshot excludes inherited turns and keeps prompt/answer pairing (kap-server); live + backfill merge yields exactly one turn with the fork's own prompt and answer, no inherited turns, no duplicate empty frames (kap-server).

Note: wire logs written before this fix carry no `inherited` marker, so transcripts of forks created by older versions are not repaired retroactively.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
