### PR TITLE
fix(agent-core-v2): treat reason-less turn cancels as programmatic aborts

### DIFF
--- a/.changeset/fix-headless-shutdown-interruption-reminder.md
+++ b/.changeset/fix-headless-shutdown-interruption-reminder.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix headless runs recording a false "previous turn was interrupted by the user" note into session history on exit.

--- a/.changeset/fix-headless-shutdown-interruption-reminder.md
+++ b/.changeset/fix-headless-shutdown-interruption-reminder.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Fix headless runs recording a false "previous turn was interrupted by the user" note into session history on exit.

--- a/apps/kimi-code/src/cli/v2/run-v2-print.ts
+++ b/apps/kimi-code/src/cli/v2/run-v2-print.ts
@@ -979,7 +979,7 @@ function collectSessionAgentHandles(
  * Stop producers, drain prompts, and cancel turns so closing records exist
  * before the wire flush; returns a release holding a guard per loop.
  */
-async function quiesceSessionAgents(
+export async function quiesceSessionAgents(
   session: ISessionScopeHandle,
   mainAgent: IAgentScopeHandle,
 ): Promise<(() => void) | undefined> {
@@ -1013,11 +1013,17 @@ async function quiesceSessionAgents(
   );
   // Repeat until every queue is empty and every loop freezable: a prompt can
   // still surface from the launch window or a cancelled turn's settle chain.
+  // Shutdown cancellation is programmatic, not a user interruption: pass an
+  // explicit reason so straggler turns end as 'aborted' and do not record the
+  // interruption reminder. Constructed locally (AbortError shape) rather than
+  // imported from the engine, keeping this file's dependency surface unchanged.
+  const shutdownReason = new Error('Session closed');
+  shutdownReason.name = 'AbortError';
   for (;;) {
-    await Promise.allSettled(promptServices.map((service) => service.drain()));
+    await Promise.allSettled(promptServices.map((service) => service.drain(shutdownReason)));
     for (const loop of loops) {
-      for (const queueId of loop.status().pendingPromptIds) loop.cancelQueued(queueId);
-      loop.cancel();
+      for (const queueId of loop.status().pendingPromptIds) loop.cancelQueued(queueId, shutdownReason);
+      loop.cancel(undefined, shutdownReason);
     }
     await Promise.allSettled(loops.map((loop) => loop.settled()));
     const guards: { dispose(): void }[] = [];

--- a/apps/kimi-code/test/cli/run-v2-print.test.ts
+++ b/apps/kimi-code/test/cli/run-v2-print.test.ts
@@ -1,4 +1,12 @@
-import { PRINT_WAIT_CEILING_S_DEFAULT } from '@moonshot-ai/agent-core-v2';
+import {
+  IAgentLifecycleService,
+  IAgentLoopService,
+  IAgentPromptService,
+  IAgentTaskService,
+  PRINT_WAIT_CEILING_S_DEFAULT,
+  type IAgentScopeHandle,
+  type ISessionScopeHandle,
+} from '@moonshot-ai/agent-core-v2';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -6,6 +14,7 @@ import {
   createPrintTurnEndings,
   formatTrustGatedMcpWarning,
   PrintSteeredTurnFailedError,
+  quiesceSessionAgents,
   type PrintTurnEnding,
   type PrintTurnEndings,
 } from '#/cli/v2/run-v2-print';
@@ -518,5 +527,66 @@ describe('formatTrustGatedMcpWarning', () => {
     ]);
     expect(text).toContain('skipped 2 project-level MCP servers:');
     expect(text).toContain('api (http: https://example.com/mcp), fs (stdio: node server.js)');
+  });
+});
+
+describe('quiesceSessionAgents', () => {
+  it('cancels stragglers with a programmatic shutdown reason, not a user cancellation', async () => {
+    const drain = vi.fn(async (_reason?: unknown) => {});
+    const cancelQueued = vi.fn((_queueId?: unknown, _reason?: unknown) => true);
+    const cancel = vi.fn((_turnId?: unknown, _reason?: unknown) => true);
+    const disposeGuard = vi.fn();
+    const stopAllOnExit = vi.fn(async () => {});
+    const services = new Map<unknown, unknown>([
+      [IAgentTaskService, { stopAllOnExit }],
+      [
+        IAgentPromptService,
+        { drain, list: () => ({ launching: false, active: undefined, pending: [] }) },
+      ],
+      [
+        IAgentLoopService,
+        {
+          status: () => ({ pendingPromptIds: ['q1'] }),
+          cancelQueued,
+          cancel,
+          settled: () => Promise.resolve(),
+          tryAcquireQuiescence: () => ({ dispose: disposeGuard }),
+        },
+      ],
+    ]);
+    const mainAgent = {
+      accessor: {
+        get: (token: unknown) => {
+          const service = services.get(token);
+          if (service === undefined) throw new Error('unknown service');
+          return service;
+        },
+      },
+    } as unknown as IAgentScopeHandle;
+    const session = {
+      accessor: {
+        get: (token: unknown) => {
+          if (token === IAgentLifecycleService) {
+            return { list: () => [], handleOf: () => undefined };
+          }
+          throw new Error('unknown service');
+        },
+      },
+    } as unknown as ISessionScopeHandle;
+
+    const release = await quiesceSessionAgents(session, mainAgent);
+
+    expect(stopAllOnExit).toHaveBeenCalledWith('Session closed');
+    expect(drain).toHaveBeenCalledTimes(1);
+    const reason = drain.mock.calls[0]![0] as Error & { userCancelled?: boolean };
+    expect(reason).toBeInstanceOf(Error);
+    expect(reason.name).toBe('AbortError');
+    expect(reason.message).toBe('Session closed');
+    expect(reason.userCancelled).not.toBe(true);
+    expect(cancelQueued).toHaveBeenCalledWith('q1', reason);
+    expect(cancel).toHaveBeenCalledWith(undefined, reason);
+
+    release?.();
+    expect(disposeGuard).toHaveBeenCalled();
   });
 });

--- a/packages/agent-core-v2/src/agent/loop/loopService.ts
+++ b/packages/agent-core-v2/src/agent/loop/loopService.ts
@@ -327,7 +327,7 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
   }
 
   cancel(turnId?: number, reason?: unknown): boolean {
-    const cancellation = reason ?? userCancellationReason();
+    const cancellation = reason ?? abortError('Turn cancelled');
     return this.cancelActiveTurn(turnId, cancellation);
   }
 
@@ -340,7 +340,7 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
   }
 
   private cancelReservation(reservation: TurnReservation, reason?: unknown): boolean {
-    const cancellation = reason ?? userCancellationReason();
+    const cancellation = reason ?? abortError('Turn cancelled');
     if (this.active?.reservation === reservation) {
       return this.cancelActiveTurn(undefined, cancellation);
     }
@@ -363,7 +363,7 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
         trace_id: status.activeTraceId,
       });
     }
-    this.cancel(turnId);
+    this.cancel(turnId, userCancellationReason());
   }
 
   tryAcquireQuiescence(): IDisposable | undefined {

--- a/packages/agent-core-v2/src/agent/prompt/promptService.ts
+++ b/packages/agent-core-v2/src/agent/prompt/promptService.ts
@@ -6,7 +6,7 @@ import { LifecycleScope } from '#/app/scopes';
 import { ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { defineState } from '#/state/state';
 import { extractImageCompressionCaptions, gateImageFormatParts } from '#/agent/media/image-compress';
-import { userCancellationReason } from '#/_base/utils/abort';
+import { abortError } from '#/_base/utils/abort';
 import { IAgentContextMemoryService } from '#/agent/contextMemory/contextMemory';
 import { newMessageId } from '#/agent/contextMemory/messageId';
 import { USER_PROMPT_ORIGIN, type ContextMessage } from '#/agent/contextMemory/types';
@@ -467,7 +467,7 @@ export class AgentPromptService implements IAgentPromptService {
     return selected.map((item) => item.handle);
   }
 
-  abort(promptId: string, reason: Error = userCancellationReason()): boolean {
+  abort(promptId: string, reason: Error = abortError('Prompt cancelled')): boolean {
     if (this.active?.id === promptId) { this.active.turn.cancel(reason); return true; }
     const index = this.pending.findIndex((item) => item.id === promptId);
     if (index < 0) throw new Error2(ErrorCodes.PROMPT_NOT_FOUND, `prompt ${promptId} not found`);
@@ -478,7 +478,7 @@ export class AgentPromptService implements IAgentPromptService {
     return true;
   }
 
-  async drain(reason: Error = userCancellationReason()): Promise<void> {
+  async drain(reason: Error = abortError('Prompt cancelled')): Promise<void> {
     for (const item of this.pending.slice()) this.abort(item.id, reason);
     if (this.active !== undefined) this.abort(this.active.id, reason);
   }

--- a/packages/agent-core-v2/src/app/gateway/gatewayService.ts
+++ b/packages/agent-core-v2/src/app/gateway/gatewayService.ts
@@ -11,6 +11,7 @@ import { ILogService } from '#/_base/log/log';
 import { ISessionManager } from '#/app/sessionManager/sessionManager';
 import { IAgentPromptService } from '#/agent/prompt/prompt';
 import { IAgentLoopService } from '#/agent/loop/loop';
+import { userCancellationReason } from '#/_base/utils/abort';
 
 import { IRestGateway, IWSGateway } from './gateway';
 
@@ -80,7 +81,9 @@ export class RestGateway implements IRestGateway {
     return turn.id === undefined ? undefined : { turn_id: turn.id };
   }
   cancel(sessionId: string, agentId: string, reason?: string): Promise<void> {
-    this.agent(sessionId, agentId).accessor.get(IAgentLoopService).cancel(undefined, reason);
+    this.agent(sessionId, agentId)
+      .accessor.get(IAgentLoopService)
+      .cancel(undefined, reason ?? userCancellationReason());
     return Promise.resolve();
   }
   getStatus(sessionId: string): Promise<unknown> {

--- a/packages/agent-core-v2/src/index.ts
+++ b/packages/agent-core-v2/src/index.ts
@@ -663,6 +663,12 @@ export * from '#/agent/fullCompaction/compactionInstruction';
 export * from '#/agent/llmRequester/llmRequester';
 export * from '#/agent/llmRequester/llmRequesterService';
 export * from '#/agent/llmRequester/llmRequestOps';
+export {
+  abortError,
+  isUserCancellation,
+  UserCancellationError,
+  userCancellationReason,
+} from '#/_base/utils/abort';
 export * from '#/_base/utils/promise';
 export * from '#/_base/utils/retry';
 export * from '#/_base/utils/timer';

--- a/packages/agent-core-v2/test/agent/loop/loop.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/loop.test.ts
@@ -1431,7 +1431,7 @@ describe('interruption reminder', () => {
 
   function cancelOnFirstDelta(): IDisposable {
     return ctx.get(IEventBus).subscribe(AssistantDelta, () => {
-      loop.cancel();
+      loop.cancelFromUser();
     });
   }
 
@@ -1511,7 +1511,10 @@ describe('interruption reminder', () => {
     const subscription = ctx.get(IEventBus).subscribe(AssistantDelta, () => {
       if (cancelled) return;
       cancelled = true;
-      results.push(loop.cancel(), loop.cancel());
+      results.push(
+        loop.cancel(undefined, userCancellationReason()),
+        loop.cancel(undefined, userCancellationReason()),
+      );
     });
     const turn = submitTurn(loop, 'Hello').turn;
     await expect(turn.result).resolves.toMatchObject({ type: 'cancelled' });
@@ -1545,6 +1548,26 @@ describe('interruption reminder', () => {
     });
     expect(interruptionReminders()).toHaveLength(0);
 
+    const cancelRecord = ctx.allEvents.find(
+      (entry) => entry.type === '[wire]' && entry.event === 'turn.cancel',
+    );
+    expect(cancelRecord?.args).toMatchObject({ target: 'active', reason: 'aborted' });
+    const turnEnded = ctx.allEvents.find(
+      (entry) => entry.type === '[rpc]' && entry.event === 'turn.ended',
+    );
+    expect(turnEnded?.args).toMatchObject({ reason: 'cancelled', interruptReason: 'aborted' });
+  });
+
+  it('treats a reason-less cancel as a programmatic abort', async () => {
+    ctx.mockNextResponse({ type: 'text', text: 'partial answer' });
+    const subscription = ctx.get(IEventBus).subscribe(AssistantDelta, () => {
+      loop.cancel();
+    });
+    const turn = submitTurn(loop, 'Hello').turn;
+    await expect(turn.result).resolves.toMatchObject({ type: 'cancelled' });
+    subscription.dispose();
+
+    expect(interruptionReminders()).toHaveLength(0);
     const cancelRecord = ctx.allEvents.find(
       (entry) => entry.type === '[wire]' && entry.event === 'turn.cancel',
     );
@@ -1598,11 +1621,11 @@ describe('interruption reminder', () => {
 
     const active = submitTurn(loop, 'active').turn;
     const queued = submitTurn(loop, 'queued').turn;
-    expect(queued.cancel()).toBe(true);
+    expect(queued.cancel(userCancellationReason())).toBe(true);
     await expect(queued.result).resolves.toMatchObject({ type: 'cancelled', steps: 0 });
     await entered;
     release();
-    loop.cancel(active.id);
+    loop.cancelFromUser(active.id);
     await expect(active.result).resolves.toMatchObject({ type: 'cancelled' });
 
     expect(interruptionReminders()).toHaveLength(1);
@@ -1655,7 +1678,7 @@ describe('interruption reminder', () => {
   it('drops unsigned thinking but keeps signed thinking on user cancel', async () => {
     ctx.mockNextResponse({ type: 'think', think: 'pondering' }, { type: 'text', text: 'answer' });
     const subscription = ctx.get(IEventBus).subscribe(ThinkingDelta, () => {
-      loop.cancel();
+      loop.cancelFromUser();
     });
     const turn = submitTurn(loop, 'Hello').turn;
     await expect(turn.result).resolves.toMatchObject({ type: 'cancelled' });
@@ -1673,7 +1696,7 @@ describe('interruption reminder', () => {
       { type: 'text', text: 'partial answer' },
     );
     const second = ctx.get(IEventBus).subscribe(AssistantDelta, () => {
-      loop.cancel();
+      loop.cancelFromUser();
     });
     const secondTurn = submitTurn(loop, 'Again').turn;
     await expect(secondTurn.result).resolves.toMatchObject({ type: 'cancelled' });
@@ -1715,7 +1738,7 @@ describe('interruption reminder', () => {
 
     ctx.mockNextResponse({ type: 'text', text: 'retried answer' });
     const onStepStarted = ctx.get(IEventBus).subscribe(TurnStepStarted, () => {
-      loop.cancel();
+      loop.cancelFromUser();
     });
     const retryTurn = loop.submit({
       message: { role: 'user', content: [], toolCalls: [], origin: { kind: 'retry' } },
@@ -1770,8 +1793,8 @@ describe('interruption reminder', () => {
       );
       const turn = submitTurn(localLoop, 'do work').turn;
       await slowToolStarted.promise;
-      localLoop.cancel(turn.id);
-      localLoop.cancel(turn.id);
+      localLoop.cancelFromUser(turn.id);
+      localLoop.cancelFromUser(turn.id);
       await expect(turn.result).resolves.toMatchObject({ type: 'cancelled' });
 
       expect(contentPartRecordsIn(local)).toBe(2);

--- a/packages/agent-core-v2/test/agent/loop/stubs.ts
+++ b/packages/agent-core-v2/test/agent/loop/stubs.ts
@@ -1,5 +1,6 @@
 import { toDisposable } from '#/_base/di/lifecycle';
 import { Event } from '#/_base/event';
+import { userCancellationReason } from '#/_base/utils/abort';
 import type { IAgentLoopService, LoopErrorHandler, LoopErrorHandlerRegistrationOptions, LoopNotify, LoopNotifyHandle, LoopPromptSubmit, Turn, TurnResult } from '#/agent/loop/loop';
 import type { IAgentToolExecutorService } from '#/agent/toolExecutor/toolExecutor';
 import type { BeforeToolExecuteEvent, ToolDidExecuteContext, WillExecuteToolEvent } from '#/agent/toolExecutor/toolHooks';
@@ -88,7 +89,7 @@ export function stubLoopWithHooks(options: StubLoopOptions = {}): StubLoop {
     activitySnapshot() { return {}; },
     cancel(turnId, reason) { cancels.push({ turnId, reason }); if (active === undefined || (turnId !== undefined && active.id !== turnId)) return false; active.cancel(reason); return true; },
     cancelQueued() { return false; },
-    cancelFromUser(turnId) { stub.cancel(turnId); },
+    cancelFromUser(turnId) { stub.cancel(turnId, userCancellationReason()); },
     tryAcquireQuiescence: () => toDisposable(() => {}),
     hasPendingRequests: hasPending,
     registerLoopErrorHandler: errorHandlers.register,

--- a/packages/kap-server/src/routes/prompts.ts
+++ b/packages/kap-server/src/routes/prompts.ts
@@ -32,6 +32,7 @@ import {
   Error2,
   ErrorCodes,
   sessionMediaOriginalsDir,
+  userCancellationReason,
   type ISessionScopeHandle,
   type Scope,
 } from '@moonshot-ai/agent-core-v2';
@@ -457,7 +458,7 @@ const promptActions: ActionTable<'abort' | 'steer', PromptActionExtra> = {
 
 async function abortPromptAction(ctx: PromptActionCtx): Promise<void> {
   const { resolved, session_id, req, reply, id } = ctx;
-  resolved.prompt.abort(id);
+  resolved.prompt.abort(id, userCancellationReason());
   requestLog(req)?.info({ session_id, prompt_id: id }, 'prompt aborted');
   reply.send(okEnvelope({ aborted: true }, req.id));
 }


### PR DESCRIPTION
## Related Issue

N/A — internal investigation (no linked issue).

## Problem

Reason-less programmatic cancels were misclassified as user interruptions. The engine's `loop.cancel()` / `cancelQueued()` / `promptService.abort()` / `drain()` all defaulted to a user-cancellation reason, so any programmatic caller that forgot to pass one produced `TurnEnded(cancelled, user_cancelled)`. Concretely, headless (`kimi -p`) shutdown cancels straggler turns with that default, which injected a false "The previous turn was interrupted by the user" reminder into those agents' contexts (persisted, then shown to the model on resume) and skewed the `turn_interrupted` telemetry.

## What changed

- Engine default flip: reason-less `loop.cancel()` / `cancelQueued()` / `promptService.abort()` / `drain()` now default to a programmatic `AbortError` instead of a user-cancellation reason. `cancelFromUser()` and the REST gateway pass the user reason explicitly, so genuine user interrupts (Esc, stop button, abort endpoint) are unchanged — verified by the existing interruption-reminder tests.
- CLI: the print-mode shutdown quiesce passes an explicit `'Session closed'` reason to `drain()` / `cancelQueued()` / `cancel()`, consistent with the interactive teardown path (`agentLifecycleService.remove` uses `abortError('Agent removed')`).
- Tests: new coverage pinning that a reason-less `loop.cancel()` ends as `aborted` with no interruption reminder, and that the print-mode quiesce passes a non-user reason; existing tests that simulated user cancels via bare `loop.cancel()` now go through `cancelFromUser()` or an explicit user reason.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`). N/A — internal investigation.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.