### PR TITLE
fix(agent-core-v2): rebuild session and search indexes on storage failures, journal session-index freshness

### DIFF
--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexDirtyJournal.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexDirtyJournal.ts
@@ -1,0 +1,47 @@
+import { IFileSystemStorageService } from '#/persistence/interface/storage';
+
+export const SESSION_INDEX_DIRTY_DIR = '.index-dirty';
+
+const EMPTY = new Uint8Array(0);
+
+function dirtyScope(sessionsScope: string): string {
+  return `${sessionsScope}/${SESSION_INDEX_DIRTY_DIR}`;
+}
+
+export async function markSessionDirty(
+  storage: IFileSystemStorageService,
+  sessionsScope: string,
+  sessionId: string,
+): Promise<void> {
+  await storage.append(dirtyScope(sessionsScope), `${sessionId}.${Date.now()}`, EMPTY, {
+    durable: false,
+  });
+}
+
+export async function listDirtyMarks(
+  storage: IFileSystemStorageService,
+  sessionsScope: string,
+): Promise<readonly string[]> {
+  return storage.list(dirtyScope(sessionsScope));
+}
+
+export function dirtyMarkSessionIds(marks: readonly string[]): Set<string> {
+  const ids = new Set<string>();
+  for (const name of marks) {
+    const dot = name.lastIndexOf('.');
+    if (dot > 0) ids.add(name.slice(0, dot));
+  }
+  return ids;
+}
+
+export async function clearDirtyMarks(
+  storage: IFileSystemStorageService,
+  sessionsScope: string,
+  marks: readonly string[],
+): Promise<void> {
+  await Promise.all(
+    marks.map((name) =>
+      storage.delete(dirtyScope(sessionsScope), name).catch(() => undefined),
+    ),
+  );
+}

--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexMirrorService.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexMirrorService.ts
@@ -168,18 +168,26 @@ export class SessionIndexMirror extends Disposable implements ISessionIndexMirro
       for (const [id, summary] of chunk) {
         if (this.pendingMap.get(id) === summary) this.pendingMap.delete(id);
       }
+      if (this.consecutiveFailures > 0) {
+        this.log.info('session index mirror flush recovered', {
+          afterFailures: this.consecutiveFailures,
+          pending: this.pendingMap.size,
+        });
+      }
       this.consecutiveFailures = 0;
       this.giveUpTracked = false;
     } catch (error) {
       this.consecutiveFailures += 1;
-      this.log.warn('failed to flush session index mirror chunk', {
-        pending: this.pendingMap.size,
-        failures: this.consecutiveFailures,
-        error: String(error),
-      });
+      if (this.consecutiveFailures === 1) {
+        this.log.warn('failed to flush session index mirror chunk', {
+          pending: this.pendingMap.size,
+          error: String(error),
+        });
+      }
       if (this.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
         this.log.warn('session index mirror giving up until the next record; reconciliation will heal', {
           pending: this.pendingMap.size,
+          failures: this.consecutiveFailures,
         });
         if (!this.giveUpTracked) {
           this.giveUpTracked = true;

--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexMirrorService.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexMirrorService.ts
@@ -3,12 +3,15 @@ import { LifecycleScope } from '#/app/scopes';
 import { ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { ILogService } from '#/_base/log/log';
 import { IntervalTimer } from '#/_base/utils/timer';
+import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { IConfigService } from '#/app/config/config';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
 import { databaseBaseEnabled } from '#/persistence/configSection';
 import { IQueryStore } from '#/persistence/interface/queryStore';
+import { IFileSystemStorageService } from '#/persistence/interface/storage';
 
 import { ISessionIndexMirror, type SessionSummary } from './sessionIndex';
+import { markSessionDirty } from './sessionIndexDirtyJournal';
 import {
   SESSION_INDEX_MANIFEST,
   recencyColumn,
@@ -33,24 +36,31 @@ export class SessionIndexMirror extends Disposable implements ISessionIndexMirro
   declare readonly _serviceBrand: undefined;
 
   private readonly pendingMap = new Map<string, SessionSummary>();
+  private readonly pendingMarks = new Set<Promise<void>>();
   private readonly timer = this._register(new IntervalTimer({ unref: true }));
   private flushing: Promise<void> | undefined;
   private consecutiveFailures = 0;
   private giveUpTracked = false;
   private disposed = false;
   private overflowLogged = false;
+  private readonly sessionsScope: string;
 
   constructor(
     @IQueryStore private readonly queryStore: IQueryStore,
     @IConfigService private readonly config: IConfigService,
     @ITelemetryService private readonly telemetry: ITelemetryService,
     @ILogService private readonly log: ILogService,
+    @IFileSystemStorageService private readonly storage: IFileSystemStorageService,
+    @IBootstrapService bootstrap: IBootstrapService,
   ) {
     super();
+    this.sessionsScope = bootstrap.scope('sessions');
     this._register(
       toDisposable(() => {
         this.disposed = true;
-        const pending = this.drain().catch(() => {});
+        const pending = Promise.all(this.pendingMarks)
+          .catch(() => {})
+          .then(() => this.drain().catch(() => {}));
         pendingDrains.add(pending);
         void pending.finally(() => pendingDrains.delete(pending));
       }),
@@ -58,7 +68,13 @@ export class SessionIndexMirror extends Disposable implements ISessionIndexMirro
   }
 
   record(summary: SessionSummary): void {
-    if (this.disposed || !databaseBaseEnabled(this.config)) return;
+    if (this.disposed) return;
+    const mark = markSessionDirty(this.storage, this.sessionsScope, summary.id).catch((error) => {
+      this.log.debug('session index dirty mark failed', { error: String(error) });
+    });
+    this.pendingMarks.add(mark);
+    void mark.finally(() => this.pendingMarks.delete(mark));
+    if (!databaseBaseEnabled(this.config)) return;
     if (this.pendingMap.size >= MAX_PENDING && !this.pendingMap.has(summary.id)) {
       if (!this.overflowLogged) {
         this.overflowLogged = true;

--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexModel.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexModel.ts
@@ -2,6 +2,8 @@ import type { SessionSummary } from './sessionIndex';
 
 export const SESSION_INDEX_MANIFEST = 'sessionIndex';
 
+export const SESSION_INDEX_SCHEMA_VERSION = 1;
+
 export const PARENT_INDEX_NAME = 'byParent';
 
 export interface SessionWorkspaceCounts {

--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexModel.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexModel.ts
@@ -2,7 +2,7 @@ import type { SessionSummary } from './sessionIndex';
 
 export const SESSION_INDEX_MANIFEST = 'sessionIndex';
 
-export const SESSION_INDEX_SCHEMA_VERSION = 1;
+export const SESSION_INDEX_SCHEMA_VERSION = 2;
 
 export const PARENT_INDEX_NAME = 'byParent';
 

--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexProjector.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexProjector.ts
@@ -51,6 +51,7 @@ export interface AuthoritativeScan {
   readonly summaries: SessionSummary[];
   readonly counts: Map<string, { active: number; archived: number }>;
   readonly sourceMaxMtimeMs: number;
+  readonly sourceSessionCount: number;
 }
 
 interface ScanSlot {
@@ -106,6 +107,7 @@ export class SessionIndexProjector {
     scan: Promise<AuthoritativeScan>,
   ): Promise<ProjectionResult> {
     const { queryStore, log } = this.deps;
+    const epoch = queryStore.storeEpoch();
     const collection = sessionCollection(generation);
     const counters = sessionCountersCollection(generation);
     await queryStore.dropCollection(collection);
@@ -116,7 +118,7 @@ export class SessionIndexProjector {
       field: `custom.${PARENT_SESSION_ID_KEY}`,
     });
 
-    const { summaries, counts, sourceMaxMtimeMs } = await scan;
+    const { summaries, counts, sourceMaxMtimeMs, sourceSessionCount } = await scan;
     await this.batchChunks(
       summaries.map((summary) => ({
         kind: 'put' as const,
@@ -127,12 +129,16 @@ export class SessionIndexProjector {
       })),
     );
     await this.writeCounters(counters, counts);
-    await queryStore.setCheckpoint(SESSION_INDEX_MANIFEST, {
-      seq: generation,
-      sourceMaxMtimeMs,
-      sourceSessionCount: summaries.length,
-      schemaVersion: SESSION_INDEX_SCHEMA_VERSION,
-    });
+    await queryStore.setCheckpoint(
+      SESSION_INDEX_MANIFEST,
+      {
+        seq: generation,
+        sourceMaxMtimeMs,
+        sourceSessionCount,
+        schemaVersion: SESSION_INDEX_SCHEMA_VERSION,
+      },
+      epoch,
+    );
     log.info('session index generation published', {
       generation,
       sessions: summaries.length,
@@ -156,9 +162,11 @@ export class SessionIndexProjector {
 
   async reconcile(generation: number): Promise<ReconcileResult> {
     const { queryStore, log } = this.deps;
+    const epoch = queryStore.storeEpoch();
     const collection = sessionCollection(generation);
     const counters = sessionCountersCollection(generation);
-    const { summaries, counts, sourceMaxMtimeMs } = await this.scanAuthoritative();
+    const { summaries, counts, sourceMaxMtimeMs, sourceSessionCount } =
+      await this.scanAuthoritative();
     const authoritativeIds = new Set(summaries.map((s) => s.id));
 
     const storedKeys = await queryStore.listKeys(collection);
@@ -188,11 +196,15 @@ export class SessionIndexProjector {
     await this.writeCounters(counters, counts);
     const manifest = await queryStore.getCheckpoint(SESSION_INDEX_MANIFEST);
     if (manifest?.seq === generation) {
-      await queryStore.setCheckpoint(SESSION_INDEX_MANIFEST, {
-        ...manifest,
-        sourceMaxMtimeMs: Math.max(manifest.sourceMaxMtimeMs ?? 0, sourceMaxMtimeMs),
-        sourceSessionCount: summaries.length,
-      });
+      await queryStore.setCheckpoint(
+        SESSION_INDEX_MANIFEST,
+        {
+          ...manifest,
+          sourceMaxMtimeMs: Math.max(manifest.sourceMaxMtimeMs ?? 0, sourceMaxMtimeMs),
+          sourceSessionCount,
+        },
+        epoch,
+      );
     }
     const result = { sessions: summaries.length, upserted: upserts.length, removed: removals.length };
     if (result.upserted > 0 || result.removed > 0) {
@@ -206,8 +218,10 @@ export class SessionIndexProjector {
     const summaries: SessionSummary[] = [];
     const counts = new Map<string, { active: number; archived: number }>();
     let sourceMaxMtimeMs = (await storage.mtime(SESSION_INDEX_SCOPE, SESSION_INDEX_KEY)) ?? 0;
+    let sourceSessionCount = 0;
     for (const workspaceId of await listWorkspaceIds(storage, sessionsScope)) {
       const sessionIds = await listSessionIds(storage, sessionsScope, workspaceId);
+      sourceSessionCount += sessionIds.length;
       const found = await mapBounded(sessionIds, SCAN_CONCURRENCY, async (sessionId) => {
         const mtime = await sessionStateMaxMtime(storage, sessionsScope, workspaceId, sessionId, log);
         if (mtime > sourceMaxMtimeMs) sourceMaxMtimeMs = mtime;
@@ -221,7 +235,7 @@ export class SessionIndexProjector {
       }
       counts.set(workspaceId, entry);
     }
-    return { summaries, counts, sourceMaxMtimeMs };
+    return { summaries, counts, sourceMaxMtimeMs, sourceSessionCount };
   }
 
   private async writeCounters(

--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexProjector.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexProjector.ts
@@ -1,10 +1,14 @@
 import { ILogService } from '#/_base/log/log';
-import { SESSION_INDEX_KEY, SESSION_INDEX_SCOPE } from '#/app/workspace/workspaceAlias';
 import { IAtomicDocumentStore } from '#/persistence/interface/atomicDocumentStore';
 import { IQueryStore, type WriteOp } from '#/persistence/interface/queryStore';
 import { IFileSystemStorageService } from '#/persistence/interface/storage';
 
 import { PARENT_SESSION_ID_KEY, type SessionSummary } from './sessionIndex';
+import {
+  clearDirtyMarks,
+  dirtyMarkSessionIds,
+  listDirtyMarks,
+} from './sessionIndexDirtyJournal';
 import {
   PARENT_INDEX_NAME,
   SESSION_INDEX_MANIFEST,
@@ -20,7 +24,6 @@ import {
   listWorkspaceIds,
   mapBounded,
   readSessionSummary,
-  sessionStateMaxMtime,
   summaryEquals,
 } from './sessionIndexSource';
 
@@ -50,7 +53,6 @@ export interface ReconcileResult {
 export interface AuthoritativeScan {
   readonly summaries: SessionSummary[];
   readonly counts: Map<string, { active: number; archived: number }>;
-  readonly sourceMaxMtimeMs: number;
   readonly sourceSessionCount: number;
 }
 
@@ -118,7 +120,7 @@ export class SessionIndexProjector {
       field: `custom.${PARENT_SESSION_ID_KEY}`,
     });
 
-    const { summaries, counts, sourceMaxMtimeMs, sourceSessionCount } = await scan;
+    const { summaries, counts, sourceSessionCount } = await scan;
     await this.batchChunks(
       summaries.map((summary) => ({
         kind: 'put' as const,
@@ -133,7 +135,6 @@ export class SessionIndexProjector {
       SESSION_INDEX_MANIFEST,
       {
         seq: generation,
-        sourceMaxMtimeMs,
         sourceSessionCount,
         schemaVersion: SESSION_INDEX_SCHEMA_VERSION,
       },
@@ -161,52 +162,118 @@ export class SessionIndexProjector {
   }
 
   async reconcile(generation: number): Promise<ReconcileResult> {
-    const { queryStore, log } = this.deps;
+    const { queryStore, docs, storage, log, sessionsScope } = this.deps;
     const epoch = queryStore.storeEpoch();
     const collection = sessionCollection(generation);
     const counters = sessionCountersCollection(generation);
-    const { summaries, counts, sourceMaxMtimeMs, sourceSessionCount } =
-      await this.scanAuthoritative();
-    const authoritativeIds = new Set(summaries.map((s) => s.id));
+    const marks = await listDirtyMarks(storage, sessionsScope);
+    const changed = dirtyMarkSessionIds(marks);
 
+    const workspaceIds = await listWorkspaceIds(storage, sessionsScope);
+    const authoritative = new Map<string, string>();
+    for (const workspaceId of workspaceIds) {
+      for (const sessionId of await listSessionIds(storage, sessionsScope, workspaceId)) {
+        authoritative.set(sessionId, workspaceId);
+      }
+    }
     const storedKeys = await queryStore.listKeys(collection);
-    const stored = await queryStore.getMany<SessionSummary>(
-      collection,
-      summaries.map((s) => s.id),
-    );
+    const stored = new Set(storedKeys);
+    for (const sessionId of authoritative.keys()) {
+      if (!stored.has(sessionId)) changed.add(sessionId);
+    }
+    for (const key of storedKeys) {
+      if (!authoritative.has(key)) changed.add(key);
+    }
 
+    const olds = await queryStore.getMany<SessionSummary>(collection, [...changed]);
     const upserts: WriteOp[] = [];
-    for (const summary of summaries) {
-      const existing = stored.get(summary.id);
+    const removals: WriteOp[] = [];
+    const applied = new Map<string, SessionSummary>();
+    const removed = new Set<string>();
+    await mapBounded([...changed], SCAN_CONCURRENCY, async (sessionId) => {
+      const workspaceId = authoritative.get(sessionId);
+      const summary =
+        workspaceId === undefined
+          ? undefined
+          : await readSessionSummary(docs, sessionsScope, workspaceId, sessionId);
+      if (summary === undefined) {
+        if (olds.get(sessionId) !== undefined) {
+          removals.push({ kind: 'delete', collection, key: sessionId });
+          removed.add(sessionId);
+        }
+        return;
+      }
+      applied.set(sessionId, summary);
+      const existing = olds.get(sessionId);
       if (existing === undefined || !summaryEquals(existing, summary)) {
         upserts.push({
           kind: 'put',
           collection,
-          key: summary.id,
+          key: sessionId,
           value: withRecencyField(generation, summary),
           columns: { [recencyColumn(generation)]: summary.updatedAt },
         });
       }
-    }
-    const removals: WriteOp[] = storedKeys
-      .filter((key) => !authoritativeIds.has(key))
-      .map((key) => ({ kind: 'delete' as const, collection, key }));
+    });
 
-    await this.batchChunks([...upserts, ...removals]);
-    await this.writeCounters(counters, counts);
+    const deltas = new Map<string, { active: number; archived: number }>();
+    const bump = (workspaceId: string, field: 'active' | 'archived', by: number): void => {
+      const entry = deltas.get(workspaceId) ?? { active: 0, archived: 0 };
+      entry[field] += by;
+      deltas.set(workspaceId, entry);
+    };
+    for (const summary of applied.values()) {
+      const old = olds.get(summary.id);
+      if (old === undefined) {
+        bump(summary.workspaceId, summary.archived ? 'archived' : 'active', 1);
+      } else if (old.workspaceId !== summary.workspaceId) {
+        bump(old.workspaceId, old.archived ? 'archived' : 'active', -1);
+        bump(summary.workspaceId, summary.archived ? 'archived' : 'active', 1);
+      } else if (old.archived !== summary.archived) {
+        bump(summary.workspaceId, old.archived ? 'archived' : 'active', -1);
+        bump(summary.workspaceId, summary.archived ? 'archived' : 'active', 1);
+      }
+    }
+    for (const sessionId of removed) {
+      const old = olds.get(sessionId);
+      if (old !== undefined) bump(old.workspaceId, old.archived ? 'archived' : 'active', -1);
+    }
+    const current = await queryStore.getMany<SessionWorkspaceCounts>(counters, [...deltas.keys()]);
+    const counterOps: WriteOp[] = [...deltas.entries()].map(([workspaceId, delta]) => {
+      const base = current.get(workspaceId) ?? { active: 0, archived: 0 };
+      const value: SessionWorkspaceCounts = {
+        active: Math.max(0, base.active + delta.active),
+        archived: Math.max(0, base.archived + delta.archived),
+      };
+      return { kind: 'put', collection: counters, key: workspaceId, value };
+    });
+    const totals = new Map<string, number>();
+    for (const workspaceId of authoritative.values()) {
+      totals.set(workspaceId, (totals.get(workspaceId) ?? 0) + 1);
+    }
+    for (const key of await queryStore.listKeys(counters)) {
+      if (!totals.has(key)) counterOps.push({ kind: 'delete', collection: counters, key });
+    }
+
+    await this.batchChunks([...upserts, ...removals, ...counterOps]);
     const manifest = await queryStore.getCheckpoint(SESSION_INDEX_MANIFEST);
     if (manifest?.seq === generation) {
       await queryStore.setCheckpoint(
         SESSION_INDEX_MANIFEST,
         {
-          ...manifest,
-          sourceMaxMtimeMs: Math.max(manifest.sourceMaxMtimeMs ?? 0, sourceMaxMtimeMs),
-          sourceSessionCount,
+          seq: generation,
+          sourceSessionCount: authoritative.size,
+          schemaVersion: SESSION_INDEX_SCHEMA_VERSION,
         },
         epoch,
       );
     }
-    const result = { sessions: summaries.length, upserted: upserts.length, removed: removals.length };
+    await clearDirtyMarks(storage, sessionsScope, marks);
+    const result = {
+      sessions: authoritative.size,
+      upserted: upserts.length,
+      removed: removals.length,
+    };
     if (result.upserted > 0 || result.removed > 0) {
       log.info('session index reconciliation repaired drift', { generation, ...result });
     }
@@ -214,19 +281,16 @@ export class SessionIndexProjector {
   }
 
   private async scanAuthoritative(): Promise<AuthoritativeScan> {
-    const { storage, docs, sessionsScope, log } = this.deps;
+    const { storage, docs, sessionsScope } = this.deps;
     const summaries: SessionSummary[] = [];
     const counts = new Map<string, { active: number; archived: number }>();
-    let sourceMaxMtimeMs = (await storage.mtime(SESSION_INDEX_SCOPE, SESSION_INDEX_KEY)) ?? 0;
     let sourceSessionCount = 0;
     for (const workspaceId of await listWorkspaceIds(storage, sessionsScope)) {
       const sessionIds = await listSessionIds(storage, sessionsScope, workspaceId);
       sourceSessionCount += sessionIds.length;
-      const found = await mapBounded(sessionIds, SCAN_CONCURRENCY, async (sessionId) => {
-        const mtime = await sessionStateMaxMtime(storage, sessionsScope, workspaceId, sessionId, log);
-        if (mtime > sourceMaxMtimeMs) sourceMaxMtimeMs = mtime;
-        return readSessionSummary(docs, sessionsScope, workspaceId, sessionId);
-      });
+      const found = await mapBounded(sessionIds, SCAN_CONCURRENCY, async (sessionId) =>
+        readSessionSummary(docs, sessionsScope, workspaceId, sessionId),
+      );
       const entry = counts.get(workspaceId) ?? { active: 0, archived: 0 };
       for (const summary of found) {
         summaries.push(summary);
@@ -235,7 +299,7 @@ export class SessionIndexProjector {
       }
       counts.set(workspaceId, entry);
     }
-    return { summaries, counts, sourceMaxMtimeMs, sourceSessionCount };
+    return { summaries, counts, sourceSessionCount };
   }
 
   private async writeCounters(

--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexProjector.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexProjector.ts
@@ -130,6 +130,7 @@ export class SessionIndexProjector {
     await queryStore.setCheckpoint(SESSION_INDEX_MANIFEST, {
       seq: generation,
       sourceMaxMtimeMs,
+      sourceSessionCount: summaries.length,
       schemaVersion: SESSION_INDEX_SCHEMA_VERSION,
     });
     log.info('session index generation published', {
@@ -190,6 +191,7 @@ export class SessionIndexProjector {
       await queryStore.setCheckpoint(SESSION_INDEX_MANIFEST, {
         ...manifest,
         sourceMaxMtimeMs: Math.max(manifest.sourceMaxMtimeMs ?? 0, sourceMaxMtimeMs),
+        sourceSessionCount: summaries.length,
       });
     }
     const result = { sessions: summaries.length, upserted: upserts.length, removed: removals.length };

--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexProjector.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexProjector.ts
@@ -8,6 +8,7 @@ import { PARENT_SESSION_ID_KEY, type SessionSummary } from './sessionIndex';
 import {
   PARENT_INDEX_NAME,
   SESSION_INDEX_MANIFEST,
+  SESSION_INDEX_SCHEMA_VERSION,
   recencyColumn,
   sessionCollection,
   sessionCountersCollection,
@@ -129,6 +130,7 @@ export class SessionIndexProjector {
     await queryStore.setCheckpoint(SESSION_INDEX_MANIFEST, {
       seq: generation,
       sourceMaxMtimeMs,
+      schemaVersion: SESSION_INDEX_SCHEMA_VERSION,
     });
     log.info('session index generation published', {
       generation,
@@ -186,7 +188,7 @@ export class SessionIndexProjector {
     const manifest = await queryStore.getCheckpoint(SESSION_INDEX_MANIFEST);
     if (manifest?.seq === generation) {
       await queryStore.setCheckpoint(SESSION_INDEX_MANIFEST, {
-        seq: generation,
+        ...manifest,
         sourceMaxMtimeMs: Math.max(manifest.sourceMaxMtimeMs ?? 0, sourceMaxMtimeMs),
       });
     }

--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexService.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexService.ts
@@ -31,6 +31,7 @@ import {
   type SessionListQuery,
   type SessionSummary,
 } from './sessionIndex';
+import { markSessionDirty } from './sessionIndexDirtyJournal';
 import {
   PARENT_INDEX_NAME,
   SESSION_INDEX_MANIFEST,
@@ -181,12 +182,10 @@ export class FileSessionIndex extends Disposable implements ISessionIndex {
   }
 
   private async manifestFresh(manifest: Checkpoint): Promise<boolean> {
-    const published = manifest.sourceMaxMtimeMs;
-    const publishedCount = manifest.sourceSessionCount;
-    if (published === undefined || publishedCount === undefined) return false;
+    if (manifest.sourceSessionCount === undefined) return false;
     try {
-      const scan = await scanSessionsFreshness(this.storage, this.sessionsScope, this.log);
-      return scan.maxMtimeMs <= published && scan.sessionCount === publishedCount;
+      const scan = await scanSessionsFreshness(this.storage, this.sessionsScope);
+      return scan.dirtyMarkCount === 0 && scan.sessionCount === manifest.sourceSessionCount;
     } catch (error) {
       this.log.warn('session index freshness check failed; treating the index as stale', {
         error: String(error),
@@ -348,6 +347,11 @@ export class FileSessionIndex extends Disposable implements ISessionIndex {
       },
       () => Promise.resolve(),
     );
+    try {
+      await markSessionDirty(this.storage, this.sessionsScope, id);
+    } catch (error) {
+      this.log.warn('session index dirty mark failed', { error: String(error) });
+    }
   }
 
   private async withReadModel<T>(

--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexService.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexService.ts
@@ -46,7 +46,7 @@ import {
   listSessionIds,
   listWorkspaceIds,
   readSessionSummary,
-  scanSessionsMaxMtime,
+  scanSessionsFreshness,
   summaryMatchesChildOf,
 } from './sessionIndexSource';
 
@@ -182,9 +182,11 @@ export class FileSessionIndex extends Disposable implements ISessionIndex {
 
   private async manifestFresh(manifest: Checkpoint): Promise<boolean> {
     const published = manifest.sourceMaxMtimeMs;
-    if (published === undefined) return false;
+    const publishedCount = manifest.sourceSessionCount;
+    if (published === undefined || publishedCount === undefined) return false;
     try {
-      return (await scanSessionsMaxMtime(this.storage, this.sessionsScope, this.log)) <= published;
+      const scan = await scanSessionsFreshness(this.storage, this.sessionsScope, this.log);
+      return scan.maxMtimeMs <= published && scan.sessionCount === publishedCount;
     } catch (error) {
       this.log.warn('session index freshness check failed; treating the index as stale', {
         error: String(error),

--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexService.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexService.ts
@@ -34,6 +34,7 @@ import {
 import {
   PARENT_INDEX_NAME,
   SESSION_INDEX_MANIFEST,
+  SESSION_INDEX_SCHEMA_VERSION,
   recencyColumn,
   sessionCollection,
   sessionCountersCollection,
@@ -79,6 +80,7 @@ export class FileSessionIndex extends Disposable implements ISessionIndex {
   private statusReason: string | undefined;
   private degradedCount = 0;
   private nextPrepareRetryAt = 0;
+  private lastDegradedKey: string | undefined;
   private prepareFlight: Promise<SessionIndexStatus> | undefined;
   private projectFlight: Promise<void> | undefined;
   private readonly reconcileTimer = this._register(new IntervalTimer({ unref: true }));
@@ -132,7 +134,7 @@ export class FileSessionIndex extends Disposable implements ISessionIndex {
     this.state = 'preparing';
     try {
       const manifest = await this.queryStore.getCheckpoint(SESSION_INDEX_MANIFEST);
-      if (manifest === undefined || !(await this.manifestFresh(manifest))) {
+      if (manifest === undefined || manifest.schemaVersion !== SESSION_INDEX_SCHEMA_VERSION) {
         const projection = this.ensureProjection();
         if (deadlineMs === undefined) {
           await projection;
@@ -147,6 +149,25 @@ export class FileSessionIndex extends Disposable implements ISessionIndex {
       } else {
         this.generation = manifest.seq;
         await this.ensureSchema(manifest.seq);
+        if (!(await this.manifestFresh(manifest))) {
+          try {
+            const reconciliation = this.projector.reconcile(manifest.seq);
+            if (deadlineMs === undefined) {
+              await reconciliation;
+            } else {
+              await Promise.race([
+                reconciliation,
+                new Promise((resolve) => {
+                  setTimeout(resolve, deadlineMs);
+                }),
+              ]);
+            }
+          } catch (error) {
+            this.log.warn('session index startup reconciliation failed; serving the published generation', {
+              error: String(error),
+            });
+          }
+        }
       }
       const published = await this.queryStore.getCheckpoint(SESSION_INDEX_MANIFEST);
       if (published !== undefined) {
@@ -165,7 +186,7 @@ export class FileSessionIndex extends Disposable implements ISessionIndex {
     try {
       return (await scanSessionsMaxMtime(this.storage, this.sessionsScope, this.log)) <= published;
     } catch (error) {
-      this.log.warn('session index freshness check failed; re-projecting', {
+      this.log.warn('session index freshness check failed; treating the index as stale', {
         error: String(error),
       });
       return false;
@@ -241,6 +262,7 @@ export class FileSessionIndex extends Disposable implements ISessionIndex {
         return;
       }
       this.generation = manifest.seq;
+      if (await this.manifestFresh(manifest)) return;
       await this.projector.reconcile(manifest.seq);
     } catch (error) {
       this.log.warn('session index reconciliation failed', { error: String(error) });
@@ -248,8 +270,12 @@ export class FileSessionIndex extends Disposable implements ISessionIndex {
   }
 
   private markReady(): void {
+    if (this.state === 'degraded') {
+      this.log.info('session index read model recovered', { degradedCount: this.degradedCount });
+    }
     this.state = 'ready';
     this.statusReason = undefined;
+    this.lastDegradedKey = undefined;
     this.ensureReconcileTimer();
   }
 
@@ -261,6 +287,9 @@ export class FileSessionIndex extends Disposable implements ISessionIndex {
     this.ensureReconcileTimer();
     const detail =
       error instanceof Error ? error.message : typeof error === 'string' ? error : undefined;
+    const episodeKey = `${reason}:${detail ?? ''}`;
+    if (episodeKey === this.lastDegradedKey) return;
+    this.lastDegradedKey = episodeKey;
     this.log.warn('session index read model degraded; serving authoritative reads', {
       reason,
       ...(detail !== undefined ? { error: detail } : {}),

--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexService.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexService.ts
@@ -164,6 +164,10 @@ export class FileSessionIndex extends Disposable implements ISessionIndex {
               ]);
             }
           } catch (error) {
+            const published = await this.queryStore
+              .getCheckpoint(SESSION_INDEX_MANIFEST)
+              .catch(() => undefined);
+            if (published === undefined) throw error;
             this.log.warn('session index startup reconciliation failed; serving the published generation', {
               error: String(error),
             });

--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexSource.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexSource.ts
@@ -209,20 +209,27 @@ export async function sessionStateMaxMtime(
   return Math.max(direct ?? 0, nested ?? 0);
 }
 
-export async function scanSessionsMaxMtime(
+export interface SessionsFreshness {
+  readonly maxMtimeMs: number;
+  readonly sessionCount: number;
+}
+
+export async function scanSessionsFreshness(
   storage: IFileSystemStorageService,
   sessionsScope: string,
   log?: ILogService,
-): Promise<number> {
-  let max = (await storage.mtime(SESSION_INDEX_SCOPE, SESSION_INDEX_KEY)) ?? 0;
+): Promise<SessionsFreshness> {
+  let maxMtimeMs = (await storage.mtime(SESSION_INDEX_SCOPE, SESSION_INDEX_KEY)) ?? 0;
+  let sessionCount = 0;
   for (const workspaceId of await listWorkspaceIds(storage, sessionsScope)) {
     const sessionIds = await listSessionIds(storage, sessionsScope, workspaceId);
+    sessionCount += sessionIds.length;
     const mtimes = await mapBounded(sessionIds, MTIME_SCAN_CONCURRENCY, (sessionId) =>
       sessionStateMaxMtime(storage, sessionsScope, workspaceId, sessionId, log),
     );
     for (const mtime of mtimes) {
-      if (mtime > max) max = mtime;
+      if (mtime > maxMtimeMs) maxMtimeMs = mtime;
     }
   }
-  return max;
+  return { maxMtimeMs, sessionCount };
 }

--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexSource.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexSource.ts
@@ -1,17 +1,11 @@
-import { ILogService } from '#/_base/log/log';
-import { SESSION_INDEX_KEY, SESSION_INDEX_SCOPE } from '#/app/workspace/workspaceAlias';
 import { IAtomicDocumentStore } from '#/persistence/interface/atomicDocumentStore';
-import {
-  IFileSystemStorageService,
-  StorageError,
-  StorageErrors,
-} from '#/persistence/interface/storage';
+import { IFileSystemStorageService } from '#/persistence/interface/storage';
 
 import { CHILD_SESSION_KIND, CHILD_SESSION_KIND_KEY, type SessionSummary } from './sessionIndex';
+import { SESSION_INDEX_DIRTY_DIR, listDirtyMarks } from './sessionIndexDirtyJournal';
 
 const META_SCOPE = 'session-meta';
 const META_KEY = 'state.json';
-const MTIME_SCAN_CONCURRENCY = 16;
 
 export function parseTime(value: unknown): number {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
@@ -100,7 +94,7 @@ export async function listWorkspaceIds(
   sessionsScope: string,
 ): Promise<readonly string[]> {
   try {
-    return await storage.list(sessionsScope);
+    return (await storage.list(sessionsScope)).filter((entry) => entry !== SESSION_INDEX_DIRTY_DIR);
   } catch {
     return [];
   }
@@ -176,60 +170,22 @@ export async function mapBounded<T, R>(
   return out;
 }
 
-async function stateFileMtime(
-  storage: IFileSystemStorageService,
-  scope: string,
-  log: ILogService | undefined,
-): Promise<number | undefined> {
-  try {
-    return await storage.mtime(scope, META_KEY);
-  } catch (error) {
-    if (
-      error instanceof StorageError &&
-      error.code === StorageErrors.codes.STORAGE_IO_FAILED &&
-      error.details?.['errno'] === 'ENOTDIR'
-    ) {
-      log?.warn('session index skips a non-directory entry', { path: error.details['path'] });
-      return undefined;
-    }
-    throw error;
-  }
-}
-
-export async function sessionStateMaxMtime(
-  storage: IFileSystemStorageService,
-  sessionsScope: string,
-  workspaceId: string,
-  sessionId: string,
-  log?: ILogService,
-): Promise<number> {
-  const base = `${sessionsScope}/${workspaceId}/${sessionId}`;
-  const direct = await stateFileMtime(storage, base, log);
-  const nested = await stateFileMtime(storage, `${base}/${META_SCOPE}`, log);
-  return Math.max(direct ?? 0, nested ?? 0);
-}
-
 export interface SessionsFreshness {
-  readonly maxMtimeMs: number;
+  readonly dirtyMarkCount: number;
   readonly sessionCount: number;
 }
 
 export async function scanSessionsFreshness(
   storage: IFileSystemStorageService,
   sessionsScope: string,
-  log?: ILogService,
 ): Promise<SessionsFreshness> {
-  let maxMtimeMs = (await storage.mtime(SESSION_INDEX_SCOPE, SESSION_INDEX_KEY)) ?? 0;
+  const [marks, workspaceIds] = await Promise.all([
+    listDirtyMarks(storage, sessionsScope),
+    listWorkspaceIds(storage, sessionsScope),
+  ]);
   let sessionCount = 0;
-  for (const workspaceId of await listWorkspaceIds(storage, sessionsScope)) {
-    const sessionIds = await listSessionIds(storage, sessionsScope, workspaceId);
-    sessionCount += sessionIds.length;
-    const mtimes = await mapBounded(sessionIds, MTIME_SCAN_CONCURRENCY, (sessionId) =>
-      sessionStateMaxMtime(storage, sessionsScope, workspaceId, sessionId, log),
-    );
-    for (const mtime of mtimes) {
-      if (mtime > maxMtimeMs) maxMtimeMs = mtime;
-    }
+  for (const workspaceId of workspaceIds) {
+    sessionCount += (await listSessionIds(storage, sessionsScope, workspaceId)).length;
   }
-  return { maxMtimeMs, sessionCount };
+  return { dirtyMarkCount: marks.length, sessionCount };
 }

--- a/packages/agent-core-v2/src/persistence/backends/minidb/miniDbQueryStore.ts
+++ b/packages/agent-core-v2/src/persistence/backends/minidb/miniDbQueryStore.ts
@@ -50,7 +50,8 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
   private readonly dir: string;
   private dbPromise: Promise<ClusterDb> | undefined;
   private rebuildPromise: Promise<void> | undefined;
-  private transientFailures = 0;
+  private transientReadFailures = 0;
+  private transientWriteFailures = 0;
   private storeEpochCounter = 0;
   private readonly ensuredIndexes = new Set<string>();
 
@@ -125,6 +126,7 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
 
   private async withDb<T>(
     op: (db: ClusterDb) => Promise<T>,
+    kind: 'read' | 'write',
     expectedStoreEpoch?: number,
   ): Promise<T> {
     const db = await this.openDb();
@@ -133,14 +135,19 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
     }
     try {
       const result = await op(db);
-      this.transientFailures = 0;
+      if (kind === 'write') this.transientWriteFailures = 0;
+      else this.transientReadFailures = 0;
       return result;
     } catch (error) {
       if (classifyStorageError(error) !== 'rebuild') {
-        this.transientFailures += 1;
-        if (this.transientFailures < TRANSIENT_ESCALATION_LIMIT) throw error;
+        const failures =
+          kind === 'write'
+            ? (this.transientWriteFailures += 1)
+            : (this.transientReadFailures += 1);
+        if (failures < TRANSIENT_ESCALATION_LIMIT) throw error;
       }
-      this.transientFailures = 0;
+      this.transientReadFailures = 0;
+      this.transientWriteFailures = 0;
       await this.rebuild(error);
       if (expectedStoreEpoch !== undefined) throw new QueryStoreRebuiltError();
       throw error;
@@ -153,41 +160,45 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
     value: T,
     options?: { columns?: Record<string, number> },
   ): Promise<void> {
-    await this.withDb((db) =>
-      db.set(physicalKey(collection, key), value, { dt: options?.columns }),
+    await this.withDb(
+      (db) => db.set(physicalKey(collection, key), value, { dt: options?.columns }),
+      'write',
     );
   }
 
   async batch(ops: readonly WriteOp[]): Promise<void> {
     if (ops.length === 0) return;
-    await this.withDb((db) =>
-      db.batch(
-        ops.map((op) =>
-          op.kind === 'put'
-            ? {
-                op: 'set' as const,
-                key: physicalKey(op.collection, op.key),
-                value: op.value,
-                dt: op.columns,
-              }
-            : { op: 'del' as const, key: physicalKey(op.collection, op.key) },
+    await this.withDb(
+      (db) =>
+        db.batch(
+          ops.map((op) =>
+            op.kind === 'put'
+              ? {
+                  op: 'set' as const,
+                  key: physicalKey(op.collection, op.key),
+                  value: op.value,
+                  dt: op.columns,
+                }
+              : { op: 'del' as const, key: physicalKey(op.collection, op.key) },
+          ),
         ),
-      ),
+      'write',
     );
   }
 
   async delete(collection: string, key: string): Promise<void> {
-    await this.withDb((db) => db.del(physicalKey(collection, key)));
+    await this.withDb((db) => db.del(physicalKey(collection, key)), 'write');
   }
 
   async get<T>(collection: string, key: string): Promise<T | undefined> {
-    return this.withDb((db) => db.get(physicalKey(collection, key)) as Promise<T | undefined>);
+    return this.withDb((db) => db.get(physicalKey(collection, key)) as Promise<T | undefined>, 'read');
   }
 
   async getMany<T>(collection: string, keys: readonly string[]): Promise<Map<string, T>> {
     if (keys.length === 0) return new Map();
-    const values = await this.withDb((db) =>
-      db.mget(keys.map((key) => physicalKey(collection, key))),
+    const values = await this.withDb(
+      (db) => db.mget(keys.map((key) => physicalKey(collection, key))),
+      'read',
     );
     const out = new Map<string, T>();
     values.forEach((value, index) => {
@@ -198,36 +209,39 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
 
   async pageByColumn<T>(collection: string, query: ColumnPageQuery): Promise<Page<T>> {
     const dir = query.dir ?? 'asc';
-    const rows = (await this.withDb((db) =>
-      db.query({
-        dt: { [query.column]: query.bounds ?? {} },
-        filter: query.filter as Record<string, unknown> | undefined,
-        sort: { [query.column]: dir === 'desc' ? -1 : 1 },
-        limit: query.limit,
-      }),
+    const rows = (await this.withDb(
+      (db) =>
+        db.query({
+          dt: { [query.column]: query.bounds ?? {} },
+          filter: query.filter as Record<string, unknown> | undefined,
+          sort: { [query.column]: dir === 'desc' ? -1 : 1 },
+          limit: query.limit,
+        }),
+      'read',
     )) as ReadonlyArray<{ value: T }>;
     return { items: rows.map((row) => row.value) };
   }
 
   async listKeys(collection: string): Promise<readonly string[]> {
     const prefix = `${collection}${SEP}`;
-    const entries = await this.withDb((db) => db.scan({ prefix }));
+    const entries = await this.withDb((db) => db.scan({ prefix }), 'read');
     return entries.map((entry) => entry.key.slice(prefix.length));
   }
 
   async dropCollection(collection: string): Promise<void> {
     const prefix = `${collection}${SEP}`;
-    const entries = await this.withDb((db) => db.scan({ prefix }));
+    const entries = await this.withDb((db) => db.scan({ prefix }), 'read');
     for (let start = 0; start < entries.length; start += DROP_BATCH_SIZE) {
       const chunk = entries.slice(start, start + DROP_BATCH_SIZE);
-      await this.withDb((db) =>
-        db.batch(chunk.map((entry) => ({ op: 'del' as const, key: entry.key }))),
+      await this.withDb(
+        (db) => db.batch(chunk.map((entry) => ({ op: 'del' as const, key: entry.key }))),
+        'write',
       );
     }
   }
 
   query<T>(collection: string): IQuery<T> {
-    return new MiniDbQuery<T>((op) => this.withDb(op), collection);
+    return new MiniDbQuery<T>((op) => this.withDb(op, 'read'), collection);
   }
 
   async ensureIndex(collection: string, def: IndexDef): Promise<void> {
@@ -249,7 +263,7 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
       } catch (error) {
         if (!(error instanceof Error) || !error.message.includes('already exists')) throw error;
       }
-    });
+    }, 'write');
     this.ensuredIndexes.add(guard);
   }
 
@@ -264,6 +278,7 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
   ): Promise<void> {
     await this.withDb(
       (db) => db.set(physicalKey(CHECKPOINT_COLLECTION, source), checkpoint),
+      'write',
       expectedStoreEpoch,
     );
   }

--- a/packages/agent-core-v2/src/persistence/backends/minidb/miniDbQueryStore.ts
+++ b/packages/agent-core-v2/src/persistence/backends/minidb/miniDbQueryStore.ts
@@ -2,7 +2,7 @@ import { promises as fsp } from 'node:fs';
 
 import { join } from 'pathe';
 
-import { type QueryOptions } from '@moonshot-ai/minidb';
+import { classifyStorageError, LockError, type QueryOptions } from '@moonshot-ai/minidb';
 import { ClusterDb } from '@moonshot-ai/minidb/cluster';
 
 import { Disposable, toDisposable } from '#/_base/di/lifecycle';
@@ -29,6 +29,7 @@ const STORE_SUBDIR = 'query-store';
 const SHARD_COUNT = 16;
 const LOCK_ACQUIRE_TIMEOUT_MS = 1000;
 const DROP_BATCH_SIZE = 500;
+const TRANSIENT_ESCALATION_LIMIT = 5;
 
 function physicalKey(collection: string, key: string): string {
   return `${collection}${SEP}${key}`;
@@ -36,10 +37,6 @@ function physicalKey(collection: string, key: string): string {
 
 function indexName(collection: string, name: string): string {
   return `${collection}:${name}`;
-}
-
-function isRebuildable(error: unknown): boolean {
-  return error instanceof SyntaxError || (error as { name?: string }).name === 'CorruptFrameError';
 }
 
 const pendingDisposals = new Set<Promise<void>>();
@@ -54,6 +51,7 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
   private readonly dir: string;
   private dbPromise: Promise<ClusterDb> | undefined;
   private rebuildPromise: Promise<void> | undefined;
+  private transientFailures = 0;
   private readonly ensuredIndexes = new Set<string>();
 
   constructor(
@@ -95,7 +93,7 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
 
   private rebuild(cause: unknown): Promise<void> {
     this.rebuildPromise ??= (async () => {
-      this.log.warn('minidb query-store rebuilt after corruption', {
+      this.log.warn('minidb query-store rebuilt after unrecoverable failure', {
         dir: this.dir,
         error: String(cause),
       });
@@ -106,16 +104,45 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
         const db = await previous.catch(() => undefined);
         await db?.close().catch(() => {});
       }
+      let probeError: unknown;
+      try {
+        const probe = await ClusterDb.open({
+          dir: this.dir,
+          shardCount: SHARD_COUNT,
+          valueCodec: 'json',
+          lockAcquireTimeoutMs: LOCK_ACQUIRE_TIMEOUT_MS,
+        });
+        await probe.close().catch(() => {});
+        probeError = undefined;
+      } catch (error) {
+        probeError = error;
+      }
+      if (probeError instanceof LockError) throw cause;
       await fsp.rm(this.dir, { recursive: true, force: true });
     })();
-    return this.rebuildPromise;
+    const settled = this.rebuildPromise;
+    return settled.then(
+      () => {
+        if (this.rebuildPromise === settled) this.rebuildPromise = undefined;
+      },
+      (error: unknown) => {
+        if (this.rebuildPromise === settled) this.rebuildPromise = undefined;
+        throw error;
+      },
+    );
   }
 
   private async withDb<T>(op: (db: ClusterDb) => Promise<T>): Promise<T> {
     try {
-      return await op(await this.openDb());
+      const result = await op(await this.openDb());
+      this.transientFailures = 0;
+      return result;
     } catch (error) {
-      if (!isRebuildable(error)) throw error;
+      if (classifyStorageError(error) !== 'rebuild') {
+        this.transientFailures += 1;
+        if (this.transientFailures < TRANSIENT_ESCALATION_LIMIT) throw error;
+      }
+      this.transientFailures = 0;
       await this.rebuild(error);
       return op(await this.openDb());
     }

--- a/packages/agent-core-v2/src/persistence/backends/minidb/miniDbQueryStore.ts
+++ b/packages/agent-core-v2/src/persistence/backends/minidb/miniDbQueryStore.ts
@@ -10,6 +10,7 @@ import { ILogService } from '#/_base/log/log';
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import {
   IQueryStore,
+  QueryStoreRebuiltError,
   type Checkpoint,
   type ColumnBounds,
   type ColumnPageQuery,
@@ -50,6 +51,7 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
   private dbPromise: Promise<ClusterDb> | undefined;
   private rebuildPromise: Promise<void> | undefined;
   private transientFailures = 0;
+  private storeEpochCounter = 0;
   private readonly ensuredIndexes = new Set<string>();
 
   constructor(
@@ -107,6 +109,7 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
         lockAcquireTimeoutMs: LOCK_ACQUIRE_TIMEOUT_MS,
       });
       if (outcome === 'locked') throw cause;
+      this.storeEpochCounter += 1;
     })();
     const settled = this.rebuildPromise;
     return settled.then(
@@ -120,9 +123,16 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
     );
   }
 
-  private async withDb<T>(op: (db: ClusterDb) => Promise<T>): Promise<T> {
+  private async withDb<T>(
+    op: (db: ClusterDb) => Promise<T>,
+    expectedStoreEpoch?: number,
+  ): Promise<T> {
+    const db = await this.openDb();
+    if (expectedStoreEpoch !== undefined && expectedStoreEpoch !== this.storeEpochCounter) {
+      throw new QueryStoreRebuiltError();
+    }
     try {
-      const result = await op(await this.openDb());
+      const result = await op(db);
       this.transientFailures = 0;
       return result;
     } catch (error) {
@@ -132,7 +142,8 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
       }
       this.transientFailures = 0;
       await this.rebuild(error);
-      return op(await this.openDb());
+      if (expectedStoreEpoch !== undefined) throw new QueryStoreRebuiltError();
+      throw error;
     }
   }
 
@@ -246,8 +257,19 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
     return this.get<Checkpoint>(CHECKPOINT_COLLECTION, source);
   }
 
-  async setCheckpoint(source: string, checkpoint: Checkpoint): Promise<void> {
-    await this.put(CHECKPOINT_COLLECTION, source, checkpoint);
+  async setCheckpoint(
+    source: string,
+    checkpoint: Checkpoint,
+    expectedStoreEpoch?: number,
+  ): Promise<void> {
+    await this.withDb(
+      (db) => db.set(physicalKey(CHECKPOINT_COLLECTION, source), checkpoint),
+      expectedStoreEpoch,
+    );
+  }
+
+  storeEpoch(): number {
+    return this.storeEpochCounter;
   }
 
   async close(): Promise<void> {

--- a/packages/agent-core-v2/src/persistence/backends/minidb/miniDbQueryStore.ts
+++ b/packages/agent-core-v2/src/persistence/backends/minidb/miniDbQueryStore.ts
@@ -1,9 +1,7 @@
-import { promises as fsp } from 'node:fs';
-
 import { join } from 'pathe';
 
-import { classifyStorageError, LockError, type QueryOptions } from '@moonshot-ai/minidb';
-import { ClusterDb } from '@moonshot-ai/minidb/cluster';
+import { classifyStorageError, type QueryOptions } from '@moonshot-ai/minidb';
+import { ClusterDb, wipeCluster } from '@moonshot-ai/minidb/cluster';
 
 import { Disposable, toDisposable } from '#/_base/di/lifecycle';
 import { LifecycleScope } from '#/app/scopes';
@@ -104,21 +102,11 @@ export class MiniDbQueryStore extends Disposable implements IQueryStore {
         const db = await previous.catch(() => undefined);
         await db?.close().catch(() => {});
       }
-      let probeError: unknown;
-      try {
-        const probe = await ClusterDb.open({
-          dir: this.dir,
-          shardCount: SHARD_COUNT,
-          valueCodec: 'json',
-          lockAcquireTimeoutMs: LOCK_ACQUIRE_TIMEOUT_MS,
-        });
-        await probe.close().catch(() => {});
-        probeError = undefined;
-      } catch (error) {
-        probeError = error;
-      }
-      if (probeError instanceof LockError) throw cause;
-      await fsp.rm(this.dir, { recursive: true, force: true });
+      const outcome = await wipeCluster({
+        dir: this.dir,
+        lockAcquireTimeoutMs: LOCK_ACQUIRE_TIMEOUT_MS,
+      });
+      if (outcome === 'locked') throw cause;
     })();
     const settled = this.rebuildPromise;
     return settled.then(

--- a/packages/agent-core-v2/src/persistence/interface/queryStore.ts
+++ b/packages/agent-core-v2/src/persistence/interface/queryStore.ts
@@ -66,7 +66,6 @@ export type WriteOp =
 
 export interface Checkpoint {
   readonly seq: number;
-  readonly sourceMaxMtimeMs?: number;
   readonly sourceSessionCount?: number;
   readonly schemaVersion?: number;
 }

--- a/packages/agent-core-v2/src/persistence/interface/queryStore.ts
+++ b/packages/agent-core-v2/src/persistence/interface/queryStore.ts
@@ -67,6 +67,7 @@ export type WriteOp =
 export interface Checkpoint {
   readonly seq: number;
   readonly sourceMaxMtimeMs?: number;
+  readonly sourceSessionCount?: number;
   readonly schemaVersion?: number;
 }
 

--- a/packages/agent-core-v2/src/persistence/interface/queryStore.ts
+++ b/packages/agent-core-v2/src/persistence/interface/queryStore.ts
@@ -67,6 +67,7 @@ export type WriteOp =
 export interface Checkpoint {
   readonly seq: number;
   readonly sourceMaxMtimeMs?: number;
+  readonly schemaVersion?: number;
 }
 
 export interface ColumnBounds {

--- a/packages/agent-core-v2/src/persistence/interface/queryStore.ts
+++ b/packages/agent-core-v2/src/persistence/interface/queryStore.ts
@@ -71,6 +71,13 @@ export interface Checkpoint {
   readonly schemaVersion?: number;
 }
 
+export class QueryStoreRebuiltError extends Error {
+  constructor() {
+    super('the query-store was rebuilt while the operation was in flight');
+    this.name = 'QueryStoreRebuiltError';
+  }
+}
+
 export interface ColumnBounds {
   readonly gt?: number;
   readonly gte?: number;
@@ -105,7 +112,8 @@ export interface IQueryStore {
   listKeys(collection: string): Promise<readonly string[]>;
   dropCollection(collection: string): Promise<void>;
   getCheckpoint(source: string): Promise<Checkpoint | undefined>;
-  setCheckpoint(source: string, checkpoint: Checkpoint): Promise<void>;
+  setCheckpoint(source: string, checkpoint: Checkpoint, expectedStoreEpoch?: number): Promise<void>;
+  storeEpoch(): number;
   close(): Promise<void>;
 }
 

--- a/packages/agent-core-v2/test/app/sessionIndex/sessionIndex.test.ts
+++ b/packages/agent-core-v2/test/app/sessionIndex/sessionIndex.test.ts
@@ -1355,6 +1355,28 @@ describe('FileSessionIndex (read model)', () => {
     expect(status).toEqual({ state: 'ready', generation: 1, degradedCount: 0 });
     const page = await second.listRecent({ workspaceIds: [workspaceId] });
     expect(page.items.map((s) => s.id)).toEqual(['c', 'b', 'a']);
+
+    const disposeSecond = disposeHost ?? (() => undefined);
+    disposeSecond();
+    disposeHost = undefined;
+    await drainSessionIndexMirror();
+    await drainQueryStoreDisposals();
+
+    await seedSession('d', { title: 'd', createdAt: 4, updatedAt: 5 });
+    const third = build();
+    expect(await queryStore.getCheckpoint(SESSION_INDEX_MANIFEST)).toMatchObject({ seq: 1 });
+    const internal = queryStore as unknown as { dbPromise: Promise<{ batch: unknown }> };
+    const db = await internal.dbPromise;
+    db.batch = () =>
+      Promise.reject(Object.assign(new Error('poisoned'), { code: 'WAL_POISONED' }));
+    const degraded = await third.prepare();
+    expect(degraded.state).toBe('degraded');
+    expect(degraded.reason).toBe('prepare failed');
+
+    const recovered = await third.prepare();
+    expect(recovered.state).toBe('ready');
+    const republished = await third.listRecent({ workspaceIds: [workspaceId] });
+    expect(republished.items.map((s) => s.id)).toEqual(['d', 'c', 'b', 'a']);
   });
 
   it('the periodic tick skips reconciliation while the session directories are unchanged', async () => {

--- a/packages/agent-core-v2/test/app/sessionIndex/sessionIndex.test.ts
+++ b/packages/agent-core-v2/test/app/sessionIndex/sessionIndex.test.ts
@@ -1319,7 +1319,7 @@ describe('FileSessionIndex (read model)', () => {
     expect(docs.gets).toBe(0);
   });
 
-  it('re-projects on the next startup when the session directories changed externally', async () => {
+  it('reconciles the current generation on the next startup when the session directories changed externally', async () => {
     await seedSession('a', { title: 'a', createdAt: 1, updatedAt: 2 });
     await seedSession('b', { title: 'b', createdAt: 2, updatedAt: 3 });
 
@@ -1341,9 +1341,38 @@ describe('FileSessionIndex (read model)', () => {
 
     const second = build();
     const status = await second.prepare();
-    expect(status).toEqual({ state: 'ready', generation: 2, degradedCount: 0 });
+    expect(status).toEqual({ state: 'ready', generation: 1, degradedCount: 0 });
     const page = await second.listRecent({ workspaceIds: [workspaceId] });
     expect(page.items.map((s) => s.id)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('the periodic tick skips reconciliation while the session directories are unchanged', async () => {
+    await seedSession('a', { title: 'a', createdAt: 1, updatedAt: 2 });
+    const store = build();
+    await store.prepare();
+    const internals = store as unknown as {
+      projector: { reconcile(generation: number): Promise<unknown> };
+      tick(): Promise<void>;
+    };
+    let reconciles = 0;
+    const original = internals.projector.reconcile.bind(internals.projector);
+    internals.projector.reconcile = async (generation: number) => {
+      reconciles += 1;
+      return original(generation);
+    };
+
+    await internals.tick();
+    expect(reconciles).toBe(0);
+
+    await seedSession('b', { title: 'b', createdAt: 2, updatedAt: 3 });
+    const future = new Date(Date.now() + 60_000);
+    await fsp.utimes(
+      join(sessionsDir, workspaceId, 'b', 'session-meta', 'state.json'),
+      future,
+      future,
+    );
+    await internals.tick();
+    expect(reconciles).toBe(1);
   });
 
   it('treats a published checkpoint without sourceMaxMtimeMs as stale and re-projects', async () => {

--- a/packages/agent-core-v2/test/app/sessionIndex/sessionIndex.test.ts
+++ b/packages/agent-core-v2/test/app/sessionIndex/sessionIndex.test.ts
@@ -27,6 +27,7 @@ import {
   recencyColumn,
   sessionCollection,
 } from '#/app/sessionIndex/sessionIndexModel';
+import { markSessionDirty } from '#/app/sessionIndex/sessionIndexDirtyJournal';
 import { FileSessionIndex } from '#/app/sessionIndex/sessionIndexService';
 import {
   drainSessionIndexMirror,
@@ -956,6 +957,7 @@ describe('FileSessionIndex (read model)', () => {
     expect(await store.count({ workspaceIds: [workspaceId] })).toBe(3);
 
     await seedSession('keep', { title: 'after', createdAt: 1, updatedAt: 4 });
+    await markSessionDirty(new FileStorageService(homeDir), 'sessions', 'keep');
     await fsp.rm(join(sessionsDir, workspaceId, 'gone'), { recursive: true, force: true });
     await store.reconcileNow();
 
@@ -1296,11 +1298,7 @@ describe('FileSessionIndex (read model)', () => {
     await first.prepare();
     expect(first.status()).toEqual({ state: 'ready', generation: 1, degradedCount: 0 });
     const published = await queryStore.getCheckpoint(SESSION_INDEX_MANIFEST);
-    expect(published).toMatchObject({
-      seq: 1,
-      sourceMaxMtimeMs: expect.any(Number),
-      sourceSessionCount: 3,
-    });
+    expect(published).toMatchObject({ seq: 1, sourceSessionCount: 3 });
     disposeHost?.();
     disposeHost = undefined;
     await drainSessionIndexMirror();
@@ -1351,12 +1349,6 @@ describe('FileSessionIndex (read model)', () => {
     await drainQueryStoreDisposals();
 
     await seedSession('c', { title: 'c', createdAt: 3, updatedAt: 4 });
-    const future = new Date(Date.now() + 60_000);
-    await fsp.utimes(
-      join(sessionsDir, workspaceId, 'c', 'session-meta', 'state.json'),
-      future,
-      future,
-    );
 
     const second = build();
     const status = await second.prepare();
@@ -1384,12 +1376,6 @@ describe('FileSessionIndex (read model)', () => {
     expect(reconciles).toBe(0);
 
     await seedSession('b', { title: 'b', createdAt: 2, updatedAt: 3 });
-    const future = new Date(Date.now() + 60_000);
-    await fsp.utimes(
-      join(sessionsDir, workspaceId, 'b', 'session-meta', 'state.json'),
-      future,
-      future,
-    );
     await internals.tick();
     expect(reconciles).toBe(1);
 
@@ -1409,9 +1395,22 @@ describe('FileSessionIndex (read model)', () => {
     expect(withoutGhost.items.map((s) => s.id)).toEqual(['a']);
     await internals.tick();
     expect(reconciles).toBe(3);
+
+    await seedSession('a', { title: 'a-renamed', createdAt: 1, updatedAt: 4 });
+    await internals.tick();
+    expect(reconciles).toBe(3);
+    expect((await store.get('a'))?.title).toBe('a');
+
+    await markSessionDirty(new FileStorageService(homeDir), 'sessions', 'a');
+    await internals.tick();
+    expect(reconciles).toBe(4);
+    expect((await store.get('a'))?.title).toBe('a-renamed');
+    expect(await fsp.readdir(join(sessionsDir, '.index-dirty'))).toEqual([]);
+    await internals.tick();
+    expect(reconciles).toBe(4);
   });
 
-  it('treats a published checkpoint without sourceMaxMtimeMs as stale and re-projects', async () => {
+  it('re-projects when the published checkpoint predates the current schema version', async () => {
     await seedSession('a', { title: 'a', createdAt: 1, updatedAt: 2 });
 
     const first = build();
@@ -1429,27 +1428,51 @@ describe('FileSessionIndex (read model)', () => {
     expect(page.items.map((s) => s.id)).toEqual(['a']);
   });
 
-  it('reconciliation refreshes the published source max mtime', async () => {
+  it('reconciliation reads only the journaled sessions and refreshes the checkpoint', async () => {
     await seedSession('a', { title: 'a', createdAt: 1, updatedAt: 2 });
+    await seedSession('b', { title: 'b', createdAt: 2, updatedAt: 3 });
+    await seedSession('c', { title: 'c', createdAt: 3, updatedAt: 4 });
 
-    const store = build();
+    class CountingDocs extends JsonAtomicDocumentStore {
+      gets = 0;
+      override async get<T>(scope: string, key: string): Promise<T | undefined> {
+        this.gets += 1;
+        return super.get<T>(scope, key);
+      }
+    }
+    const fileStorage = new FileStorageService(homeDir);
+    const docs = new CountingDocs(fileStorage);
+    const host = createScopedTestHost([
+      stubPair(IFileSystemStorageService, fileStorage),
+      stubPair(IAtomicDocumentStore, docs),
+      stubPair(IBootstrapService, stubBootstrap(homeDir)),
+      stubPair(ILogService, stubLog()),
+      stubPair(IConfigService, stubConfigService({ [DATABASE_SECTION]: { base: true } })),
+      stubPair(ITelemetryService, noopTelemetryService),
+    ]);
+    disposeHost = () => {
+      host.dispose();
+    };
+    queryStore = host.app.accessor.get(IQueryStore);
+    mirror = host.app.accessor.get(ISessionIndexMirror);
+    const store = host.app.accessor.get(ISessionIndex) as FileSessionIndex;
+
     await store.prepare();
-    const published = await queryStore.getCheckpoint(SESSION_INDEX_MANIFEST);
-    expect(published).toMatchObject({ seq: 1, sourceMaxMtimeMs: expect.any(Number) });
+    expect(docs.gets).toBe(6);
+    docs.gets = 0;
 
     await seedSession('a', { title: 'a2', createdAt: 1, updatedAt: 5 });
-    const future = new Date((published?.sourceMaxMtimeMs ?? 0) + 60_000);
-    await fsp.utimes(
-      join(sessionsDir, workspaceId, 'a', 'session-meta', 'state.json'),
-      future,
-      future,
-    );
-
+    await markSessionDirty(fileStorage, 'sessions', 'a');
     await store.reconcileNow();
-    const refreshed = await queryStore.getCheckpoint(SESSION_INDEX_MANIFEST);
-    expect(refreshed?.seq).toBe(1);
-    expect(refreshed?.sourceMaxMtimeMs).toBeGreaterThan(published?.sourceMaxMtimeMs ?? 0);
+
+    expect(docs.gets).toBe(2);
     expect((await store.get('a'))?.title).toBe('a2');
+    expect(await store.listRecent({ workspaceIds: [workspaceId] })).toMatchObject({
+      items: [{ id: 'a' }, { id: 'c' }, { id: 'b' }],
+    });
+    const refreshed = await queryStore.getCheckpoint(SESSION_INDEX_MANIFEST);
+    expect(refreshed).toMatchObject({ seq: 1, sourceSessionCount: 3, schemaVersion: 2 });
+    expect(await fsp.readdir(join(sessionsDir, '.index-dirty'))).toEqual([]);
   });
 
   it('the resume-startup sequence pays one scan: point lookup, projection, then warm lists', async () => {

--- a/packages/agent-core-v2/test/app/sessionIndex/sessionIndex.test.ts
+++ b/packages/agent-core-v2/test/app/sessionIndex/sessionIndex.test.ts
@@ -1281,7 +1281,11 @@ describe('FileSessionIndex (read model)', () => {
     await first.prepare();
     expect(first.status()).toEqual({ state: 'ready', generation: 1, degradedCount: 0 });
     const published = await queryStore.getCheckpoint(SESSION_INDEX_MANIFEST);
-    expect(published).toMatchObject({ seq: 1, sourceMaxMtimeMs: expect.any(Number) });
+    expect(published).toMatchObject({
+      seq: 1,
+      sourceMaxMtimeMs: expect.any(Number),
+      sourceSessionCount: 3,
+    });
     disposeHost?.();
     disposeHost = undefined;
     await drainSessionIndexMirror();
@@ -1373,6 +1377,15 @@ describe('FileSessionIndex (read model)', () => {
     );
     await internals.tick();
     expect(reconciles).toBe(1);
+
+    await fsp.rm(join(sessionsDir, workspaceId, 'b'), { recursive: true, force: true });
+    await internals.tick();
+    expect(reconciles).toBe(2);
+    const remaining = await store.listRecent({ workspaceIds: [workspaceId] });
+    expect(remaining.items.map((s) => s.id)).toEqual(['a']);
+
+    await internals.tick();
+    expect(reconciles).toBe(2);
   });
 
   it('treats a published checkpoint without sourceMaxMtimeMs as stale and re-projects', async () => {

--- a/packages/agent-core-v2/test/app/sessionIndex/sessionIndex.test.ts
+++ b/packages/agent-core-v2/test/app/sessionIndex/sessionIndex.test.ts
@@ -797,16 +797,17 @@ describe('FileSessionIndex (read model)', () => {
     expect(await store.count({ workspaceIds: [workspaceId], includeArchived: true })).toBe(3);
   });
 
-  it('a crashed initial projection falls back to disk and recovers on retry', async () => {
+  it('a crashed or rebuilt mid-flight projection falls back to disk and recovers on retry', async () => {
     await seedSession('a', { title: 'a', createdAt: 1, updatedAt: 2 });
     await seedSession('b', { title: 'b', createdAt: 2, updatedAt: 3 });
 
     class FlakyQueryStore extends MiniDbQueryStore {
       failNextBatch = false;
+      failure: Error = new Error('injected projection crash');
       override async batch(ops: readonly WriteOp[]): Promise<void> {
         if (this.failNextBatch) {
           this.failNextBatch = false;
-          throw new Error('injected projection crash');
+          throw this.failure;
         }
         return super.batch(ops);
       }
@@ -851,6 +852,20 @@ describe('FileSessionIndex (read model)', () => {
     expect(recovered).toEqual({ state: 'ready', generation: 1, degradedCount: 1 });
     const warm = await store.listRecent({ workspaceIds: [workspaceId] });
     expect(warm.items.map((s) => s.id)).toEqual(['b', 'a']);
+
+    const internal = queryStore as unknown as { dbPromise: Promise<{ batch: unknown }> };
+    const db = await internal.dbPromise;
+    db.batch = () =>
+      Promise.reject(Object.assign(new Error('poisoned'), { code: 'WAL_POISONED' }));
+    await store.reprojectNow();
+    expect(store.status().state).toBe('degraded');
+    expect(await queryStore.getCheckpoint(SESSION_INDEX_MANIFEST)).toBeUndefined();
+
+    const rebuilt = await store.prepare();
+    expect(rebuilt.state).toBe('ready');
+    const after = await store.listRecent({ workspaceIds: [workspaceId] });
+    expect(after.items.map((s) => s.id)).toEqual(['b', 'a']);
+    expect(await store.count({ workspaceIds: [workspaceId] })).toBe(2);
   });
 
   it('a crashed re-projection keeps readers on the previous generation', async () => {
@@ -1386,6 +1401,14 @@ describe('FileSessionIndex (read model)', () => {
 
     await internals.tick();
     expect(reconciles).toBe(2);
+
+    await fsp.mkdir(join(sessionsDir, workspaceId, 'ghost'), { recursive: true });
+    await internals.tick();
+    expect(reconciles).toBe(3);
+    const withoutGhost = await store.listRecent({ workspaceIds: [workspaceId] });
+    expect(withoutGhost.items.map((s) => s.id)).toEqual(['a']);
+    await internals.tick();
+    expect(reconciles).toBe(3);
   });
 
   it('treats a published checkpoint without sourceMaxMtimeMs as stale and re-projects', async () => {

--- a/packages/agent-core-v2/test/app/sessionIndex/sessionIndexMirror.test.ts
+++ b/packages/agent-core-v2/test/app/sessionIndex/sessionIndexMirror.test.ts
@@ -27,8 +27,10 @@ import {
   SessionIndexMirror,
 } from '#/app/sessionIndex/sessionIndexMirrorService';
 import { drainQueryStoreDisposals, MiniDbQueryStore } from '#/persistence/backends/minidb/miniDbQueryStore';
+import { FileStorageService } from '#/persistence/backends/node-fs/fileStorageService';
 import { DATABASE_SECTION } from '#/persistence/configSection';
 import { IQueryStore } from '#/persistence/interface/queryStore';
+import { IFileSystemStorageService } from '#/persistence/interface/storage';
 
 import { stubBootstrap } from '../bootstrap/stubs';
 import { stubConfigService } from '../config/stubs';
@@ -92,6 +94,7 @@ describe('SessionIndexMirror', () => {
   ): ISessionIndexMirror {
     const host = createScopedTestHost([
       stubPair(IBootstrapService, stubBootstrap(homeDir)),
+      stubPair(IFileSystemStorageService, new FileStorageService(homeDir)),
       stubPair(ILogService, stubLog()),
       stubPair(IConfigService, stubConfigService({ [DATABASE_SECTION]: { base: baseEnabled } })),
       stubPair(ITelemetryService, telemetry),
@@ -161,6 +164,7 @@ describe('SessionIndexMirror', () => {
   it('never blocks record on the query store', async () => {
     const host = createScopedTestHost([
       stubPair(IBootstrapService, stubBootstrap(homeDir)),
+      stubPair(IFileSystemStorageService, new FileStorageService(homeDir)),
       stubPair(ILogService, stubLog()),
       stubPair(IConfigService, stubConfigService({ [DATABASE_SECTION]: { base: true } })),
       stubPair(ITelemetryService, noopTelemetryService),

--- a/packages/agent-core-v2/test/persistence/backends/minidb/miniDbQueryStore.test.ts
+++ b/packages/agent-core-v2/test/persistence/backends/minidb/miniDbQueryStore.test.ts
@@ -10,7 +10,7 @@ import { ILogService } from '#/_base/log/log';
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { ClusterDb } from '@moonshot-ai/minidb/cluster';
 import { drainQueryStoreDisposals, MiniDbQueryStore } from '#/persistence/backends/minidb/miniDbQueryStore';
-import { IQueryStore } from '#/persistence/interface/queryStore';
+import { IQueryStore, QueryStoreRebuiltError } from '#/persistence/interface/queryStore';
 import { stubBootstrap } from '../../../app/bootstrap/stubs';
 import { stubLog } from '../../../_base/log/stubs';
 
@@ -166,8 +166,11 @@ describe('MiniDbQueryStore', () => {
     await fsp.writeFile(registryFile, '{ definitely not valid json');
 
     const second = build();
-    await second.ensureIndex(COLLECTION, { kind: 'value', name: 'byV', field: 'v' });
+    await expect(
+      second.ensureIndex(COLLECTION, { kind: 'value', name: 'byV', field: 'v' }),
+    ).rejects.toThrow(SyntaxError);
     expect(await second.get(COLLECTION, 'a')).toBeUndefined();
+    await second.ensureIndex(COLLECTION, { kind: 'value', name: 'byV', field: 'v' });
     await second.put(COLLECTION, 'b', { id: 'b', v: 2 });
     const page = await second.query<{ id: string; v: number }>(COLLECTION).where({ v: 2 }).execute();
     expect(page.items).toEqual([{ id: 'b', v: 2 }]);
@@ -180,8 +183,9 @@ describe('MiniDbQueryStore', () => {
     const db = await internal.dbPromise;
     const poisoned = Object.assign(new Error('poisoned'), { code: 'WAL_POISONED' });
     (db as unknown as { set: unknown }).set = () => Promise.reject(poisoned);
-    await store.put(COLLECTION, 'b', { id: 'b', v: 2 });
+    await expect(store.put(COLLECTION, 'b', { id: 'b', v: 2 })).rejects.toThrow('poisoned');
     expect(await store.get(COLLECTION, 'a')).toBeUndefined();
+    await store.put(COLLECTION, 'b', { id: 'b', v: 2 });
     expect(await store.get(COLLECTION, 'b')).toEqual({ id: 'b', v: 2 });
 
     const db2 = await internal.dbPromise;
@@ -190,8 +194,9 @@ describe('MiniDbQueryStore', () => {
     for (let i = 0; i < 4; i++) {
       await expect(store.put(COLLECTION, `t${i}`, { v: i })).rejects.toThrow('locked');
     }
-    await store.put(COLLECTION, 'c', { id: 'c', v: 3 });
+    await expect(store.put(COLLECTION, 'c', { id: 'c', v: 3 })).rejects.toThrow('locked');
     expect(await store.get(COLLECTION, 'b')).toBeUndefined();
+    await store.put(COLLECTION, 'c', { id: 'c', v: 3 });
     expect(await store.get(COLLECTION, 'c')).toEqual({ id: 'c', v: 3 });
 
     const storeDir = join(homeDir, 'cache', 'query-store');
@@ -206,9 +211,22 @@ describe('MiniDbQueryStore', () => {
     const db4 = await internal.dbPromise;
     (db4 as unknown as { set: unknown }).set = () => Promise.reject(poisoned);
     await peer.close();
-    await store.put(COLLECTION, 'd', { v: 4 });
+    await expect(store.put(COLLECTION, 'd', { v: 4 })).rejects.toThrow('poisoned');
     expect(await store.get(COLLECTION, 'c')).toBeUndefined();
+    await store.put(COLLECTION, 'd', { v: 4 });
     expect(await store.get(COLLECTION, 'd')).toEqual({ v: 4 });
+
+    const epoch = store.storeEpoch();
+    const db5 = await internal.dbPromise;
+    (db5 as unknown as { set: unknown }).set = () => Promise.reject(poisoned);
+    await expect(store.put(COLLECTION, 'e', { v: 5 })).rejects.toThrow('poisoned');
+    expect(store.storeEpoch()).toBe(epoch + 1);
+    await expect(store.setCheckpoint('projection', { seq: 7 }, epoch)).rejects.toThrow(
+      QueryStoreRebuiltError,
+    );
+    expect(await store.getCheckpoint('projection')).toBeUndefined();
+    await store.setCheckpoint('projection', { seq: 7 }, store.storeEpoch());
+    expect(await store.getCheckpoint('projection')).toEqual({ seq: 7 });
   });
 
   it('getMany returns present values and skips missing keys', async () => {

--- a/packages/agent-core-v2/test/persistence/backends/minidb/miniDbQueryStore.test.ts
+++ b/packages/agent-core-v2/test/persistence/backends/minidb/miniDbQueryStore.test.ts
@@ -139,13 +139,6 @@ describe('MiniDbQueryStore', () => {
     expect(shardEntries.filter((name) => name.includes('text'))).toEqual([]);
   });
 
-  it('stores checkpoints', async () => {
-    const store = build();
-    expect(await store.getCheckpoint('wire:abc')).toBeUndefined();
-    await store.setCheckpoint('wire:abc', { seq: 42 });
-    expect(await store.getCheckpoint('wire:abc')).toEqual({ seq: 42 });
-  });
-
   it('shares the store with a second cluster instance instead of locking it out', async () => {
     const storeDir = join(homeDir, 'cache', 'query-store');
     const peer = await ClusterDb.open({ dir: storeDir, shardCount: 16, valueCodec: 'json' });
@@ -180,18 +173,26 @@ describe('MiniDbQueryStore', () => {
     expect(page.items).toEqual([{ id: 'b', v: 2 }]);
   });
 
-  it('opens a 16-shard cluster under the cache dir', async () => {
+  it('wipes and rebuilds the store after poison-class or persistent transient failures', async () => {
     const store = build();
-    await store.put(COLLECTION, 'a', { id: 'a' });
-    const storeDir = join(homeDir, 'cache', 'query-store');
-    const meta = JSON.parse(await fsp.readFile(join(storeDir, 'cluster.meta.json'), 'utf8')) as {
-      shardCount: number;
-    };
-    expect(meta.shardCount).toBe(16);
-    const entries = await fsp.readdir(storeDir);
-    for (let i = 0; i < 16; i++) {
-      expect(entries).toContain(`shard-${String(i).padStart(2, '0')}`);
+    await store.put(COLLECTION, 'a', { id: 'a', v: 1 });
+    const internal = store as unknown as { dbPromise: Promise<ClusterDb> };
+    const db = await internal.dbPromise;
+    const poisoned = Object.assign(new Error('poisoned'), { code: 'WAL_POISONED' });
+    (db as unknown as { set: unknown }).set = () => Promise.reject(poisoned);
+    await store.put(COLLECTION, 'b', { id: 'b', v: 2 });
+    expect(await store.get(COLLECTION, 'a')).toBeUndefined();
+    expect(await store.get(COLLECTION, 'b')).toEqual({ id: 'b', v: 2 });
+
+    const db2 = await internal.dbPromise;
+    const locked = Object.assign(new Error('locked'), { code: 'ELOCKED' });
+    (db2 as unknown as { set: unknown }).set = () => Promise.reject(locked);
+    for (let i = 0; i < 4; i++) {
+      await expect(store.put(COLLECTION, `t${i}`, { v: i })).rejects.toThrow('locked');
     }
+    await store.put(COLLECTION, 'c', { id: 'c', v: 3 });
+    expect(await store.get(COLLECTION, 'b')).toBeUndefined();
+    expect(await store.get(COLLECTION, 'c')).toEqual({ id: 'c', v: 3 });
   });
 
   it('getMany returns present values and skips missing keys', async () => {

--- a/packages/agent-core-v2/test/persistence/backends/minidb/miniDbQueryStore.test.ts
+++ b/packages/agent-core-v2/test/persistence/backends/minidb/miniDbQueryStore.test.ts
@@ -193,6 +193,7 @@ describe('MiniDbQueryStore', () => {
     (db2 as unknown as { set: unknown }).set = () => Promise.reject(locked);
     for (let i = 0; i < 4; i++) {
       await expect(store.put(COLLECTION, `t${i}`, { v: i })).rejects.toThrow('locked');
+      expect(await store.get(COLLECTION, 'b')).toEqual({ id: 'b', v: 2 });
     }
     await expect(store.put(COLLECTION, 'c', { id: 'c', v: 3 })).rejects.toThrow('locked');
     expect(await store.get(COLLECTION, 'b')).toBeUndefined();

--- a/packages/agent-core-v2/test/persistence/backends/minidb/miniDbQueryStore.test.ts
+++ b/packages/agent-core-v2/test/persistence/backends/minidb/miniDbQueryStore.test.ts
@@ -193,6 +193,22 @@ describe('MiniDbQueryStore', () => {
     await store.put(COLLECTION, 'c', { id: 'c', v: 3 });
     expect(await store.get(COLLECTION, 'b')).toBeUndefined();
     expect(await store.get(COLLECTION, 'c')).toEqual({ id: 'c', v: 3 });
+
+    const storeDir = join(homeDir, 'cache', 'query-store');
+    const peer = await ClusterDb.open({ dir: storeDir, shardCount: 16, valueCodec: 'json', lockHoldMs: 0 });
+    await peer.set(`${COLLECTION}${SEP}peer`, { id: 'peer', v: 9 });
+    const db3 = await internal.dbPromise;
+    (db3 as unknown as { set: unknown }).set = () => Promise.reject(poisoned);
+    await expect(store.put(COLLECTION, 'd', { v: 4 })).rejects.toThrow('poisoned');
+    expect(await peer.get(`${COLLECTION}${SEP}peer`)).toEqual({ id: 'peer', v: 9 });
+    expect(await store.get(COLLECTION, 'c')).toEqual({ id: 'c', v: 3 });
+
+    const db4 = await internal.dbPromise;
+    (db4 as unknown as { set: unknown }).set = () => Promise.reject(poisoned);
+    await peer.close();
+    await store.put(COLLECTION, 'd', { v: 4 });
+    expect(await store.get(COLLECTION, 'c')).toBeUndefined();
+    expect(await store.get(COLLECTION, 'd')).toEqual({ v: 4 });
   });
 
   it('getMany returns present values and skips missing keys', async () => {

--- a/packages/agent-core-v2/test/persistence/interface/stubs.ts
+++ b/packages/agent-core-v2/test/persistence/interface/stubs.ts
@@ -21,6 +21,7 @@ export function stubQueryStore(): IQueryStore {
     dropCollection: async (_c: string) => {},
     getCheckpoint: async (_s: string) => undefined as Checkpoint | undefined,
     setCheckpoint: async (_s: string, _c: Checkpoint) => {},
+    storeEpoch: () => 0,
     close: async () => {},
   };
 }

--- a/packages/kap-server/src/search/indexCore.ts
+++ b/packages/kap-server/src/search/indexCore.ts
@@ -1,13 +1,13 @@
 import { createHash } from 'node:crypto';
-import { open, readFile, readdir, rm, stat } from 'node:fs/promises';
+import { open, readFile, readdir, stat } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 
 import {
   classifyStorageError,
-  LockError,
   MiniDb,
   OpTracker,
   TextIndexBuildingError,
+  wipeStoreDir,
   type BatchInputOp,
 } from '@moonshot-ai/minidb';
 
@@ -348,22 +348,12 @@ export class SearchIndexCore {
       return await MiniDb.open<SearchDoc>(opts);
     } catch (error) {
       if (classifyStorageError(error) !== 'rebuild') throw error;
-      let probeError: unknown;
-      try {
-        const probe = await MiniDb.open<SearchDoc>({ dir: opts.dir, valueCodec: opts.valueCodec, valueMode: opts.valueMode });
-        await probe.close().catch(() => {});
-        probeError = undefined;
-      } catch (error) {
-        probeError = error;
-      }
-      if (probeError instanceof LockError) {
-        throw error;
-      }
+      const outcome = await wipeStoreDir({ dir: this.indexDir });
+      if (outcome === 'locked') throw error;
       this.log.warn('global search: search-index corruption detected; rebuilding from scratch', {
         dir: this.indexDir,
         error: errorMessage(error),
       });
-      await rm(this.indexDir, { recursive: true, force: true });
       return MiniDb.open<SearchDoc>(opts);
     }
   }
@@ -965,7 +955,13 @@ export class SearchIndexCore {
     this.openPromise = null;
     this.fullSyncDone = false;
     this.lockToken = undefined;
-    await rm(this.indexDir, { recursive: true, force: true });
+    const outcome = await wipeStoreDir({ dir: this.indexDir });
+    if (outcome === 'locked') {
+      throw new GlobalSearchError(
+        'readonly_index',
+        'another process holds the search-index write lock; reindex from that process',
+      );
+    }
     await this.ensureOpen();
   }
 

--- a/packages/kap-server/src/search/indexCore.ts
+++ b/packages/kap-server/src/search/indexCore.ts
@@ -63,6 +63,7 @@ const WIRE_BATCH_OPS = 1_000;
 const SYNC_ROUND_BYTE_BUDGET = 64 << 20;
 const SYNC_ROUND_TIME_BUDGET_MS = 30_000;
 const SYNC_FAILURE_ESCALATION_LIMIT = 5;
+const SESSION_SYNC_FAILURE_SKIP_LIMIT = 5;
 const EMPTY_BUFFER = Buffer.alloc(0);
 
 interface SyncRoundBudget {
@@ -160,6 +161,12 @@ export interface SyncSessionInput {
   readonly dir: string;
 }
 
+interface SessionSyncResult {
+  readonly truncated: boolean;
+  readonly failed: boolean;
+  readonly error?: string;
+}
+
 export interface CoreIndexView {
   readonly state: 'building' | 'ready' | 'readonly';
   readonly indexedSessions: number;
@@ -192,6 +199,7 @@ export interface CoreSyncOutcome {
   readonly sessions: number;
   readonly documents: number;
   readonly truncated: boolean;
+  readonly failures: number;
   readonly lockToken?: string;
   readonly lifecycle: CoreLifecycleReport;
 }
@@ -235,6 +243,7 @@ export class SearchIndexCore {
   private lockToken: string | undefined;
   private lastMaintenanceDetail: string | undefined;
   private consecutiveSyncFailures = 0;
+  private readonly sessionSyncFailures = new Map<string, number>();
 
   db: MiniDb<SearchDoc> | null = null;
   openPromise: Promise<void> | null = null;
@@ -440,7 +449,13 @@ export class SearchIndexCore {
   }
 
   async sync(sessions: readonly SyncSessionInput[]): Promise<CoreSyncOutcome> {
-    let outcome: CoreSyncPassOutcome = { noop: true, sessions: 0, documents: 0, truncated: false };
+    let outcome: CoreSyncPassOutcome = {
+      noop: true,
+      sessions: 0,
+      documents: 0,
+      truncated: false,
+      failures: 0,
+    };
     await this.tracked(async () => {
       try {
         outcome = await this.runSync(sessions);
@@ -452,7 +467,7 @@ export class SearchIndexCore {
         }
         this.consecutiveSyncFailures = 0;
         await this.recoverByRebuild(error);
-        outcome = { noop: false, sessions: 0, documents: 0, truncated: true };
+        outcome = { noop: false, sessions: 0, documents: 0, truncated: true, failures: 0 };
       }
     });
     return { ...outcome, lockToken: this.lockToken, lifecycle: this.lifecycleState() };
@@ -467,18 +482,25 @@ export class SearchIndexCore {
   }
 
   private async runSync(sessions: readonly SyncSessionInput[]): Promise<CoreSyncPassOutcome> {
-    if (this.disposed) return { noop: true, sessions: 0, documents: 0, truncated: false };
+    const noop: CoreSyncPassOutcome = {
+      noop: true,
+      sessions: 0,
+      documents: 0,
+      truncated: false,
+      failures: 0,
+    };
+    if (this.disposed) return noop;
     this.syncReplaced = false;
     await this.ensureOpen();
     const db = this.db;
-    if (!db || db.readOnly || this.disposed) return { noop: true, sessions: 0, documents: 0, truncated: false };
+    if (!db || db.readOnly || this.disposed) return noop;
 
     await this.migrateFileMetaKeys(db);
 
     const currentIds = new Set(sessions.map((s) => s.id));
 
     for (const row of db.query({ key: { prefix: SESSION_META_PREFIX }, project: [] })) {
-      if (this.disposed) return { noop: true, sessions: 0, documents: 0, truncated: false };
+      if (this.disposed) return noop;
       const sessionId = row.key.slice(SESSION_META_PREFIX.length);
       if (!currentIds.has(sessionId)) await this.deleteSessionDocs(db, sessionId);
     }
@@ -489,25 +511,40 @@ export class SearchIndexCore {
     };
     let indexed = 0;
     let truncated = false;
+    let failures = 0;
     for (const summary of sessions) {
-      if (this.disposed) return { noop: true, sessions: 0, documents: 0, truncated: false };
+      if (this.disposed) return noop;
+      if ((this.sessionSyncFailures.get(summary.id) ?? 0) >= SESSION_SYNC_FAILURE_SKIP_LIMIT) {
+        continue;
+      }
       if (syncBudgetExhausted(budget)) {
         truncated = true;
         break;
       }
-      try {
-        if (await this.syncSession(db, summary, budget)) truncated = true;
-        indexed++;
-      } catch (error) {
-        if (classifyStorageError(error) === 'rebuild') throw error;
-        this.log.warn('global search: failed to index session', {
-          sessionId: summary.id,
-          error: error instanceof Error ? error.message : String(error),
-        });
+      const result = await this.syncSession(db, summary, budget);
+      if (result.truncated) truncated = true;
+      if (result.failed) {
+        const count = (this.sessionSyncFailures.get(summary.id) ?? 0) + 1;
+        this.sessionSyncFailures.set(summary.id, count);
+        if (count >= SESSION_SYNC_FAILURE_SKIP_LIMIT) {
+          this.log.warn(
+            'global search: giving up on a session whose wire transcript stays unreadable',
+            { sessionId: summary.id, error: result.error },
+          );
+        } else {
+          failures += 1;
+          this.log.warn('global search: failed to index session', {
+            sessionId: summary.id,
+            error: result.error,
+          });
+        }
+      } else {
+        this.sessionSyncFailures.delete(summary.id);
       }
+      indexed++;
     }
 
-    if (this.disposed) return { noop: true, sessions: 0, documents: 0, truncated: false };
+    if (this.disposed) return noop;
     const metaCount = db.query({ key: { prefix: '\0meta\\' }, project: [] }).length;
     const stats: StatsDoc = {
       kind: 'stats',
@@ -516,11 +553,11 @@ export class SearchIndexCore {
       lastIndexedAt: Date.now(),
     };
     await db.set(STATS_KEY, stats);
-    if (!truncated) this.fullSyncDone = true;
+    if (!truncated && failures === 0) this.fullSyncDone = true;
     if (this.syncReplaced) {
       this.generation++;
     }
-    return { noop: false, sessions: indexed, documents: stats.documents, truncated };
+    return { noop: false, sessions: indexed, documents: stats.documents, truncated, failures };
   }
 
   private async migrateFileMetaKeys(db: MiniDb<SearchDoc>): Promise<void> {
@@ -552,7 +589,7 @@ export class SearchIndexCore {
     db: MiniDb<SearchDoc>,
     summary: SyncSessionInput,
     budget: SyncRoundBudget,
-  ): Promise<boolean> {
+  ): Promise<SessionSyncResult> {
     const wireFiles = await collectWireFiles(summary.dir);
     const seenPaths = new Set(wireFiles.map((file) => file.path));
 
@@ -565,8 +602,15 @@ export class SearchIndexCore {
     }
 
     let truncated = false;
+    let failed = false;
+    let error: string | undefined;
     for (const file of wireFiles) {
-      if (await this.syncWireFile(db, summary, file, budget)) truncated = true;
+      const result = await this.syncWireFile(db, summary, file, budget);
+      if (result.truncated) truncated = true;
+      if (result.failed) {
+        failed = true;
+        error ??= result.error;
+      }
     }
 
     const title = summary.title ?? '';
@@ -594,7 +638,7 @@ export class SearchIndexCore {
       const sessionMeta: SessionMetaDoc = { kind: 'sessionMeta' };
       await db.set(SESSION_META_PREFIX + summary.id, sessionMeta);
     }
-    return truncated;
+    return { truncated, failed, error };
   }
 
   private async deleteFileDocs(db: MiniDb<SearchDoc>, meta: FileMetaDoc): Promise<void> {
@@ -609,12 +653,12 @@ export class SearchIndexCore {
     summary: SyncSessionInput,
     file: WireFileRef,
     budget: SyncRoundBudget,
-  ): Promise<boolean> {
+  ): Promise<SessionSyncResult> {
     let st: { size: number; mtimeMs: number; ino: number };
     try {
       st = await stat(file.path);
     } catch {
-      return false;
+      return { truncated: false, failed: false };
     }
     const size = st.size;
     const metaKey = fileMetaKey(summary.id, file.path);
@@ -675,29 +719,41 @@ export class SearchIndexCore {
         if (legacyKey !== null) ops.push({ op: 'del', key: legacyKey });
         await db.batch(ops);
       }
-      return false;
+      return { truncated: false, failed: false };
     }
 
-    const handle = await open(file.path, 'r');
+    let handle: Awaited<ReturnType<typeof open>>;
+    try {
+      handle = await open(file.path, 'r');
+    } catch (error) {
+      return { truncated: false, failed: true, error: errorMessage(error) };
+    }
     const ops: BatchInputOp<SearchDoc>[] = [];
     let byteCursor = offset;
     let position = offset;
+    let wireError: unknown;
     try {
       let pending: Buffer = EMPTY_BUFFER;
       let finishing = false;
       const chunk = Buffer.allocUnsafe(WIRE_READ_CHUNK_BYTES);
       while (position < size) {
-        if (this.disposed) return false;
+        if (this.disposed) return { truncated: false, failed: false };
         if (syncBudgetExhausted(budget)) {
           if (pending.length === 0) break;
           finishing = true;
         }
-        const { bytesRead } = await handle.read(
-          chunk,
-          0,
-          Math.min(chunk.length, size - position),
-          position,
-        );
+        let bytesRead: number;
+        try {
+          ({ bytesRead } = await handle.read(
+            chunk,
+            0,
+            Math.min(chunk.length, size - position),
+            position,
+          ));
+        } catch (error) {
+          wireError = error;
+          break;
+        }
         if (bytesRead === 0) break;
         budget.bytesLeft -= bytesRead;
         const slice = chunk.subarray(0, bytesRead);
@@ -750,7 +806,11 @@ export class SearchIndexCore {
       if (legacyKey !== null) ops.push({ op: 'del', key: legacyKey });
       await db.batch(ops);
     }
-    return truncated;
+    return {
+      truncated,
+      failed: wireError !== undefined,
+      error: wireError !== undefined ? errorMessage(wireError) : undefined,
+    };
   }
 
   private collectWireLine(
@@ -954,6 +1014,7 @@ export class SearchIndexCore {
     }
     this.openPromise = null;
     this.fullSyncDone = false;
+    this.sessionSyncFailures.clear();
     this.lockToken = undefined;
     const outcome = await wipeStoreDir({ dir: this.indexDir });
     if (outcome === 'locked') {

--- a/packages/kap-server/src/search/indexCore.ts
+++ b/packages/kap-server/src/search/indexCore.ts
@@ -64,6 +64,7 @@ const SYNC_ROUND_BYTE_BUDGET = 64 << 20;
 const SYNC_ROUND_TIME_BUDGET_MS = 30_000;
 const SYNC_FAILURE_ESCALATION_LIMIT = 5;
 const SESSION_SYNC_FAILURE_SKIP_LIMIT = 5;
+const SESSION_SYNC_SKIP_COOLDOWN_MS = 300_000;
 const EMPTY_BUFFER = Buffer.alloc(0);
 
 interface SyncRoundBudget {
@@ -244,6 +245,7 @@ export class SearchIndexCore {
   private lastMaintenanceDetail: string | undefined;
   private consecutiveSyncFailures = 0;
   private readonly sessionSyncFailures = new Map<string, number>();
+  private readonly sessionSyncSkips = new Map<string, { at: number; updatedAt: number }>();
 
   db: MiniDb<SearchDoc> | null = null;
   openPromise: Promise<void> | null = null;
@@ -251,6 +253,7 @@ export class SearchIndexCore {
   fullSyncDone = false;
   syncRoundBytes = SYNC_ROUND_BYTE_BUDGET;
   syncRoundMs = SYNC_ROUND_TIME_BUDGET_MS;
+  syncSkipCooldownMs = SESSION_SYNC_SKIP_COOLDOWN_MS;
 
   constructor(private readonly options: SearchCoreOptions) {}
 
@@ -514,9 +517,15 @@ export class SearchIndexCore {
     let failures = 0;
     for (const summary of sessions) {
       if (this.disposed) return noop;
-      if ((this.sessionSyncFailures.get(summary.id) ?? 0) >= SESSION_SYNC_FAILURE_SKIP_LIMIT) {
+      const skip = this.sessionSyncSkips.get(summary.id);
+      if (
+        skip !== undefined &&
+        summary.updatedAt === skip.updatedAt &&
+        Date.now() - skip.at < this.syncSkipCooldownMs
+      ) {
         continue;
       }
+      this.sessionSyncSkips.delete(summary.id);
       if (syncBudgetExhausted(budget)) {
         truncated = true;
         break;
@@ -527,6 +536,8 @@ export class SearchIndexCore {
         const count = (this.sessionSyncFailures.get(summary.id) ?? 0) + 1;
         this.sessionSyncFailures.set(summary.id, count);
         if (count >= SESSION_SYNC_FAILURE_SKIP_LIMIT) {
+          this.sessionSyncFailures.delete(summary.id);
+          this.sessionSyncSkips.set(summary.id, { at: Date.now(), updatedAt: summary.updatedAt });
           this.log.warn(
             'global search: giving up on a session whose wire transcript stays unreadable',
             { sessionId: summary.id, error: result.error },
@@ -1015,6 +1026,7 @@ export class SearchIndexCore {
     this.openPromise = null;
     this.fullSyncDone = false;
     this.sessionSyncFailures.clear();
+    this.sessionSyncSkips.clear();
     this.lockToken = undefined;
     const outcome = await wipeStoreDir({ dir: this.indexDir });
     if (outcome === 'locked') {

--- a/packages/kap-server/src/search/indexCore.ts
+++ b/packages/kap-server/src/search/indexCore.ts
@@ -240,6 +240,8 @@ export class SearchIndexCore {
   openPromise: Promise<void> | null = null;
   refreshPromise: Promise<void> | null = null;
   fullSyncDone = false;
+  syncRoundBytes = SYNC_ROUND_BYTE_BUDGET;
+  syncRoundMs = SYNC_ROUND_TIME_BUDGET_MS;
 
   constructor(private readonly options: SearchCoreOptions) {}
 
@@ -492,8 +494,8 @@ export class SearchIndexCore {
     }
 
     const budget: SyncRoundBudget = {
-      bytesLeft: SYNC_ROUND_BYTE_BUDGET,
-      deadline: Date.now() + SYNC_ROUND_TIME_BUDGET_MS,
+      bytesLeft: this.syncRoundBytes,
+      deadline: Date.now() + this.syncRoundMs,
     };
     let indexed = 0;
     let truncated = false;
@@ -504,7 +506,7 @@ export class SearchIndexCore {
         break;
       }
       try {
-        await this.syncSession(db, summary, budget);
+        if (await this.syncSession(db, summary, budget)) truncated = true;
         indexed++;
       } catch (error) {
         if (classifyStorageError(error) === 'rebuild') throw error;
@@ -524,7 +526,7 @@ export class SearchIndexCore {
       lastIndexedAt: Date.now(),
     };
     await db.set(STATS_KEY, stats);
-    this.fullSyncDone = true;
+    if (!truncated) this.fullSyncDone = true;
     if (this.syncReplaced) {
       this.generation++;
     }
@@ -556,7 +558,11 @@ export class SearchIndexCore {
     await db.del(SESSION_META_PREFIX + sessionId);
   }
 
-  private async syncSession(db: MiniDb<SearchDoc>, summary: SyncSessionInput, budget: SyncRoundBudget): Promise<void> {
+  private async syncSession(
+    db: MiniDb<SearchDoc>,
+    summary: SyncSessionInput,
+    budget: SyncRoundBudget,
+  ): Promise<boolean> {
     const wireFiles = await collectWireFiles(summary.dir);
     const seenPaths = new Set(wireFiles.map((file) => file.path));
 
@@ -568,8 +574,9 @@ export class SearchIndexCore {
       await db.del(row.key);
     }
 
+    let truncated = false;
     for (const file of wireFiles) {
-      await this.syncWireFile(db, summary, file, budget);
+      if (await this.syncWireFile(db, summary, file, budget)) truncated = true;
     }
 
     const title = summary.title ?? '';
@@ -597,6 +604,7 @@ export class SearchIndexCore {
       const sessionMeta: SessionMetaDoc = { kind: 'sessionMeta' };
       await db.set(SESSION_META_PREFIX + summary.id, sessionMeta);
     }
+    return truncated;
   }
 
   private async deleteFileDocs(db: MiniDb<SearchDoc>, meta: FileMetaDoc): Promise<void> {
@@ -611,12 +619,12 @@ export class SearchIndexCore {
     summary: SyncSessionInput,
     file: WireFileRef,
     budget: SyncRoundBudget,
-  ): Promise<void> {
+  ): Promise<boolean> {
     let st: { size: number; mtimeMs: number; ino: number };
     try {
       st = await stat(file.path);
     } catch {
-      return;
+      return false;
     }
     const size = st.size;
     const metaKey = fileMetaKey(summary.id, file.path);
@@ -677,19 +685,23 @@ export class SearchIndexCore {
         if (legacyKey !== null) ops.push({ op: 'del', key: legacyKey });
         await db.batch(ops);
       }
-      return;
+      return false;
     }
 
     const handle = await open(file.path, 'r');
     const ops: BatchInputOp<SearchDoc>[] = [];
     let byteCursor = offset;
+    let position = offset;
     try {
-      let position = offset;
       let pending: Buffer = EMPTY_BUFFER;
+      let finishing = false;
       const chunk = Buffer.allocUnsafe(WIRE_READ_CHUNK_BYTES);
       while (position < size) {
-        if (this.disposed) return;
-        if (syncBudgetExhausted(budget)) break;
+        if (this.disposed) return false;
+        if (syncBudgetExhausted(budget)) {
+          if (pending.length === 0) break;
+          finishing = true;
+        }
         const { bytesRead } = await handle.read(
           chunk,
           0,
@@ -701,6 +713,7 @@ export class SearchIndexCore {
         const slice = chunk.subarray(0, bytesRead);
         position += bytesRead;
         let start = 0;
+        let completedRecord = false;
         for (;;) {
           const nl = slice.indexOf(0x0a, start);
           if (nl === -1) break;
@@ -719,12 +732,14 @@ export class SearchIndexCore {
             lineOffset,
             { turnState, stepState },
           ));
+          completedRecord = true;
           start = nl + 1;
         }
         pending =
           pending.length > 0
             ? Buffer.concat([pending, slice.subarray(start)])
             : Buffer.from(slice.subarray(start));
+        if (finishing && completedRecord) break;
         if (ops.length >= WIRE_BATCH_OPS) {
           ops.push({ op: 'set', key: metaKey, value: fileMeta(byteCursor, turnState, stepState) });
           if (legacyKey !== null) {
@@ -739,10 +754,13 @@ export class SearchIndexCore {
       await handle.close();
     }
 
-    if (byteCursor === offset && legacyKey === null) return;
-    ops.push({ op: 'set', key: metaKey, value: fileMeta(byteCursor, turnState, stepState) });
-    if (legacyKey !== null) ops.push({ op: 'del', key: legacyKey });
-    await db.batch(ops);
+    const truncated = position < size && syncBudgetExhausted(budget);
+    if (byteCursor !== offset || legacyKey !== null) {
+      ops.push({ op: 'set', key: metaKey, value: fileMeta(byteCursor, turnState, stepState) });
+      if (legacyKey !== null) ops.push({ op: 'del', key: legacyKey });
+      await db.batch(ops);
+    }
+    return truncated;
   }
 
   private collectWireLine(

--- a/packages/kap-server/src/search/indexCore.ts
+++ b/packages/kap-server/src/search/indexCore.ts
@@ -3,6 +3,7 @@ import { open, readFile, readdir, rm, stat } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 
 import {
+  classifyStorageError,
   LockError,
   MiniDb,
   OpTracker,
@@ -59,7 +60,19 @@ function legacyFileMetaKey(filePath: string): string {
 
 const WIRE_READ_CHUNK_BYTES = 1 << 20;
 const WIRE_BATCH_OPS = 1_000;
+const SYNC_ROUND_BYTE_BUDGET = 64 << 20;
+const SYNC_ROUND_TIME_BUDGET_MS = 30_000;
+const SYNC_FAILURE_ESCALATION_LIMIT = 5;
 const EMPTY_BUFFER = Buffer.alloc(0);
+
+interface SyncRoundBudget {
+  bytesLeft: number;
+  deadline: number;
+}
+
+function syncBudgetExhausted(budget: SyncRoundBudget): boolean {
+  return budget.bytesLeft <= 0 || Date.now() >= budget.deadline;
+}
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -178,6 +191,7 @@ export interface CoreSyncOutcome {
   readonly noop: boolean;
   readonly sessions: number;
   readonly documents: number;
+  readonly truncated: boolean;
   readonly lockToken?: string;
   readonly lifecycle: CoreLifecycleReport;
 }
@@ -219,6 +233,8 @@ export class SearchIndexCore {
   private openError: string | null = null;
   private fileMetaMigrated = false;
   private lockToken: string | undefined;
+  private lastMaintenanceDetail: string | undefined;
+  private consecutiveSyncFailures = 0;
 
   db: MiniDb<SearchDoc> | null = null;
   openPromise: Promise<void> | null = null;
@@ -318,6 +334,7 @@ export class SearchIndexCore {
     const opts = {
       dir: this.indexDir,
       valueCodec: 'json',
+      valueMode: 'disk',
       fsyncPolicy: 'everysec',
       onLockFail: 'readonly',
       onLockAcquired: (info: { readonly token: string }) => {
@@ -328,10 +345,10 @@ export class SearchIndexCore {
     try {
       return await MiniDb.open<SearchDoc>(opts);
     } catch (error) {
-      if (!isRebuildableCorruption(error)) throw error;
+      if (classifyStorageError(error) !== 'rebuild') throw error;
       let probeError: unknown;
       try {
-        const probe = await MiniDb.open<SearchDoc>({ dir: opts.dir, valueCodec: opts.valueCodec });
+        const probe = await MiniDb.open<SearchDoc>({ dir: opts.dir, valueCodec: opts.valueCodec, valueMode: opts.valueMode });
         await probe.close().catch(() => {});
         probeError = undefined;
       } catch (error) {
@@ -431,37 +448,66 @@ export class SearchIndexCore {
   }
 
   async sync(sessions: readonly SyncSessionInput[]): Promise<CoreSyncOutcome> {
-    let outcome: CoreSyncPassOutcome = { noop: true, sessions: 0, documents: 0 };
+    let outcome: CoreSyncPassOutcome = { noop: true, sessions: 0, documents: 0, truncated: false };
     await this.tracked(async () => {
-      outcome = await this.runSync(sessions);
+      try {
+        outcome = await this.runSync(sessions);
+        this.consecutiveSyncFailures = 0;
+      } catch (error) {
+        if (classifyStorageError(error) !== 'rebuild') {
+          this.consecutiveSyncFailures += 1;
+          if (this.consecutiveSyncFailures < SYNC_FAILURE_ESCALATION_LIMIT) throw error;
+        }
+        this.consecutiveSyncFailures = 0;
+        await this.recoverByRebuild(error);
+        outcome = { noop: false, sessions: 0, documents: 0, truncated: true };
+      }
     });
     return { ...outcome, lockToken: this.lockToken, lifecycle: this.lifecycleState() };
   }
 
+  private async recoverByRebuild(cause: unknown): Promise<void> {
+    this.log.warn('global search: search-index state is unrecoverable; wiping and rebuilding from the transcripts', {
+      dir: this.indexDir,
+      error: errorMessage(cause),
+    });
+    await this.reindex();
+  }
+
   private async runSync(sessions: readonly SyncSessionInput[]): Promise<CoreSyncPassOutcome> {
-    if (this.disposed) return { noop: true, sessions: 0, documents: 0 };
+    if (this.disposed) return { noop: true, sessions: 0, documents: 0, truncated: false };
     this.syncReplaced = false;
     await this.ensureOpen();
     const db = this.db;
-    if (!db || db.readOnly || this.disposed) return { noop: true, sessions: 0, documents: 0 };
+    if (!db || db.readOnly || this.disposed) return { noop: true, sessions: 0, documents: 0, truncated: false };
 
     await this.migrateFileMetaKeys(db);
 
     const currentIds = new Set(sessions.map((s) => s.id));
 
     for (const row of db.query({ key: { prefix: SESSION_META_PREFIX }, project: [] })) {
-      if (this.disposed) return { noop: true, sessions: 0, documents: 0 };
+      if (this.disposed) return { noop: true, sessions: 0, documents: 0, truncated: false };
       const sessionId = row.key.slice(SESSION_META_PREFIX.length);
       if (!currentIds.has(sessionId)) await this.deleteSessionDocs(db, sessionId);
     }
 
+    const budget: SyncRoundBudget = {
+      bytesLeft: SYNC_ROUND_BYTE_BUDGET,
+      deadline: Date.now() + SYNC_ROUND_TIME_BUDGET_MS,
+    };
     let indexed = 0;
+    let truncated = false;
     for (const summary of sessions) {
-      if (this.disposed) return { noop: true, sessions: 0, documents: 0 };
+      if (this.disposed) return { noop: true, sessions: 0, documents: 0, truncated: false };
+      if (syncBudgetExhausted(budget)) {
+        truncated = true;
+        break;
+      }
       try {
-        await this.syncSession(db, summary);
+        await this.syncSession(db, summary, budget);
         indexed++;
       } catch (error) {
+        if (classifyStorageError(error) === 'rebuild') throw error;
         this.log.warn('global search: failed to index session', {
           sessionId: summary.id,
           error: error instanceof Error ? error.message : String(error),
@@ -469,7 +515,7 @@ export class SearchIndexCore {
       }
     }
 
-    if (this.disposed) return { noop: true, sessions: 0, documents: 0 };
+    if (this.disposed) return { noop: true, sessions: 0, documents: 0, truncated: false };
     const metaCount = db.query({ key: { prefix: '\0meta\\' }, project: [] }).length;
     const stats: StatsDoc = {
       kind: 'stats',
@@ -482,7 +528,7 @@ export class SearchIndexCore {
     if (this.syncReplaced) {
       this.generation++;
     }
-    return { noop: false, sessions: indexed, documents: stats.documents };
+    return { noop: false, sessions: indexed, documents: stats.documents, truncated };
   }
 
   private async migrateFileMetaKeys(db: MiniDb<SearchDoc>): Promise<void> {
@@ -510,7 +556,7 @@ export class SearchIndexCore {
     await db.del(SESSION_META_PREFIX + sessionId);
   }
 
-  private async syncSession(db: MiniDb<SearchDoc>, summary: SyncSessionInput): Promise<void> {
+  private async syncSession(db: MiniDb<SearchDoc>, summary: SyncSessionInput, budget: SyncRoundBudget): Promise<void> {
     const wireFiles = await collectWireFiles(summary.dir);
     const seenPaths = new Set(wireFiles.map((file) => file.path));
 
@@ -523,7 +569,7 @@ export class SearchIndexCore {
     }
 
     for (const file of wireFiles) {
-      await this.syncWireFile(db, summary, file);
+      await this.syncWireFile(db, summary, file, budget);
     }
 
     const title = summary.title ?? '';
@@ -564,6 +610,7 @@ export class SearchIndexCore {
     db: MiniDb<SearchDoc>,
     summary: SyncSessionInput,
     file: WireFileRef,
+    budget: SyncRoundBudget,
   ): Promise<void> {
     let st: { size: number; mtimeMs: number; ino: number };
     try {
@@ -642,6 +689,7 @@ export class SearchIndexCore {
       const chunk = Buffer.allocUnsafe(WIRE_READ_CHUNK_BYTES);
       while (position < size) {
         if (this.disposed) return;
+        if (syncBudgetExhausted(budget)) break;
         const { bytesRead } = await handle.read(
           chunk,
           0,
@@ -649,6 +697,7 @@ export class SearchIndexCore {
           position,
         );
         if (bytesRead === 0) break;
+        budget.bytesLeft -= bytesRead;
         const slice = chunk.subarray(0, bytesRead);
         position += bytesRead;
         let start = 0;
@@ -677,6 +726,11 @@ export class SearchIndexCore {
             ? Buffer.concat([pending, slice.subarray(start)])
             : Buffer.from(slice.subarray(start));
         if (ops.length >= WIRE_BATCH_OPS) {
+          ops.push({ op: 'set', key: metaKey, value: fileMeta(byteCursor, turnState, stepState) });
+          if (legacyKey !== null) {
+            ops.push({ op: 'del', key: legacyKey });
+            legacyKey = null;
+          }
           await db.batch(ops);
           ops.length = 0;
         }
@@ -900,6 +954,7 @@ export class SearchIndexCore {
   lifecycleState(): CoreLifecycleReport {
     if (this.disposed) return { state: this.db === null ? 'stopped' : 'closing' };
     const db = this.db;
+    if (db !== null) this.noteMaintenanceDetail(db);
     if (db === null) {
       if (this.openPromise !== null) return { state: 'opening' };
       if (this.openError !== null) return { state: 'degraded', detail: this.openError };
@@ -911,12 +966,32 @@ export class SearchIndexCore {
     return { state: 'ready' };
   }
 
+  private maintenanceDetail(db: MiniDb<SearchDoc>): string | undefined {
+    const failure = db.lastCompactError ?? db.lastGenBuildError;
+    return failure === null ? undefined : errorMessage(failure);
+  }
+
+  private noteMaintenanceDetail(db: MiniDb<SearchDoc>): void {
+    const detail = this.maintenanceDetail(db);
+    if (detail === this.lastMaintenanceDetail) return;
+    const previous = this.lastMaintenanceDetail;
+    this.lastMaintenanceDetail = detail;
+    if (detail !== undefined) {
+      this.log.warn('global search: index maintenance is failing; the WAL keeps growing until it recovers', {
+        error: detail,
+      });
+    } else if (previous !== undefined) {
+      this.log.info('global search: index maintenance recovered');
+    }
+  }
+
   async status(): Promise<CoreStatus> {
     await this.ensureOpen();
     if (this.db?.readOnly === true) {
       await this.refresh();
     }
     const stats = this.db?.get(STATS_KEY);
+    const maintenance = this.db !== null ? this.maintenanceDetail(this.db) : undefined;
     return {
       sessions: stats?.kind === 'stats' ? stats.sessions : 0,
       documents: stats?.kind === 'stats' ? stats.documents : 0,
@@ -924,7 +999,7 @@ export class SearchIndexCore {
       generation: this.generation,
       readOnly: this.db?.readOnly === true,
       lockToken: this.lockToken,
-      degraded: this.lastRefreshError?.message,
+      degraded: this.lastRefreshError?.message ?? maintenance,
       lifecycle: this.lifecycleState(),
     };
   }
@@ -989,13 +1064,4 @@ async function collectWireFiles(sessionDir: string): Promise<WireFileRef[]> {
 
 function docKeyPrefix(sessionId: string, file: WireFileRef): string {
   return `${sessionId}/${file.agentId}/${file.source}:`;
-}
-
-function isRebuildableCorruption(error: unknown): boolean {
-  return (
-    error instanceof SyntaxError ||
-    (error !== null &&
-      typeof error === 'object' &&
-      (error as { name?: string }).name === 'CorruptFrameError')
-  );
 }

--- a/packages/kap-server/src/search/searchService.ts
+++ b/packages/kap-server/src/search/searchService.ts
@@ -356,7 +356,8 @@ export class GlobalSearchService implements IGlobalSearchService {
     }
     this.summaries = new Map(sessions.map((s) => [s.id, s]));
     this.lastSyncStartedAt = Date.now();
-    await backend.sync(sessions.map((s) => this.toSyncInput(s)));
+    const outcome = await backend.sync(sessions.map((s) => this.toSyncInput(s)));
+    if (outcome.truncated) this.requestSync();
   }
 
   private async listAllSessions(): Promise<SessionSummary[]> {

--- a/packages/kap-server/src/search/searchService.ts
+++ b/packages/kap-server/src/search/searchService.ts
@@ -357,7 +357,7 @@ export class GlobalSearchService implements IGlobalSearchService {
     this.summaries = new Map(sessions.map((s) => [s.id, s]));
     this.lastSyncStartedAt = Date.now();
     const outcome = await backend.sync(sessions.map((s) => this.toSyncInput(s)));
-    if (outcome.truncated) this.requestSync();
+    if (outcome.truncated || outcome.failures > 0) this.requestSync();
   }
 
   private async listAllSessions(): Promise<SessionSummary[]> {

--- a/packages/kap-server/src/search/worker/host.ts
+++ b/packages/kap-server/src/search/worker/host.ts
@@ -440,7 +440,7 @@ export class SearchWorkerHost {
     this.reapPromise = this.reapLockFile(deadToken).finally(() => {
       this.reapPromise = null;
     });
-    this.failures = sessionMs > STABLE_SESSION_MS ? 1 : this.failures + 1;
+    this.failures = sessionMs > STABLE_SESSION_MS ? Math.max(1, this.failures - 1) : this.failures + 1;
     const backoff = Math.min(BACKOFF_BASE_MS * 2 ** (this.failures - 1), BACKOFF_CAP_MS);
     this.nextRetryAfter = Date.now() + backoff;
     this.log.warn('global search: worker exited unexpectedly; restart backed off', {

--- a/packages/kap-server/test/search/searchService.test.ts
+++ b/packages/kap-server/test/search/searchService.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { appendFile, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { appendFile, chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { monitorEventLoopDelay, performance } from 'node:perf_hooks';
@@ -494,35 +494,76 @@ describe('GlobalSearchService', () => {
     expect(page.items[0]?.role).toBe('user');
   });
 
-  it('marks a mid-file budget stop as truncated and still completes an oversized record', async () => {
+  it('sync rounds account truncation, session-local wire failures, and escalating storage failures', async () => {
     const s1 = summary('s1', 'budget', T1);
     const lines = [
       userLine('苹果 head', T1),
       userLine(`苹果 giant ${'x'.repeat(1_700_000)}`, T2),
       userLine(`苹果 tail ${'y'.repeat(400_000)}`, T3),
     ];
-    await writeWire(home!, 's1', 'main', lines);
+    const s1Wire = await writeWire(home!, 's1', 'main', lines);
+    const s2 = summary('s2', 'wirefail', T1);
+    const s2Wire = await writeWire(home!, 's2', 'main', [userLine('苹果 unreachable', T1)]);
     const core = new SearchIndexCore({
       indexDir: join(home!, 'search-index'),
       log: noopLog,
       bootSalt: 'budget-test',
     });
     core.syncRoundBytes = 1 << 20;
-    const input = [syncInput(home!, s1)];
-    const messageCount = (): number =>
-      core.db?.query({ key: { prefix: 's1/' }, project: ['kind'] }).filter((row) => row.value.kind === 'message')
+    const input = [syncInput(home!, s1), syncInput(home!, s2)];
+    const messageCount = (id: string): number =>
+      core.db?.query({ key: { prefix: `${id}/` }, project: ['kind'] }).filter((row) => row.value.kind === 'message')
         .length ?? 0;
     try {
       const first = await core.sync(input);
       expect(first.truncated).toBe(true);
+      expect(first.failures).toBe(0);
       expect(core.fullSyncDone).toBe(false);
-      expect(messageCount()).toBe(2);
+      expect(messageCount('s1')).toBe(2);
+      expect(messageCount('s2')).toBe(0);
 
       const second = await core.sync(input);
       expect(second.truncated).toBe(false);
+      expect(second.failures).toBe(0);
       expect(core.fullSyncDone).toBe(true);
-      expect(messageCount()).toBe(3);
+      expect(messageCount('s1')).toBe(3);
+      expect(messageCount('s2')).toBe(1);
+
+      core.syncRoundBytes = 64 << 20;
+      if (process.platform !== 'win32') {
+        await core.reindex();
+        await chmod(s2Wire, 0o000);
+        for (let round = 0; round < 4; round++) {
+          const outcome = await core.sync(input);
+          expect(outcome.failures).toBe(1);
+          expect(outcome.truncated).toBe(false);
+          expect(core.fullSyncDone).toBe(false);
+        }
+        const skipped = await core.sync(input);
+        expect(skipped.failures).toBe(0);
+        expect(core.fullSyncDone).toBe(true);
+        expect(messageCount('s2')).toBe(0);
+        expect(messageCount('s1')).toBe(3);
+        await chmod(s2Wire, 0o644);
+      }
+
+      await appendFile(s1Wire, `${userLine('苹果 extra', T3 + 1)}\n`, 'utf8');
+      (core.db as unknown as { batch: unknown }).batch = () =>
+        Promise.reject(new Error('injected io'));
+      for (let round = 0; round < 4; round++) {
+        await expect(core.sync(input)).rejects.toThrow('injected io');
+      }
+      const rebuilt = await core.sync(input);
+      expect(rebuilt.truncated).toBe(true);
+      expect(rebuilt.failures).toBe(0);
+      const converged = await core.sync(input);
+      expect(converged.truncated).toBe(false);
+      expect(converged.failures).toBe(0);
+      expect(core.fullSyncDone).toBe(true);
+      expect(messageCount('s1')).toBe(4);
+      expect(messageCount('s2')).toBe(1);
     } finally {
+      await chmod(s2Wire, 0o644).catch(() => {});
       core.beginClose();
       await core.close();
     }

--- a/packages/kap-server/test/search/searchService.test.ts
+++ b/packages/kap-server/test/search/searchService.test.ts
@@ -17,7 +17,7 @@ import { MiniDb } from '@moonshot-ai/minidb';
 import { TranscriptStore, type TranscriptOperation } from '@moonshot-ai/transcript';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { SyncSessionInput } from '../../src/search/indexCore';
+import { SearchIndexCore, type SyncSessionInput } from '../../src/search/indexCore';
 import {
   GlobalSearchError,
   GlobalSearchService,
@@ -411,19 +411,6 @@ describe('GlobalSearchService', () => {
     );
   });
 
-  it('picks up appended wire lines on the next sync pass', async () => {
-    const s1 = summary('s1', 'incremental', T1);
-    const file = await writeWire(home!, 's1', 'main', [userLine('苹果 initial', T1)]);
-    const service = track(makeService(home!, staticIndex([s1])));
-    await service.reindex();
-
-    await appendFile(file, `${userLine('苹果 appended', T2)}\n`, 'utf8');
-    await settleSync(service);
-    const page = await service.search({ query: '苹果' });
-    expect(page.items.length).toBe(2);
-    expect(page.items.some((h) => h.snippet.includes('appended'))).toBe(true);
-  });
-
   it('reports indexState building before the first full sync and ready after', async () => {
     const s1 = summary('s1', 'state', T1);
     await writeWire(home!, 's1', 'main', [userLine('苹果 state', T1)]);
@@ -505,6 +492,40 @@ describe('GlobalSearchService', () => {
     const page = await service.search({ query: 'partial' });
     expect(page.items.length).toBe(1);
     expect(page.items[0]?.role).toBe('user');
+  });
+
+  it('marks a mid-file budget stop as truncated and still completes an oversized record', async () => {
+    const s1 = summary('s1', 'budget', T1);
+    const lines = [
+      userLine('苹果 head', T1),
+      userLine(`苹果 giant ${'x'.repeat(1_700_000)}`, T2),
+      userLine(`苹果 tail ${'y'.repeat(400_000)}`, T3),
+    ];
+    await writeWire(home!, 's1', 'main', lines);
+    const core = new SearchIndexCore({
+      indexDir: join(home!, 'search-index'),
+      log: noopLog,
+      bootSalt: 'budget-test',
+    });
+    core.syncRoundBytes = 1 << 20;
+    const input = [syncInput(home!, s1)];
+    const messageCount = (): number =>
+      core.db?.query({ key: { prefix: 's1/' }, project: ['kind'] }).filter((row) => row.value.kind === 'message')
+        .length ?? 0;
+    try {
+      const first = await core.sync(input);
+      expect(first.truncated).toBe(true);
+      expect(core.fullSyncDone).toBe(false);
+      expect(messageCount()).toBe(2);
+
+      const second = await core.sync(input);
+      expect(second.truncated).toBe(false);
+      expect(core.fullSyncDone).toBe(true);
+      expect(messageCount()).toBe(3);
+    } finally {
+      core.beginClose();
+      await core.close();
+    }
   });
 
   it('indexes legacy root and v2 agents layouts of one session without key collisions', async () => {

--- a/packages/kap-server/test/search/searchService.test.ts
+++ b/packages/kap-server/test/search/searchService.test.ts
@@ -562,6 +562,44 @@ describe('GlobalSearchService', () => {
       expect(core.fullSyncDone).toBe(true);
       expect(messageCount('s1')).toBe(4);
       expect(messageCount('s2')).toBe(1);
+
+      if (process.platform !== 'win32') {
+        await appendFile(s2Wire, `${userLine('苹果 cooled', T2)}\n`, 'utf8');
+        await chmod(s2Wire, 0o000);
+        for (let round = 0; round < 4; round++) {
+          const outcome = await core.sync(input);
+          expect(outcome.failures).toBe(1);
+        }
+        const skipped = await core.sync(input);
+        expect(skipped.failures).toBe(0);
+        expect(messageCount('s2')).toBe(1);
+
+        await chmod(s2Wire, 0o644);
+        const cooling = await core.sync(input);
+        expect(cooling.failures).toBe(0);
+        expect(messageCount('s2')).toBe(1);
+
+        const changedInput = [syncInput(home!, s1), { ...syncInput(home!, s2), updatedAt: T1 + 1 }];
+        const changed = await core.sync(changedInput);
+        expect(changed.failures).toBe(0);
+        expect(messageCount('s2')).toBe(2);
+
+        await appendFile(s2Wire, `${userLine('苹果 retried', T3)}\n`, 'utf8');
+        await chmod(s2Wire, 0o000);
+        for (let round = 0; round < 4; round++) {
+          const outcome = await core.sync(changedInput);
+          expect(outcome.failures).toBe(1);
+        }
+        const reskipped = await core.sync(changedInput);
+        expect(reskipped.failures).toBe(0);
+        expect(messageCount('s2')).toBe(2);
+
+        core.syncSkipCooldownMs = 0;
+        await chmod(s2Wire, 0o644);
+        const retried = await core.sync(changedInput);
+        expect(retried.failures).toBe(0);
+        expect(messageCount('s2')).toBe(3);
+      }
     } finally {
       await chmod(s2Wire, 0o644).catch(() => {});
       core.beginClose();

--- a/packages/minidb/src/cluster/index.ts
+++ b/packages/minidb/src/cluster/index.ts
@@ -57,6 +57,8 @@ export type {
 export { Router } from './router.js';
 export { Topology } from './topology.js';
 export { LockError } from '../lockfile.js';
+export { wipeCluster } from './wipe.js';
+export type { WipeOutcome } from '../wipe.js';
 export type { ShardOpenOptions } from './shard.js';
 export { shardDirName, shardFor, stableHash32 } from './utils.js';
 

--- a/packages/minidb/src/cluster/utils.ts
+++ b/packages/minidb/src/cluster/utils.ts
@@ -4,7 +4,7 @@
 
 export const CLUSTER_META_FILE = 'cluster.meta.json';
 export const CLUSTER_INDEX_FILE = 'cluster.indexes.json';
-const SHARD_DIR_PREFIX = 'shard-';
+export const SHARD_DIR_PREFIX = 'shard-';
 
 /** Zero-padded shard directory name, e.g. shard-03 for shardCount <= 100. The
  *  width grows with the shard count so directory listings stay sorted. */

--- a/packages/minidb/src/cluster/wipe.ts
+++ b/packages/minidb/src/cluster/wipe.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { wipeStoreDir, type WipeOutcome } from '../wipe.js';
+import { SHARD_DIR_PREFIX } from './utils.js';
+
+export async function wipeCluster(opts: {
+  dir: string;
+  lockAcquireTimeoutMs?: number;
+}): Promise<WipeOutcome> {
+  const entries = await fs.readdir(opts.dir).catch((error: unknown) => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [] as string[];
+    throw error;
+  });
+  const lockFiles = entries
+    .filter((entry) => entry.startsWith(SHARD_DIR_PREFIX))
+    .map((entry) => path.join(entry, 'db.lock'));
+  return wipeStoreDir({ ...opts, lockFiles });
+}

--- a/packages/minidb/src/error-classification.ts
+++ b/packages/minidb/src/error-classification.ts
@@ -1,0 +1,15 @@
+import { CorruptFrameError } from './codec.js';
+
+export type StorageErrorAction = 'rebuild' | 'transient';
+
+export function classifyStorageError(error: unknown): StorageErrorAction {
+  if (error instanceof AggregateError) {
+    return error.errors.some((inner) => classifyStorageError(inner) === 'rebuild')
+      ? 'rebuild'
+      : 'transient';
+  }
+  if (error instanceof SyntaxError || error instanceof CorruptFrameError) return 'rebuild';
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  if (code === 'WAL_WRITE_DISABLED' || code === 'WAL_POISONED') return 'rebuild';
+  return 'transient';
+}

--- a/packages/minidb/src/generation-builder.ts
+++ b/packages/minidb/src/generation-builder.ts
@@ -220,7 +220,8 @@ export interface GenerationBuilderDeps<V> {
   /** Called when a build fails for ANY reason (abort included), so the
    *  owner's runtime WAL-growth trigger can back off instead of re-kicking
    *  a build every interval on a hopelessly churning writer. */
-  noteBuildFailure?: () => void;
+  noteBuildFailure?: (error?: unknown) => void;
+  noteBuildSuccess?: () => void;
 }
 
 export class GenerationBuilder<V> {
@@ -804,6 +805,7 @@ export class GenerationBuilder<V> {
       this.generationInfo = { id, createdAt: manifest.createdAt, walCheckpoint: sealedOffset, records: imageRecords.size };
       this.deps.stats.generationBuilds++;
       this.deps.stats.generationBuildDurationMs += performance.now() - t0;
+      this.deps.noteBuildSuccess?.();
 
       // Retention: keep the new and the previously-published generation; sweep
       // everything else (stray tmp dirs included). Best-effort, async.
@@ -839,7 +841,7 @@ export class GenerationBuilder<V> {
         return;
       }
       this.deps.stats.generationBuildErrors++;
-      this.deps.noteBuildFailure?.();
+      this.deps.noteBuildFailure?.(e);
       throw e;
     } finally {
       if (this.genBuild === gb) this.genBuild = null;

--- a/packages/minidb/src/index.ts
+++ b/packages/minidb/src/index.ts
@@ -16,6 +16,8 @@ export { UniqueViolationError } from './index-manager.js';
 export { LockError } from './lockfile.js';
 export { classifyStorageError } from './error-classification.js';
 export type { StorageErrorAction } from './error-classification.js';
+export { wipeStoreDir } from './wipe.js';
+export type { WipeOutcome, WipeStoreDirOptions } from './wipe.js';
 // The close-gate + in-flight-count lifecycle primitive, shared with embedders
 // that run lifecycle-managed background work (kap-server's search service).
 export { OpTracker } from './op-tracker.js';

--- a/packages/minidb/src/index.ts
+++ b/packages/minidb/src/index.ts
@@ -14,6 +14,8 @@
 export * from './mini-db.js';
 export { UniqueViolationError } from './index-manager.js';
 export { LockError } from './lockfile.js';
+export { classifyStorageError } from './error-classification.js';
+export type { StorageErrorAction } from './error-classification.js';
 // The close-gate + in-flight-count lifecycle primitive, shared with embedders
 // that run lifecycle-managed background work (kap-server's search service).
 export { OpTracker } from './op-tracker.js';

--- a/packages/minidb/src/lifecycle.ts
+++ b/packages/minidb/src/lifecycle.ts
@@ -25,6 +25,7 @@ import {
 import { readManifest, sweepGenerationTemps } from './generation-files.js';
 import { MaintenanceScheduler } from './maintenance.js';
 import { LockFile, LockError } from './lockfile.js';
+import { wipeStoreDir } from './wipe.js';
 import type { LifecycleTracker } from './lifecycle-status.js';
 import { ValueReader } from './value-reader.js';
 import { Store } from './store.js';
@@ -551,7 +552,8 @@ export async function openOrRebuildMiniDb<T>(
         /* fall through to a full rebuild */
       }
     }
-    await fs.rm(opts.dir, { recursive: true, force: true });
+    const outcome = await wipeStoreDir({ dir: opts.dir });
+    if (outcome === 'locked') throw err;
     return open(opts);
   }
 }

--- a/packages/minidb/src/mini-db.ts
+++ b/packages/minidb/src/mini-db.ts
@@ -35,6 +35,7 @@ import { GenerationBuilder, TEXT_BUILD_WORKER_MIN_DOCS, GEN_BUILD_WAL_DELTA_BYTE
 import type { GenBuildOp } from './generation-builder.js';
 import { WalGroupTracker } from './wal-group.js';
 import { WritePath } from './write-path.js';
+import { withWindowsEpermRetry } from './rename-replace.js';
 import { openMiniDb, closeMiniDb, renewMiniDbLock, openOrRebuildMiniDb } from './lifecycle.js';
 import { IndexAdmin } from './index-admin.js';
 import { ReadPath } from './read-path.js';
@@ -221,6 +222,7 @@ export class MiniDb<V = unknown> {
   genBuildKickFailureBackoffMs = 300_000;
   private lastGenBuildKickAt = 0;
   private lastGenBuildFailureAt = 0;
+  lastGenBuildError: unknown = null;
   /** Abort handle / mutation queue / single-flight guard / status of the
    *  generation build all live in the GenerationBuilder facet (declared
    *  below); these views keep the open / write / close paths' call sites
@@ -360,8 +362,12 @@ export class MiniDb<V = unknown> {
     ensureOpen: () => this.ensureOpen(),
     ensureWritable: () => this.ensureWritable(),
     boundedTextBuild: (name, ti, def, checkpoint) => this.boundedTextBuild(name, ti, def, checkpoint),
-    noteBuildFailure: () => {
+    noteBuildFailure: (err) => {
       this.lastGenBuildFailureAt = Date.now();
+      if (err !== undefined) this.lastGenBuildError = err;
+    },
+    noteBuildSuccess: () => {
+      this.lastGenBuildError = null;
     },
   });
 
@@ -1087,8 +1093,10 @@ export class MiniDb<V = unknown> {
       // offset belongs to the old file's coordinate system and truncating to
       // it would zero-extend the new file. The new file never carried the
       // un-acked tail, so skipping the truncate is the correct recovery.
-      const st = await fs.stat(this.walPath);
-      if (poison.failedAtOffset <= st.size) await fs.truncate(this.walPath, poison.failedAtOffset);
+      await withWindowsEpermRetry(async () => {
+        const st = await fs.stat(this.walPath);
+        if (poison.failedAtOffset <= st.size) await fs.truncate(this.walPath, poison.failedAtOffset);
+      });
     } catch (err) {
       this.writeDisabled = err;
       return;

--- a/packages/minidb/src/rename-replace.ts
+++ b/packages/minidb/src/rename-replace.ts
@@ -21,16 +21,24 @@ export interface RenameReplaceOptions {
   baseDelayMs?: number;
 }
 
-export async function renameReplace(src: string, dst: string, opts: RenameReplaceOptions = {}): Promise<void> {
-  if (process.platform !== 'win32') return fs.rename(src, dst);
+export async function retryEperm<T>(op: () => Promise<T>, opts: RenameReplaceOptions = {}): Promise<T> {
   const retries = opts.retries ?? 100;
   const base = opts.baseDelayMs ?? 20;
   for (let attempt = 0; ; attempt++) {
     try {
-      return await fs.rename(src, dst);
+      return await op();
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code !== 'EPERM' || attempt >= retries) throw e;
       await sleep(base + Math.floor(Math.random() * (base + 10)));
     }
   }
+}
+
+export async function withWindowsEpermRetry<T>(op: () => Promise<T>, opts: RenameReplaceOptions = {}): Promise<T> {
+  if (process.platform !== 'win32') return op();
+  return retryEperm(op, opts);
+}
+
+export async function renameReplace(src: string, dst: string, opts: RenameReplaceOptions = {}): Promise<void> {
+  return withWindowsEpermRetry(() => fs.rename(src, dst), opts);
 }

--- a/packages/minidb/src/wipe.ts
+++ b/packages/minidb/src/wipe.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { LockFile } from './lockfile.js';
+
+export type WipeOutcome = 'wiped' | 'locked';
+
+export interface WipeStoreDirOptions {
+  readonly dir: string;
+  readonly lockAcquireTimeoutMs?: number;
+  readonly lockFiles?: readonly string[];
+}
+
+async function acquireWithWait(lock: LockFile, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 10;
+  for (;;) {
+    if (await lock.acquire()) return true;
+    if (Date.now() + delay > deadline) return false;
+    const wait = delay + Math.floor(Math.random() * delay);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, wait);
+    });
+    delay = Math.min(delay * 2, 250);
+  }
+}
+
+export async function wipeStoreDir(opts: WipeStoreDirOptions): Promise<WipeOutcome> {
+  const lockFiles = opts.lockFiles ?? ['db.lock'];
+  const timeoutMs = opts.lockAcquireTimeoutMs ?? 0;
+  const locks = lockFiles.map((file) => new LockFile(path.join(opts.dir, file)));
+  const releaseAll = (): Promise<unknown[]> =>
+    Promise.all(locks.map((lock) => lock.release().catch(() => {})));
+  const results = await Promise.allSettled(locks.map((lock) => acquireWithWait(lock, timeoutMs)));
+  const failed = results.find((r): r is PromiseRejectedResult => r.status === 'rejected');
+  if (failed !== undefined || results.some((r) => r.status === 'fulfilled' && !r.value)) {
+    await releaseAll();
+    if (failed !== undefined) throw failed.reason;
+    return 'locked';
+  }
+  try {
+    await fs.rm(opts.dir, { recursive: true, force: true });
+  } finally {
+    await releaseAll();
+  }
+  return 'wiped';
+}

--- a/packages/minidb/src/wipe.ts
+++ b/packages/minidb/src/wipe.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { LockFile } from './lockfile.js';
+import { withWindowsEpermRetry } from './rename-replace.js';
 
 export type WipeOutcome = 'wiped' | 'locked';
 
@@ -38,7 +40,14 @@ export async function wipeStoreDir(opts: WipeStoreDirOptions): Promise<WipeOutco
     return 'locked';
   }
   try {
-    await fs.rm(opts.dir, { recursive: true, force: true });
+    const isolated = `${opts.dir}.wiping-${process.pid}-${randomUUID()}`;
+    try {
+      await withWindowsEpermRetry(() => fs.rename(opts.dir, isolated));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 'wiped';
+      throw error;
+    }
+    await fs.rm(isolated, { recursive: true, force: true });
   } finally {
     await releaseAll();
   }

--- a/packages/minidb/test/cluster/lock.test.ts
+++ b/packages/minidb/test/cluster/lock.test.ts
@@ -2,13 +2,13 @@
 //
 // Lock semantics inside one process: same-shard writer contention with
 // acquire timeout, per-shard independence, read-only coexistence, lock lease
-// renewal, and writer handoff after close.
+// renewal, and cluster-wipe exclusion while a writer is held.
 
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { ClusterDb } from '../../src/cluster/index.js';
+import { ClusterDb, wipeCluster } from '../../src/cluster/index.js';
 import { ShardLockPool } from '../../src/cluster/lock-pool.js';
 import { ShardHandle } from '../../src/cluster/shard.js';
 import { shardDirName } from '../../src/cluster/utils.js';
@@ -49,18 +49,24 @@ test('two writers contend on the same shard; loser times out with LockError', as
   }
 });
 
-test('writer handoff: after close, another instance takes the shard over', async () => {
+test('wipe refuses while any shard writer is held and proceeds once released', async () => {
   const dir = await tmpDir('minidb-cluster-');
   try {
-    const key = keyOnShard('handoff', 2, 4);
-    const db1 = await ClusterDb.open({ dir, shardCount: 4, valueCodec: 'json' });
-    await db1.set(key, { n: 1 });
-    await db1.close();
+    const key = keyOnShard('wipe', 2, 4);
+    const db1 = await ClusterDb.open({ dir, shardCount: 4, valueCodec: 'json', lockHoldMs: 0 });
+    await db1.set(key, { v: 1 });
 
-    const db2 = await ClusterDb.open({ dir, shardCount: 4, valueCodec: 'json', lockAcquireTimeoutMs: 500 });
-    assert.deepEqual(await db2.get(key), { n: 1 });
-    await db2.set(key, { n: 2 });
-    assert.deepEqual(await db2.get(key), { n: 2 });
+    assert.equal(await wipeCluster({ dir }), 'locked');
+    assert.deepEqual(await db1.get(key), { v: 1 });
+
+    await db1.close();
+    assert.equal(await wipeCluster({ dir }), 'wiped');
+    assert.equal(await fs.stat(dir).catch(() => null), null);
+
+    const db2 = await ClusterDb.open({ dir, shardCount: 4, valueCodec: 'json' });
+    assert.equal(await db2.get(key), undefined);
+    await db2.set('after', { v: 2 });
+    assert.deepEqual(await db2.get('after'), { v: 2 });
     await db2.close();
   } finally {
     await rmrf(dir);

--- a/packages/minidb/test/cluster/lock.test.ts
+++ b/packages/minidb/test/cluster/lock.test.ts
@@ -8,7 +8,9 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { MiniDb } from '../../src/index.js';
 import { ClusterDb, wipeCluster } from '../../src/cluster/index.js';
+import { LockError, LockFile } from '../../src/lockfile.js';
 import { ShardLockPool } from '../../src/cluster/lock-pool.js';
 import { ShardHandle } from '../../src/cluster/shard.js';
 import { shardDirName } from '../../src/cluster/utils.js';
@@ -68,6 +70,38 @@ test('wipe refuses while any shard writer is held and proceeds once released', a
     await db2.set('after', { v: 2 });
     assert.deepEqual(await db2.get('after'), { v: 2 });
     await db2.close();
+
+    const siblings = await fs.readdir(path.dirname(dir));
+    assert.equal(
+      siblings.filter((entry) => entry.startsWith(`${path.basename(dir)}.wiping-`)).length,
+      0,
+      'wipe leaves no isolated-tree residue behind',
+    );
+
+    const single = await tmpDir('minidb-cluster-single-');
+    try {
+      const wiper = new LockFile(path.join(single, 'db.lock'));
+      assert.equal(await wiper.acquire(), true);
+      const moved = `${single}.isolated`;
+      await fs.rename(single, moved);
+      const fresh = await MiniDb.open({ dir: single, valueCodec: 'string' });
+      await fresh.set('k', 'v');
+      await wiper.release();
+      assert.equal(
+        await fs.stat(path.join(moved, 'db.lock')).then(() => true, () => false),
+        true,
+        'release after the rename neither follows the moved corpse nor errors',
+      );
+      await assert.rejects(
+        () => MiniDb.open({ dir: single, valueCodec: 'string' }),
+        LockError,
+        'release after the rename never unlinks the new owner\'s lock',
+      );
+      await fresh.close();
+      await rmrf(moved);
+    } finally {
+      await rmrf(single);
+    }
   } finally {
     await rmrf(dir);
   }

--- a/packages/minidb/test/degrade.test.ts
+++ b/packages/minidb/test/degrade.test.ts
@@ -4,21 +4,14 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { MiniDb } from '../src/index.js';
+import { MiniDb, classifyStorageError } from '../src/index.js';
+import { CorruptFrameError } from '../src/codec.js';
 import { LockError } from '../src/lockfile.js';
+import { retryEperm } from '../src/rename-replace.js';
 
 async function tmpDir() {
   return fs.mkdtemp(path.join(os.tmpdir(), 'minidb-degrade-'));
 }
-
-test('openOrRebuild opens a healthy db normally', async () => {
-  const dir = await tmpDir();
-  const db = await MiniDb.openOrRebuild({ dir, valueCodec: 'string' });
-  await db.set('a', '1');
-  assert.equal(db.get('a'), '1');
-  await db.close();
-  await fs.rm(dir, { recursive: true, force: true });
-});
 
 test('openOrRebuild preserves data when only a sidecar definition file is corrupt', async () => {
   const dir = await tmpDir();
@@ -118,4 +111,48 @@ test('openOrRebuild with onLockFail readonly + a garbage WAL (strict) degrades t
     await writer.close();
     await fs.rm(dir, { recursive: true, force: true });
   }
+});
+
+test('classifyStorageError and retryEperm drive the rebuild/transient recovery policy', async () => {
+  const walDisabled = Object.assign(new Error('disabled'), { code: 'WAL_WRITE_DISABLED' });
+  const walPoisoned = Object.assign(new Error('poisoned'), { code: 'WAL_POISONED' });
+  assert.equal(classifyStorageError(walDisabled), 'rebuild');
+  assert.equal(classifyStorageError(walPoisoned), 'rebuild');
+  assert.equal(classifyStorageError(new CorruptFrameError('bad frame', 0)), 'rebuild');
+  assert.equal(classifyStorageError(new SyntaxError('unexpected token')), 'rebuild');
+  assert.equal(classifyStorageError(new AggregateError([new Error('x'), walPoisoned], 'partial')), 'rebuild');
+  assert.equal(classifyStorageError(new AggregateError([new Error('x'), new LockError('locked')], 'partial')), 'transient');
+  assert.equal(classifyStorageError(new LockError('locked')), 'transient');
+  assert.equal(classifyStorageError(Object.assign(new Error('perm'), { code: 'EPERM' })), 'transient');
+  assert.equal(classifyStorageError(new Error('unknown')), 'transient');
+
+  const eperm = () => Object.assign(new Error('operation not permitted'), { code: 'EPERM' });
+  let attempts = 0;
+  const recovered = await retryEperm(async () => {
+    attempts += 1;
+    if (attempts < 3) throw eperm();
+    return 'ok';
+  }, { baseDelayMs: 1 });
+  assert.equal(recovered, 'ok');
+  assert.equal(attempts, 3);
+
+  attempts = 0;
+  await assert.rejects(
+    retryEperm(async () => {
+      attempts += 1;
+      throw new Error('not eperm');
+    }),
+    /not eperm/,
+  );
+  assert.equal(attempts, 1);
+
+  attempts = 0;
+  await assert.rejects(
+    retryEperm(async () => {
+      attempts += 1;
+      throw eperm();
+    }, { retries: 2, baseDelayMs: 1 }),
+    /operation not permitted/,
+  );
+  assert.equal(attempts, 3);
 });


### PR DESCRIPTION
## Related Issue

Related to #3535 (same family of permanent minidb write failures; this PR changes the failure posture to bounded degradation and automatic rebuild, but does not remove the hardlink dependency tracked there).

## Problem

User report: on Windows with a large session store (≈1.8 GB index, ≈382 MB WAL), the log repeatedly prints "index shard write failed" and the client gets progressively slower until it is unusable.

Root cause (verified on main): the session-index read model and the global search index are rebuildable derived caches over the transcript/session files, but they are protected with authoritative-store durability semantics. A single transient I/O failure (e.g. an antivirus or indexer holding the WAL on Windows) poisons the WAL and permanently disables writes for the process lifetime (`WAL_WRITE_DISABLED`). Every later failure is then amplified: the search sync persists per-file progress only in the final batch, so any failed batch discards the whole round's work and re-reads the same backlog on every pass while duplicating it into the WAL; batch rollbacks abort generation builds, so no new checkpoint is ever published; and the search worker keeps the whole corpus in the V8 heap (memory valueMode), so a large index eventually OOM-loops on a defeated 500 ms restart backoff. The session index adds its own background load: an unconditional full reconcile every 60 s and an almost-guaranteed full reprojection on every startup. Since #3552 made both always-on in 0.42.0, large-store users hit this chronically.

## What changed

Recovery posture — errors drive bounded recovery instead of infinite retry plus log spam:

- New `classifyStorageError` in minidb: poison/corruption (`WAL_WRITE_DISABLED`, `WAL_POISONED`, `CorruptFrameError`, `SyntaxError`) → rebuild; locks/errno/unknown → transient; unknowns escalate to rebuild after 5 consecutive failures, tracked independently per operation kind (reads and writes no longer escalate each other). Shared by both consumers.
- Session-index query store: runtime failures go through the wipe-and-reproject rebuild channel, now guarded by a live-lock probe so a peer's store is never deleted, and the rebuild latch resets so repeated rebuilds actually work.
- Search worker: on rebuild-class failure (or 5 consecutive sync failures) the index directory is wiped and reopened; the degraded window surfaces through the existing building/ready/readonly status instead of per-session warn spam.
- The in-place WAL recovery's `fs.truncate` now retries EPERM with the same bounded policy as rename-replace, so a transient Windows file lock no longer becomes a permanent write-disable.

Rebuild is routine, not catastrophic:

- Search sync persists per-file offset/turn/step state in every batch, so progress survives a failed batch and is never re-read or re-written (the 382 MB duplicate-write WAL pattern).
- Each sync round has a byte (64 MB) and wall-clock (30 s) budget; a truncated round reschedules itself and drains the backlog incrementally — a rebuild is just "sync from offset zero".
- Search index runs with `valueMode: 'disk'` (an existing engine-supported larger-than-RAM mode), decoupling worker memory from corpus size.
- Worker crash backoff decays instead of resetting to 500 ms after any >60 s session.
- Sessions whose transcripts stay unreadable after 5 sync rounds are skipped with a 5-minute cooldown instead of forever, and retried immediately once their content changes.

Session-index freshness is journal-driven (no steady-state full scans):

- Session mutations register a dirty mark (`sessions/.index-dirty/<id>.<ms>`) through the session-index mirror — before the database gate, so one-shot CLI processes are registered too; deletions register through the index remove path.
- The periodic freshness check is readdir-only (dirty set + session count): no per-session stat calls (measured ≈7 ms / 0 stats on 6k sessions, down from ≈130–280 ms / 12k stats).
- Reconciliation is targeted: journaled ids plus id-set differences (which catch unjournaled adds/deletes) drive upserts/removals against only the changed sessions' summaries (2 reads per change instead of 2 per session); workspace counters update by deltas. A schema-version bump (1 → 2) migrates existing manifests through one full reprojection.
- Startup reconciliation failure without a published generation now surfaces as degraded instead of silently serving nothing.
- Accepted trade-off: edits made outside Kimi processes (hand-edited session files leave no dirty mark) are not detected until restart/rebuild.

Background load made bounded and observable:

- The 60 s reconcile is skipped when the journal/count check shows no session changes.
- Startup with a stale manifest incrementally reconciles the published generation instead of always doing a full reprojection into a new one (full reprojection is kept for schema changes/corruption).
- Mirror/degraded log lines are emitted once per failure episode (plus one on recovery) instead of on every retry; compaction and generation-publish failures surface via status and transition logs instead of being swallowed.

Verification: focused suites (minidb degrade/generation/wal, query-store, sessionIndex, kap-server search) plus the full repo suite (879 files / 15822 tests, two full combined runs) pass on Linux; the Windows-only retry behavior passes on a Windows host.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
