### PR TITLE
fix(remote-control): carry server token in rc local UI link

### DIFF
--- a/.changeset/rc-local-ui-token.md
+++ b/.changeset/rc-local-ui-token.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Include the server token in the Remote Control Local UI link so it opens already signed in.

--- a/apps/kimi-code/src/cli/sub/web/remote-control.ts
+++ b/apps/kimi-code/src/cli/sub/web/remote-control.ts
@@ -4,6 +4,7 @@ import { getVersion } from '../../version';
 import { darkColors } from '../../../tui/theme/colors';
 import { supportsHyperlinks, toTerminalHyperlink } from '../../../utils/terminal-hyperlink';
 import type { RemoteControlStatus } from '@moonshot-ai/remote-control';
+import { buildOpenableUrl, splitTokenFragment } from './access-urls';
 
 export {
   acquireRemoteControlLock,
@@ -32,6 +33,7 @@ export type {
 export interface RemoteControlOutputOptions {
   readonly url: string;
   readonly localOrigin: string;
+  readonly localServerToken: string;
   readonly deviceName: string;
   readonly qrCode: string;
   readonly pngPath: string;
@@ -41,12 +43,16 @@ export function formatRemoteControlOutput(options: RemoteControlOutputOptions): 
   const title = (text: string): string => chalk.bold.hex(darkColors.primary)(text);
   const label = (text: string): string => chalk.bold.hex(darkColors.textDim)(text);
   const accent = (text: string): string => chalk.hex(darkColors.accent)(text);
+  const dim = (text: string): string => chalk.hex(darkColors.textDim)(text);
   const muted = (text: string): string => chalk.hex(darkColors.textMuted)(text);
   const status = (text: string): string => chalk.hex(darkColors.success)(text);
   const link = (url: string): string =>
     supportsHyperlinks() ? toTerminalHyperlink(accent(url), url) : accent(url);
   const docs = toTerminalHyperlink('docs', 'https://kimi.com/code/docs/remote-control');
   const feedback = toTerminalHyperlink('feedback', 'https://kimi.com/code/feedback');
+  const [localBase, localFrag] = splitTokenFragment(
+    buildOpenableUrl(options.localOrigin, options.localServerToken),
+  );
   return [
     '',
     `  ${title('Kimi Remote Control ready')}  ${muted(getVersion())}`,
@@ -62,7 +68,7 @@ export function formatRemoteControlOutput(options: RemoteControlOutputOptions): 
     '',
     options.qrCode.trimEnd().replaceAll(/^/gm, '    '),
     `  ${label('QR code PNG: ')}${options.pngPath} ${muted('(open this if the QR above does not scan)')}`,
-    `  ${label('Local UI: ')}${muted(options.localOrigin)} ${muted('(LAN: --host)')}`,
+    `  ${label('Local UI: ')}${accent(localBase)}${dim(localFrag)} ${muted('(LAN: --host)')}`,
     '',
     `  ${docs} ${muted('·')} ${feedback}`,
     `  ${label('Logs: ')}${muted('off (--log-level info)')} ${muted('·')} ${label('Stop: ')}${muted('Ctrl+C')}`,

--- a/apps/kimi-code/src/cli/sub/web/run.ts
+++ b/apps/kimi-code/src/cli/sub/web/run.ts
@@ -233,6 +233,7 @@ export async function handleWebCommand(
           formatRemoteControlOutput({
             url: remoteControl.url,
             localOrigin: origin,
+            localServerToken: token,
             deviceName: remoteControl.deviceName,
             qrCode: qrCode.terminal,
             pngPath: qrCode.pngPath,

--- a/apps/kimi-code/src/tui/commands/web.ts
+++ b/apps/kimi-code/src/tui/commands/web.ts
@@ -80,6 +80,7 @@ export async function handleRemoteControlCommand(host: SlashCommandHost): Promis
             formatRemoteControlOutput({
               url,
               localOrigin: origin,
+              localServerToken: token,
               deviceName: remoteControl.deviceName,
               qrCode: qrCode.terminal,
               pngPath: qrCode.pngPath,

--- a/apps/kimi-code/test/cli/web/remote-control.test.ts
+++ b/apps/kimi-code/test/cli/web/remote-control.test.ts
@@ -13,6 +13,7 @@ describe('Remote Control output', () => {
   const outputOptions = {
     url: 'https://example.test/devices/example-device/?rc=1&from=kimi_code_cli',
     localOrigin: 'http://127.0.0.1:1234',
+    localServerToken: 'example-token',
     deviceName: 'example-device',
     qrCode: 'QR\n',
     pngPath: '/tmp/example-qr.png',
@@ -32,6 +33,8 @@ describe('Remote Control output', () => {
       .replaceAll(/\u001B\[[0-9;]*m/g, '');
     expect(plain).toContain(`open ${url}`);
     expect(plain).not.toContain('exampl…');
+    expect(plain).toContain('http://127.0.0.1:1234/#token=example-token');
+    expect(output).toContain('#token=example-token');
     expect(output).toContain('Connected to example.test');
     expect(output).toContain('This device:');
     expect(output).not.toContain('Manage devices');
@@ -48,6 +51,7 @@ describe('Remote Control output', () => {
     vi.stubEnv('FORCE_HYPERLINK', '0');
     const output = formatRemoteControlOutput(outputOptions);
     expect(output).toContain(`open ${outputOptions.url}`);
+    expect(output).toContain('#token=example-token');
     expect(output).not.toContain('exampl…vice');
     expect(output).not.toContain('Manage devices');
   });

--- a/apps/kimi-code/test/tui/commands/web.test.ts
+++ b/apps/kimi-code/test/tui/commands/web.test.ts
@@ -243,8 +243,11 @@ describe('handleRemoteControlCommand', () => {
       const png = readFileSync(pngPath);
       expect(png.subarray(0, 8)).toEqual(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
       expect(png).toEqual(await QRCode.toBuffer(sessionUrl));
-      expect(written).not.toContain('local-server-token');
-      expect(written).not.toContain('#token=');
+      expect(written).toContain(
+        'Local UI: http://127.0.0.1:58627/#token=local-server-token',
+      );
+      expect(written).not.toContain(`${entryUrl}#token=`);
+      expect(written).not.toContain(`${sessionUrl}#token=`);
       expect(close).toHaveBeenCalledOnce();
     } finally {
       writeSpy.mockRestore();


### PR DESCRIPTION
## Related Issue

None — reported directly by an internal user; the problem is explained below.

## Problem

In remote-control mode (`kimi web --rc` and the TUI `/rc` command), the `Local UI:` line printed to the terminal shows the bare localhost origin without the `#token=` fragment. In non-rc mode (`kimi web` / TUI `/web`) the opened URL carries `#token=`, so the web UI authenticates automatically on load. With rc running, clicking the Local UI link instead hits the server-auth login dialog even though the terminal just printed a token-authenticated relay URL.

## What changed

- `RemoteControlOutputOptions` gains a required `localServerToken`; the `Local UI:` line is now built with `buildOpenableUrl(localOrigin, token)` so it carries `#token=`, and the fragment is rendered dim (base in accent) via `splitTokenFragment`, matching the ready banner's access-link styling.
- Both rc call sites pass the token they already resolve and require: `kimi web --rc` (`cli/sub/web/run.ts`) and TUI `/rc` (`tui/commands/web.ts`).
- Existing `formatRemoteControlOutput` tests updated to cover the token fragment; no new test cases added.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
