### PR TITLE
feat(kap-server): add steer flag to submit a prompt directly into the running turn

### DIFF
--- a/docs/en/reference/server-api.md
+++ b/docs/en/reference/server-api.md
@@ -1022,7 +1022,7 @@ On success, `data` is `{ active, queued }`: `active` is the running prompt (`nul
 
 #### `POST /api/v1/sessions/{session_id}/prompts`
 
-Submits a user prompt to the session. Media references are validated first, then the optional overrides are applied to the target agent — `profile` (bound together with `model` / `thinking`), then `model`, `thinking`, `permission_mode`, and `disabled_tools` — and the prompt is enqueued; the response returns as soon as the prompt is accepted, without waiting for the turn. With `skills`, the prompt runs as a bundled skill activation instead of a plain user prompt.
+Submits a user prompt to the session. Media references are validated first, then the optional overrides are applied to the target agent — `profile` (bound together with `model` / `thinking`), then `model`, `thinking`, `permission_mode`, and `disabled_tools` — and the prompt is enqueued; the response returns as soon as the prompt is accepted, without waiting for the turn. With `steer: true`, a prompt submitted while the session is busy is steered directly into the running turn instead of waiting in the queue — the one-call form of submitting and then calling `POST /api/v1/sessions/{session_id}/prompts:steer`; on an idle session it starts a new turn as usual. With `skills`, the prompt runs as a bundled skill activation instead of a plain user prompt.
 
 | Parameter | In | Type | Description |
 | --- | --- | --- | --- |
@@ -1030,6 +1030,7 @@ Submits a user prompt to the session. Media references are validated first, then
 | `content` | body | array | **Required.** Non-empty array of content parts; variants below |
 | `agent_id` | body | string | Target agent. Default the main agent |
 | `prompt_id` | body | string | Client-chosen prompt id for idempotent submission; an id already reserved by an in-flight prompt fails `40927`, one that has already completed fails `40903`. Cannot be combined with `skills` |
+| `steer` | body | boolean | When `true`, steer the prompt directly into the running turn on a busy session instead of queueing it; a no-op on an idle session, where the prompt starts a new turn as usual. Cannot be combined with `skills` |
 | `skills` | body | array | Bundled skill activations, at least 1 entry of `{ name, args? }`; every skill must exist and be user-activatable |
 | `profile` | body | string | Agent profile to bind before submitting |
 | `model` | body | string | Model alias to switch the agent to |
@@ -1049,7 +1050,7 @@ The schema also accepts the `tool_use`, `tool_result`, and `thinking` parts of t
 
 On success, `data` is the accepted prompt `{ prompt_id, user_message_id, status, content, created_at }`.
 
-- `40001`: validation failure — for example `prompt_id` combined with `skills`, or an unknown `profile`
+- `40001`: validation failure — for example `prompt_id` or `steer` combined with `skills`, or an unknown `profile`
 - `40110`: no provider configured yet — finish login first
 - `40111`: the resolved provider has no credential (`details.provider_id`)
 - `40112`: the provider's credential was rejected (`details.provider_id`)

--- a/docs/zh/reference/server-api.md
+++ b/docs/zh/reference/server-api.md
@@ -1022,7 +1022,7 @@ main agent 的实时状态汇总；读取它会在会话为冷态时将其恢复
 
 #### `POST /api/v1/sessions/{session_id}/prompts`
 
-向会话提交一条用户提示词。先校验媒体引用，然后把可选的覆盖项应用到目标 Agent——`profile`（与 `model` / `thinking` 一起绑定），接着是 `model`、`thinking`、`permission_mode` 和 `disabled_tools`——随后提示词入队；响应在提示词被接受后立即返回，不等待轮次执行。提供 `skills` 时，提示词以打包的 Skill 激活方式运行，而不是普通用户提示词。
+向会话提交一条用户提示词。先校验媒体引用，然后把可选的覆盖项应用到目标 Agent——`profile`（与 `model` / `thinking` 一起绑定），接着是 `model`、`thinking`、`permission_mode` 和 `disabled_tools`——随后提示词入队；响应在提示词被接受后立即返回，不等待轮次执行。提供 `steer: true` 时，会话忙碌期间提交的提示词直接插入进行中的轮次，而不是在队列中等待——相当于提交后再调用 `POST /api/v1/sessions/{session_id}/prompts:steer` 的一次调用形式；会话空闲时则照常开启新轮次。提供 `skills` 时，提示词以打包的 Skill 激活方式运行，而不是普通用户提示词。
 
 | 参数 | 位置 | 类型 | 说明 |
 | --- | --- | --- | --- |
@@ -1030,6 +1030,7 @@ main agent 的实时状态汇总；读取它会在会话为冷态时将其恢复
 | `content` | body | array | **必填。** 非空的内容块数组；变体见下 |
 | `agent_id` | body | string | 目标 Agent。默认为 main agent |
 | `prompt_id` | body | string | 客户端选定的提示词 id，用于幂等提交；已被进行中提示词占用的 id 返回 `40927`，已完成的返回 `40903`。不能与 `skills` 同用 |
+| `steer` | body | boolean | 为 `true` 时，会话忙碌期间提交的提示词直接插入进行中的轮次而不是排队等待；会话空闲时为无操作，提示词照常开启新轮次。不能与 `skills` 同用 |
 | `skills` | body | array | 打包的 Skill 激活，至少 1 个 `{ name, args? }` 条目；每个 Skill 必须存在且可由用户激活 |
 | `profile` | body | string | 提交前要绑定的 Agent 档案 |
 | `model` | body | string | 要切换到的模型别名 |
@@ -1049,7 +1050,7 @@ schema 还接受共享消息格式中的 `tool_use`、`tool_result` 和 `thinkin
 
 成功时，`data` 为被接受的提示词 `{ prompt_id, user_message_id, status, content, created_at }`。
 
-- `40001`：校验失败——例如 `prompt_id` 与 `skills` 同用，或未知的 `profile`
+- `40001`：校验失败——例如 `prompt_id` 或 `steer` 与 `skills` 同用，或未知的 `profile`
 - `40110`：尚未配置供应商——请先完成登录
 - `40111`：解析出的供应商没有凭据（`details.provider_id`）
 - `40112`：供应商的凭据被拒绝（`details.provider_id`）

--- a/packages/kap-server/src/protocol/rest-prompt.ts
+++ b/packages/kap-server/src/protocol/rest-prompt.ts
@@ -30,6 +30,7 @@ export const promptSubmissionSchema = z.object({
   goal_control: z.enum(['pause', 'resume', 'cancel']).optional(),
   disabled_tools: z.array(z.string()).optional(),
   prompt_id: z.string().min(1).optional(),
+  steer: z.boolean().optional(),
   skills: z.array(promptSkillActivationSchema).min(1).optional(),
 });
 export type PromptSubmission = z.infer<typeof promptSubmissionSchema>;

--- a/packages/kap-server/src/routes/prompts.ts
+++ b/packages/kap-server/src/routes/prompts.ts
@@ -238,6 +238,12 @@ export function registerPromptsRoutes(app: PromptRouteHost, core: Scope): void {
               'prompt_id cannot be combined with a bundled skill submission',
             );
           }
+          if (req.body.steer === true) {
+            throw new Error2(
+              ErrorCodes.REQUEST_INVALID,
+              'steer cannot be combined with a bundled skill submission',
+            );
+          }
           await assertActivatableSkills(
             session.accessor.get(ISessionSkillCatalog),
             req.body.skills,
@@ -354,6 +360,13 @@ export function registerPromptsRoutes(app: PromptRouteHost, core: Scope): void {
           origin: { kind: 'user', attachments: promptAttachments },
         });
         enqueued = true;
+        if (req.body.steer === true && handle.state === 'pending') {
+          try {
+            await resolved.prompt.steer([handle.id]);
+          } catch (error) {
+            if (!(isError2(error) && error.code === ErrorCodes.PROMPT_NOT_FOUND)) throw error;
+          }
+        }
         const staging = preparedMedia;
         void Promise.race([handle.launched, handle.completion]).then(
           () => staging?.discard(),

--- a/packages/kap-server/test/prompts.test.ts
+++ b/packages/kap-server/test/prompts.test.ts
@@ -9,6 +9,7 @@ import {
   IAgentTitlePromptSource,
   IAgentContextMemoryService,
   IAgentLifecycleService,
+  IAgentLoopService,
   IAgentPermissionModeService,
   IAgentProfileService,
   IAgentStateService,
@@ -305,6 +306,55 @@ describe('server-v2 /api/v1 prompts', () => {
     expect(Array.isArray(list.body.data.queued)).toBe(true);
   });
 
+  it('steers a submission directly into the running turn when steer is true', async () => {
+    const id = await createSession(home as string);
+    await createMainAgent(id);
+    await setSessionModel(id, 'stub');
+    const session = getLiveSessionById(server!.core.accessor, id)!;
+    const agent = session.accessor.get(IAgentLifecycleService).handleOf('main')!;
+    const loop = agent.accessor.get(IAgentLoopService);
+
+    let releaseStep!: () => void;
+    const stepGate = new Promise<void>((resolve) => {
+      releaseStep = resolve;
+    });
+    let stepHeld = false;
+    const hook = loop.hooks.onWillBeginStep.register('test-hold-step', async (_context, next) => {
+      stepHeld = true;
+      await stepGate;
+      await next();
+    });
+    try {
+      const first = await call<PromptItemWire>('POST', `/api/v1/sessions/${id}/prompts`, {
+        content: [{ type: 'text', text: 'first' }],
+      });
+      expect(first.body.code).toBe(0);
+      expect(first.body.data.status).toBe('running');
+      await vi.waitFor(() => {
+        expect(stepHeld).toBe(true);
+      }, { timeout: 10_000 });
+
+      const steered = await call<PromptItemWire>('POST', `/api/v1/sessions/${id}/prompts`, {
+        content: [{ type: 'text', text: 'steer me' }],
+        steer: true,
+      });
+      expect(steered.body.code).toBe(0);
+      expect(steered.body.data.status).toBe('running');
+      expect(steered.body.data.prompt_id).not.toBe(first.body.data.prompt_id);
+
+      const list = await call<{ active: PromptItemWire | null; queued: PromptItemWire[] }>(
+        'GET',
+        `/api/v1/sessions/${id}/prompts`,
+      );
+      expect(list.body.code).toBe(0);
+      expect(list.body.data.active?.prompt_id).toBe(first.body.data.prompt_id);
+      expect(list.body.data.queued).toEqual([]);
+    } finally {
+      releaseStep();
+      hook.dispose();
+    }
+  });
+
   it('accepts a prompt-carried model when default_model is not configured', async () => {
     await writeConfigToml(home as string, PROMPT_TOML_NO_DEFAULT);
     const id = await createSession(home as string);
@@ -566,7 +616,7 @@ describe('server-v2 /api/v1 prompts', () => {
     expect(session!.accessor.get(IAgentLifecycleService).handleOf('main')).toBeUndefined();
   });
 
-  it('rejects a bundled prompt_id combination before any override or agent materialization', async () => {
+  it('rejects a bundled prompt_id or steer combination before any override or agent materialization', async () => {
     const id = await createSession(home as string);
 
     const submitted = await call<null>('POST', `/api/v1/sessions/${id}/prompts`, {
@@ -576,6 +626,14 @@ describe('server-v2 /api/v1 prompts', () => {
       skills: [{ name: 'update-config' }],
     });
     expect(submitted.body.code).toBe(40001);
+
+    const steered = await call<null>('POST', `/api/v1/sessions/${id}/prompts`, {
+      content: [{ type: 'text', text: 'Review this change.' }],
+      permission_mode: 'yolo',
+      steer: true,
+      skills: [{ name: 'update-config' }],
+    });
+    expect(steered.body.code).toBe(40001);
 
     const session = getLiveSessionById(server!.core.accessor, id);
     expect(session!.accessor.get(IAgentLifecycleService).handleOf('main')).toBeUndefined();
@@ -1568,7 +1626,7 @@ describe('server-v2 /api/v1 prompts', () => {
     expect(body.code).toBe(40001);
   });
 
-  it('returns 40402 when aborting a prompt that already settled', async () => {
+  it('returns 40402 when aborting a prompt that already settled or never existed', async () => {
     const id = await createSession(home as string);
     await createMainAgent(id);
 
@@ -1582,17 +1640,12 @@ describe('server-v2 /api/v1 prompts', () => {
       `/api/v1/sessions/${id}/prompts/${promptId}:abort`,
     );
     expect(aborted.body.code).toBe(40402);
-  });
 
-  it('returns 40402 when aborting an unknown prompt', async () => {
-    const id = await createSession(home as string);
-    await createMainAgent(id);
-
-    const { body } = await call<null>(
+    const unknown = await call<null>(
       'POST',
       `/api/v1/sessions/${id}/prompts/prompt_does_not_exist:abort`,
     );
-    expect(body.code).toBe(40402);
+    expect(unknown.body.code).toBe(40402);
   });
 
   it('returns 40401 for an unknown session', async () => {


### PR DESCRIPTION
## Related Issue

Internal feature request (no linked issue).

## Problem

API clients that want to steer a fresh message into the active turn must use a two-step flow: submit a prompt (which lands in the queue on a busy session), then call `POST /api/v1/sessions/{session_id}/prompts:steer` with the returned prompt id. The engine (`IAgentPromptService.submitSteer`) and the internal node-sdk RPC lane (`session.steer`) already support one-shot steering, but the public REST surface does not.

## What changed

- `POST /api/v1/sessions/{session_id}/prompts` accepts a new optional `steer` boolean. With `steer: true`, a prompt submitted while the session is busy is steered directly into the running turn — the one-call form of submitting and then steering; on an idle session the prompt starts a new turn as usual. The submit response keeps its shape and reports the prompt's real state (`running` / `queued`).
- A race where the active turn ends between submission and steering is tolerated the same way the engine's `submitSteer` handles it: the prompt simply stays queued instead of failing the request.
- `steer` combined with `skills` is rejected with `40001`, matching the existing `prompt_id` + `skills` rule.
- The parameter is documented in `docs/en/reference/server-api.md` and `docs/zh/reference/server-api.md`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
