### PR TITLE
feat(remote-control): compress textual tunnel responses with gzip

### DIFF
--- a/.changeset/tunnel-response-gzip.md
+++ b/.changeset/tunnel-response-gzip.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Compress Remote Control tunnel responses with gzip.

--- a/packages/remote-control/src/remote-control.ts
+++ b/packages/remote-control/src/remote-control.ts
@@ -857,15 +857,12 @@ function requestLocalHttp(
             const rewritten = body !== receivedBody;
             const headers = filterResponseHeaders(response.rawHeaders, rewritten);
             if (rewritten) headers.push('Cache-Control', 'no-cache');
-            if (
+            const negotiated =
               response.headers['content-encoding'] === undefined &&
               response.statusCode !== 206 &&
               body.length >= GZIP_MIN_BODY_BYTES &&
-              isGzipCompressibleType(contentType) &&
-              acceptsGzipEncoding(parsed.headers)
-            ) {
-              body = await gzipAsync(body);
-              headers.push('Content-Encoding', 'gzip');
+              isGzipCompressibleType(contentType);
+            if (negotiated) {
               let varyCovers = false;
               for (let index = 0; index < headers.length; index += 2) {
                 if (headers[index]!.toLowerCase() !== 'vary') continue;
@@ -876,6 +873,15 @@ function requestLocalHttp(
                 if (tokens.includes('*') || tokens.includes('accept-encoding')) varyCovers = true;
               }
               if (!varyCovers) headers.push('Vary', 'Accept-Encoding');
+            }
+            if (negotiated && acceptsGzipEncoding(parsed.headers)) {
+              body = await gzipAsync(body);
+              headers.push('Content-Encoding', 'gzip');
+              for (let index = 0; index < headers.length; index += 2) {
+                if (headers[index]!.toLowerCase() === 'etag') {
+                  headers[index + 1] = headers[index + 1]!.replace(/"$/, '-gzip"');
+                }
+              }
             }
             headers.push('Content-Length', String(body.length));
             const statusCode = response.statusCode ?? 502;

--- a/packages/remote-control/src/remote-control.ts
+++ b/packages/remote-control/src/remote-control.ts
@@ -877,10 +877,8 @@ function requestLocalHttp(
             if (negotiated && acceptsGzipEncoding(parsed.headers)) {
               body = await gzipAsync(body);
               headers.push('Content-Encoding', 'gzip');
-              for (let index = 0; index < headers.length; index += 2) {
-                if (headers[index]!.toLowerCase() === 'etag') {
-                  headers[index + 1] = headers[index + 1]!.replace(/"$/, '-gzip"');
-                }
+              for (let index = headers.length - 2; index >= 0; index -= 2) {
+                if (headers[index]!.toLowerCase() === 'etag') headers.splice(index, 2);
               }
             }
             headers.push('Content-Length', String(body.length));

--- a/packages/remote-control/src/remote-control.ts
+++ b/packages/remote-control/src/remote-control.ts
@@ -2,7 +2,8 @@ import { hostname, platform } from 'node:os';
 import { join } from 'node:path';
 import { request as httpRequest, validateHeaderName, validateHeaderValue } from 'node:http';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { gzipSync } from 'node:zlib';
+import { promisify } from 'node:util';
+import { gzip } from 'node:zlib';
 
 import {
   createKimiDeviceId,
@@ -67,6 +68,7 @@ const GZIP_COMPRESSIBLE_TYPES = new Set([
   'application/xml',
   'image/svg+xml',
 ]);
+const gzipAsync = promisify(gzip);
 
 interface RelayMessage {
   readonly type: string;
@@ -845,44 +847,44 @@ function requestLocalHttp(
         response.on('data', (chunk: Buffer | string) => chunks.push(Buffer.from(chunk)));
         response.once('error', reject);
         response.once('end', () => {
-          const contentType = response.headers['content-type'] ?? '';
-          const receivedBody = Buffer.concat(chunks);
-          let body =
-            response.headers['content-encoding'] === undefined
-              ? rewriteRemoteControlResponse(contentType, receivedBody, publicPrefix)
-              : receivedBody;
-          const rewritten = body !== receivedBody;
-          const headers = filterResponseHeaders(response.rawHeaders, rewritten);
-          if (rewritten) headers.push('Cache-Control', 'no-cache');
-          if (
-            response.headers['content-encoding'] === undefined &&
-            response.statusCode !== 206 &&
-            body.length >= GZIP_MIN_BODY_BYTES &&
-            isGzipCompressibleType(contentType) &&
-            acceptsGzipEncoding(parsed.headers)
-          ) {
-            body = gzipSync(body);
-            headers.push('Content-Encoding', 'gzip');
-            let varyCovers = false;
-            for (let index = 0; index < headers.length; index += 2) {
-              if (headers[index]!.toLowerCase() !== 'vary') continue;
-              const tokens = headers[index + 1]!
-                .toLowerCase()
-                .split(',')
-                .map((token) => token.trim());
-              if (tokens.includes('*') || tokens.includes('accept-encoding')) varyCovers = true;
+          void (async (): Promise<Buffer> => {
+            const contentType = response.headers['content-type'] ?? '';
+            const receivedBody = Buffer.concat(chunks);
+            let body =
+              response.headers['content-encoding'] === undefined
+                ? rewriteRemoteControlResponse(contentType, receivedBody, publicPrefix)
+                : receivedBody;
+            const rewritten = body !== receivedBody;
+            const headers = filterResponseHeaders(response.rawHeaders, rewritten);
+            if (rewritten) headers.push('Cache-Control', 'no-cache');
+            if (
+              response.headers['content-encoding'] === undefined &&
+              response.statusCode !== 206 &&
+              body.length >= GZIP_MIN_BODY_BYTES &&
+              isGzipCompressibleType(contentType) &&
+              acceptsGzipEncoding(parsed.headers)
+            ) {
+              body = await gzipAsync(body);
+              headers.push('Content-Encoding', 'gzip');
+              let varyCovers = false;
+              for (let index = 0; index < headers.length; index += 2) {
+                if (headers[index]!.toLowerCase() !== 'vary') continue;
+                const tokens = headers[index + 1]!
+                  .toLowerCase()
+                  .split(',')
+                  .map((token) => token.trim());
+                if (tokens.includes('*') || tokens.includes('accept-encoding')) varyCovers = true;
+              }
+              if (!varyCovers) headers.push('Vary', 'Accept-Encoding');
             }
-            if (!varyCovers) headers.push('Vary', 'Accept-Encoding');
-          }
-          headers.push('Content-Length', String(body.length));
-          const statusCode = response.statusCode ?? 502;
-          const statusMessage = response.statusMessage ?? 'Bad Gateway';
-          resolve(
-            Buffer.concat([
+            headers.push('Content-Length', String(body.length));
+            const statusCode = response.statusCode ?? 502;
+            const statusMessage = response.statusMessage ?? 'Bad Gateway';
+            return Buffer.concat([
               Buffer.from(`HTTP/1.1 ${statusCode} ${statusMessage}\r\n${headerLines(headers)}\r\n\r\n`),
               body,
-            ]),
-          );
+            ]);
+          })().then(resolve, reject);
         });
       },
     );

--- a/packages/remote-control/src/remote-control.ts
+++ b/packages/remote-control/src/remote-control.ts
@@ -856,12 +856,23 @@ function requestLocalHttp(
           if (rewritten) headers.push('Cache-Control', 'no-cache');
           if (
             response.headers['content-encoding'] === undefined &&
+            response.statusCode !== 206 &&
             body.length >= GZIP_MIN_BODY_BYTES &&
             isGzipCompressibleType(contentType) &&
             acceptsGzipEncoding(parsed.headers)
           ) {
             body = gzipSync(body);
             headers.push('Content-Encoding', 'gzip');
+            let varyCovers = false;
+            for (let index = 0; index < headers.length; index += 2) {
+              if (headers[index]!.toLowerCase() !== 'vary') continue;
+              const tokens = headers[index + 1]!
+                .toLowerCase()
+                .split(',')
+                .map((token) => token.trim());
+              if (tokens.includes('*') || tokens.includes('accept-encoding')) varyCovers = true;
+            }
+            if (!varyCovers) headers.push('Vary', 'Accept-Encoding');
           }
           headers.push('Content-Length', String(body.length));
           const statusCode = response.statusCode ?? 502;

--- a/packages/remote-control/src/remote-control.ts
+++ b/packages/remote-control/src/remote-control.ts
@@ -226,16 +226,19 @@ export function rewriteRemoteControlResponse(
 }
 
 function acceptsGzipEncoding(headers: readonly [string, string][]): boolean {
+  let wildcard = false;
   for (const [name, value] of headers) {
     if (name.toLowerCase() !== 'accept-encoding') continue;
     for (const token of value.split(',')) {
       const [encoding, ...params] = token.trim().toLowerCase().split(';');
       if (encoding !== 'gzip' && encoding !== '*') continue;
       const quality = params.map((param) => param.trim()).find((param) => param.startsWith('q='));
-      if (quality === undefined || Number(quality.slice(2)) > 0) return true;
+      const acceptable = quality === undefined || Number(quality.slice(2)) > 0;
+      if (encoding === 'gzip') return acceptable;
+      wildcard = wildcard || acceptable;
     }
   }
-  return false;
+  return wildcard;
 }
 
 function isGzipCompressibleType(contentType: string): boolean {

--- a/packages/remote-control/src/remote-control.ts
+++ b/packages/remote-control/src/remote-control.ts
@@ -2,6 +2,7 @@ import { hostname, platform } from 'node:os';
 import { join } from 'node:path';
 import { request as httpRequest, validateHeaderName, validateHeaderValue } from 'node:http';
 import { setTimeout as sleep } from 'node:timers/promises';
+import { gzipSync } from 'node:zlib';
 
 import {
   createKimiDeviceId,
@@ -58,6 +59,13 @@ const BLOCKED_RESPONSE_HEADERS = new Set([
   'trailer',
   'transfer-encoding',
   'upgrade',
+]);
+const GZIP_MIN_BODY_BYTES = 1024;
+const GZIP_COMPRESSIBLE_TYPES = new Set([
+  'application/javascript',
+  'application/json',
+  'application/xml',
+  'image/svg+xml',
 ]);
 
 interface RelayMessage {
@@ -215,6 +223,24 @@ export function rewriteRemoteControlResponse(
     return Buffer.from(text);
   }
   return body;
+}
+
+function acceptsGzipEncoding(headers: readonly [string, string][]): boolean {
+  for (const [name, value] of headers) {
+    if (name.toLowerCase() !== 'accept-encoding') continue;
+    for (const token of value.split(',')) {
+      const [encoding, ...params] = token.trim().toLowerCase().split(';');
+      if (encoding !== 'gzip' && encoding !== '*') continue;
+      const quality = params.map((param) => param.trim()).find((param) => param.startsWith('q='));
+      if (quality === undefined || Number(quality.slice(2)) > 0) return true;
+    }
+  }
+  return false;
+}
+
+function isGzipCompressibleType(contentType: string): boolean {
+  const mime = contentType.split(';', 1)[0]!.trim().toLowerCase();
+  return mime.startsWith('text/') || GZIP_COMPRESSIBLE_TYPES.has(mime);
 }
 
 export async function startRemoteControl(
@@ -818,13 +844,22 @@ function requestLocalHttp(
         response.once('end', () => {
           const contentType = response.headers['content-type'] ?? '';
           const receivedBody = Buffer.concat(chunks);
-          const body =
+          let body =
             response.headers['content-encoding'] === undefined
               ? rewriteRemoteControlResponse(contentType, receivedBody, publicPrefix)
               : receivedBody;
           const rewritten = body !== receivedBody;
           const headers = filterResponseHeaders(response.rawHeaders, rewritten);
           if (rewritten) headers.push('Cache-Control', 'no-cache');
+          if (
+            response.headers['content-encoding'] === undefined &&
+            body.length >= GZIP_MIN_BODY_BYTES &&
+            isGzipCompressibleType(contentType) &&
+            acceptsGzipEncoding(parsed.headers)
+          ) {
+            body = gzipSync(body);
+            headers.push('Content-Encoding', 'gzip');
+          }
           headers.push('Content-Length', String(body.length));
           const statusCode = response.statusCode ?? 502;
           const statusMessage = response.statusMessage ?? 'Bad Gateway';

--- a/packages/remote-control/test/remote-control.test.ts
+++ b/packages/remote-control/test/remote-control.test.ts
@@ -461,6 +461,29 @@ describe('Remote Control tunnel', () => {
     );
     expect(binaryResponse.subarray(binarySeparator + 4).equals(assetPng)).toBe(true);
 
+    const excludedResponsePromise = nextJsonMessage(httpConnections[0]!);
+    httpConnections[0]!.send(
+      JSON.stringify({
+        request_id: 'request-5',
+        type: 'request',
+        is_last: true,
+        body_base64: Buffer.from(
+          'GET /assets/index.js HTTP/1.1\r\nHost: relay.test\r\nAccept-Encoding: gzip;q=0, *;q=1\r\n\r\n',
+        ).toString('base64'),
+      }),
+    );
+    const excludedResponse = Buffer.from(
+      (await excludedResponsePromise)['body_base64'] as string,
+      'base64',
+    );
+    const excludedSeparator = excludedResponse.indexOf('\r\n\r\n');
+    expect(excludedResponse.subarray(0, excludedSeparator).toString('latin1')).not.toContain(
+      'Content-Encoding',
+    );
+    expect(excludedResponse.subarray(excludedSeparator + 4).toString()).toBe(
+      assetJs.replaceAll('"/assets/', `"/coding-relay/devices/${handle.deviceId}/assets/`),
+    );
+
     managementConnections[0]!.send(
       JSON.stringify({
         type: 'open_ws',

--- a/packages/remote-control/test/remote-control.test.ts
+++ b/packages/remote-control/test/remote-control.test.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { gunzipSync } from 'node:zlib';
 
 import {
   FileTokenStorage,
@@ -274,8 +275,20 @@ describe('Remote Control tunnel', () => {
     let localHttpRequest: IncomingMessage | undefined;
     let localWsRequest: IncomingMessage | undefined;
     const localWsServer = new WebSocketServer({ noServer: true });
+    const assetJs = `const boot = "/assets/boot.js";\n${'const chunk = "/assets/chunk.js";\n'.repeat(120)}`;
+    const assetPng = Buffer.alloc(4096, 7);
     const localServer = createServer((request, response) => {
       localHttpRequest = request;
+      if (request.url === '/assets/index.js') {
+        response.writeHead(200, { 'Content-Type': 'text/javascript' });
+        response.end(assetJs);
+        return;
+      }
+      if (request.url === '/assets/logo.png') {
+        response.writeHead(200, { 'Content-Type': 'image/png' });
+        response.end(assetPng);
+        return;
+      }
       response.writeHead(200, {
         'Content-Type': 'text/html',
         'Cache-Control': 'public, max-age=31536000, immutable',
@@ -352,7 +365,7 @@ describe('Remote Control tunnel', () => {
     expect(handle.url).toContain('?rc=1&from=kimi_code_cli');
 
     const rawRequest = Buffer.from(
-      'GET / HTTP/1.1\r\nHost: relay.test\r\nAuthorization: Bearer relay-token\r\nCookie: sid=1\r\nOrigin: https://relay.test\r\nConnection: X-Hop\r\nX-Hop: remove\r\nX-Keep: yes\r\n\r\n',
+      'GET / HTTP/1.1\r\nHost: relay.test\r\nAuthorization: Bearer relay-token\r\nCookie: sid=1\r\nOrigin: https://relay.test\r\nAccept-Encoding: gzip\r\nConnection: X-Hop\r\nX-Hop: remove\r\nX-Keep: yes\r\n\r\n',
     );
     const splitAt = Math.floor(rawRequest.length / 2);
     httpConnections[0]!.send(
@@ -384,6 +397,8 @@ describe('Remote Control tunnel', () => {
     expect(localHttpRequest?.headers['x-keep']).toBe('yes');
     expect(response).not.toContain('X-Remove');
     expect(response).not.toContain('immutable');
+    expect(response).not.toContain('Content-Encoding');
+    expect(localHttpRequest?.headers['accept-encoding']).toBeUndefined();
     expect(response).toContain('Cache-Control: no-cache');
     expect(response).toContain(`/coding-relay/devices/${handle.deviceId}/boot.js`);
 
@@ -399,6 +414,52 @@ describe('Remote Control tunnel', () => {
     );
     await rotatedResponsePromise;
     await waitFor(() => localHttpRequest?.headers.authorization === 'Bearer rotated-server-token');
+
+    const gzipResponsePromise = nextJsonMessage(httpConnections[0]!);
+    httpConnections[0]!.send(
+      JSON.stringify({
+        request_id: 'request-3',
+        type: 'request',
+        is_last: true,
+        body_base64: Buffer.from(
+          'GET /assets/index.js HTTP/1.1\r\nHost: relay.test\r\nAccept-Encoding: br, gzip\r\n\r\n',
+        ).toString('base64'),
+      }),
+    );
+    const gzipResponse = Buffer.from(
+      (await gzipResponsePromise)['body_base64'] as string,
+      'base64',
+    );
+    const gzipSeparator = gzipResponse.indexOf('\r\n\r\n');
+    const gzipHead = gzipResponse.subarray(0, gzipSeparator).toString('latin1');
+    const gzipBody = gzipResponse.subarray(gzipSeparator + 4);
+    expect(gzipHead).toContain('HTTP/1.1 200 OK');
+    expect(gzipHead).toContain('Content-Encoding: gzip');
+    expect(gzipHead).toContain(`Content-Length: ${gzipBody.length}`);
+    expect(gunzipSync(gzipBody).toString()).toBe(
+      assetJs.replaceAll('"/assets/', `"/coding-relay/devices/${handle.deviceId}/assets/`),
+    );
+
+    const binaryResponsePromise = nextJsonMessage(httpConnections[0]!);
+    httpConnections[0]!.send(
+      JSON.stringify({
+        request_id: 'request-4',
+        type: 'request',
+        is_last: true,
+        body_base64: Buffer.from(
+          'GET /assets/logo.png HTTP/1.1\r\nHost: relay.test\r\nAccept-Encoding: gzip\r\n\r\n',
+        ).toString('base64'),
+      }),
+    );
+    const binaryResponse = Buffer.from(
+      (await binaryResponsePromise)['body_base64'] as string,
+      'base64',
+    );
+    const binarySeparator = binaryResponse.indexOf('\r\n\r\n');
+    expect(binaryResponse.subarray(0, binarySeparator).toString('latin1')).not.toContain(
+      'Content-Encoding',
+    );
+    expect(binaryResponse.subarray(binarySeparator + 4).equals(assetPng)).toBe(true);
 
     managementConnections[0]!.send(
       JSON.stringify({

--- a/packages/remote-control/test/remote-control.test.ts
+++ b/packages/remote-control/test/remote-control.test.ts
@@ -277,6 +277,8 @@ describe('Remote Control tunnel', () => {
     const localWsServer = new WebSocketServer({ noServer: true });
     const assetJs = `const boot = "/assets/boot.js";\n${'const chunk = "/assets/chunk.js";\n'.repeat(120)}`;
     const assetPng = Buffer.alloc(4096, 7);
+    const assetSvg = `<svg xmlns="http://www.w3.org/2000/svg">${'<rect width="100" height="100"/>'.repeat(100)}</svg>`;
+    const assetText = 'chunk of text\n'.repeat(160);
     const localServer = createServer((request, response) => {
       localHttpRequest = request;
       if (request.url === '/assets/index.js') {
@@ -287,6 +289,22 @@ describe('Remote Control tunnel', () => {
       if (request.url === '/assets/logo.png') {
         response.writeHead(200, { 'Content-Type': 'image/png' });
         response.end(assetPng);
+        return;
+      }
+      if (request.url === '/assets/logo.svg') {
+        response.writeHead(200, {
+          'Content-Type': 'image/svg+xml',
+          'Cache-Control': 'public, max-age=31536000, immutable',
+        });
+        response.end(assetSvg);
+        return;
+      }
+      if (request.url === '/assets/partial.txt' && request.headers.range !== undefined) {
+        response.writeHead(206, {
+          'Content-Type': 'text/plain',
+          'Content-Range': 'bytes 0-2047/4096',
+        });
+        response.end(assetText);
         return;
       }
       response.writeHead(200, {
@@ -435,6 +453,7 @@ describe('Remote Control tunnel', () => {
     const gzipBody = gzipResponse.subarray(gzipSeparator + 4);
     expect(gzipHead).toContain('HTTP/1.1 200 OK');
     expect(gzipHead).toContain('Content-Encoding: gzip');
+    expect(gzipHead).toContain('Vary: Accept-Encoding');
     expect(gzipHead).toContain(`Content-Length: ${gzipBody.length}`);
     expect(gunzipSync(gzipBody).toString()).toBe(
       assetJs.replaceAll('"/assets/', `"/coding-relay/devices/${handle.deviceId}/assets/`),
@@ -483,6 +502,47 @@ describe('Remote Control tunnel', () => {
     expect(excludedResponse.subarray(excludedSeparator + 4).toString()).toBe(
       assetJs.replaceAll('"/assets/', `"/coding-relay/devices/${handle.deviceId}/assets/`),
     );
+
+    const svgResponsePromise = nextJsonMessage(httpConnections[0]!);
+    httpConnections[0]!.send(
+      JSON.stringify({
+        request_id: 'request-6',
+        type: 'request',
+        is_last: true,
+        body_base64: Buffer.from(
+          'GET /assets/logo.svg HTTP/1.1\r\nHost: relay.test\r\nAccept-Encoding: gzip\r\n\r\n',
+        ).toString('base64'),
+      }),
+    );
+    const svgResponse = Buffer.from((await svgResponsePromise)['body_base64'] as string, 'base64');
+    const svgSeparator = svgResponse.indexOf('\r\n\r\n');
+    const svgHead = svgResponse.subarray(0, svgSeparator).toString('latin1');
+    expect(svgHead).toContain('Content-Encoding: gzip');
+    expect(svgHead).toContain('Vary: Accept-Encoding');
+    expect(svgHead).toContain('immutable');
+    expect(gunzipSync(svgResponse.subarray(svgSeparator + 4)).toString()).toBe(assetSvg);
+
+    const rangeResponsePromise = nextJsonMessage(httpConnections[0]!);
+    httpConnections[0]!.send(
+      JSON.stringify({
+        request_id: 'request-7',
+        type: 'request',
+        is_last: true,
+        body_base64: Buffer.from(
+          'GET /assets/partial.txt HTTP/1.1\r\nHost: relay.test\r\nAccept-Encoding: gzip\r\nRange: bytes=0-2047\r\n\r\n',
+        ).toString('base64'),
+      }),
+    );
+    const rangeResponse = Buffer.from(
+      (await rangeResponsePromise)['body_base64'] as string,
+      'base64',
+    );
+    const rangeSeparator = rangeResponse.indexOf('\r\n\r\n');
+    const rangeHead = rangeResponse.subarray(0, rangeSeparator).toString('latin1');
+    expect(rangeHead).toContain('206');
+    expect(rangeHead).toContain('Content-Range: bytes 0-2047/4096');
+    expect(rangeHead).not.toContain('Content-Encoding');
+    expect(rangeResponse.subarray(rangeSeparator + 4).toString()).toBe(assetText);
 
     managementConnections[0]!.send(
       JSON.stringify({

--- a/packages/remote-control/test/remote-control.test.ts
+++ b/packages/remote-control/test/remote-control.test.ts
@@ -455,7 +455,7 @@ describe('Remote Control tunnel', () => {
     expect(gzipHead).toContain('HTTP/1.1 200 OK');
     expect(gzipHead).toContain('Content-Encoding: gzip');
     expect(gzipHead).toContain('Vary: Accept-Encoding');
-    expect(gzipHead).toContain('ETag: "v1-gzip"');
+    expect(gzipHead).not.toContain('ETag');
     expect(gzipHead).toContain(`Content-Length: ${gzipBody.length}`);
     expect(gunzipSync(gzipBody).toString()).toBe(
       assetJs.replaceAll('"/assets/', `"/coding-relay/devices/${handle.deviceId}/assets/`),
@@ -502,7 +502,6 @@ describe('Remote Control tunnel', () => {
     expect(excludedHead).not.toContain('Content-Encoding');
     expect(excludedHead).toContain('Vary: Accept-Encoding');
     expect(excludedHead).toContain('ETag: "v1"');
-    expect(excludedHead).not.toContain('v1-gzip');
     expect(excludedResponse.subarray(excludedSeparator + 4).toString()).toBe(
       assetJs.replaceAll('"/assets/', `"/coding-relay/devices/${handle.deviceId}/assets/`),
     );

--- a/packages/remote-control/test/remote-control.test.ts
+++ b/packages/remote-control/test/remote-control.test.ts
@@ -282,7 +282,7 @@ describe('Remote Control tunnel', () => {
     const localServer = createServer((request, response) => {
       localHttpRequest = request;
       if (request.url === '/assets/index.js') {
-        response.writeHead(200, { 'Content-Type': 'text/javascript' });
+        response.writeHead(200, { 'Content-Type': 'text/javascript', ETag: '"v1"' });
         response.end(assetJs);
         return;
       }
@@ -416,6 +416,7 @@ describe('Remote Control tunnel', () => {
     expect(response).not.toContain('X-Remove');
     expect(response).not.toContain('immutable');
     expect(response).not.toContain('Content-Encoding');
+    expect(response).not.toContain('Vary');
     expect(localHttpRequest?.headers['accept-encoding']).toBeUndefined();
     expect(response).toContain('Cache-Control: no-cache');
     expect(response).toContain(`/coding-relay/devices/${handle.deviceId}/boot.js`);
@@ -454,6 +455,7 @@ describe('Remote Control tunnel', () => {
     expect(gzipHead).toContain('HTTP/1.1 200 OK');
     expect(gzipHead).toContain('Content-Encoding: gzip');
     expect(gzipHead).toContain('Vary: Accept-Encoding');
+    expect(gzipHead).toContain('ETag: "v1-gzip"');
     expect(gzipHead).toContain(`Content-Length: ${gzipBody.length}`);
     expect(gunzipSync(gzipBody).toString()).toBe(
       assetJs.replaceAll('"/assets/', `"/coding-relay/devices/${handle.deviceId}/assets/`),
@@ -496,9 +498,11 @@ describe('Remote Control tunnel', () => {
       'base64',
     );
     const excludedSeparator = excludedResponse.indexOf('\r\n\r\n');
-    expect(excludedResponse.subarray(0, excludedSeparator).toString('latin1')).not.toContain(
-      'Content-Encoding',
-    );
+    const excludedHead = excludedResponse.subarray(0, excludedSeparator).toString('latin1');
+    expect(excludedHead).not.toContain('Content-Encoding');
+    expect(excludedHead).toContain('Vary: Accept-Encoding');
+    expect(excludedHead).toContain('ETag: "v1"');
+    expect(excludedHead).not.toContain('v1-gzip');
     expect(excludedResponse.subarray(excludedSeparator + 4).toString()).toBe(
       assetJs.replaceAll('"/assets/', `"/coding-relay/devices/${handle.deviceId}/assets/`),
     );


### PR DESCRIPTION
## Related Issue

None — reported directly by an internal user; the problem is explained below.

## Problem

Opening the Remote Control web UI for the first time frequently ends in a 504 from the relay. The entry bundle `/devices/:id/assets/index-*.js` is ~3.2 MB, and the tunnel base64-encodes the whole response before upload (~4.3 MB on the wire). The relay times the request out after 30s, so any device with less than ~2 Mbps uplink almost always fails (at 1 Mbps this single file takes ~34s). The slow leg is the user's machine → relay upload, so compression has to happen before the response enters the tunnel — compressing at the relay or gateway would be pointless.

## What changed

Tunnel client only (`packages/remote-control`); the relay and the web UI are untouched:

- The browser's original `Accept-Encoding` is read before request headers are filtered. The header is still stripped from the forwarded request as before — that strip protects the body rewrite, and this change does not alter it.
- After the local response body has been rewritten (`rewriteRemoteControlResponse`) and before the response is base64-encoded into the tunnel: if the browser accepts gzip, the body is textual (`text/*`, `application/javascript`, `application/json`, `application/xml`, `image/svg+xml`), and it is at least 1 KB, the final body is gzipped (`zlib.gzipSync`) and `Content-Encoding: gzip` is set. `Content-Length` was already recomputed, and the header is not on the response blocklist, so it passes through as-is.
- Responses that already carry `Content-Encoding` from upstream keep the existing behavior (rewrite skipped, passed through untouched, never compressed twice). When the browser does not accept gzip, the response bytes are exactly what they were before.

Not compressing in kap-server on purpose: the client skips URL rewriting for responses that already have a content-encoding (compressed bytes cannot be string-replaced), so lazily loaded `/assets/` chunks would break. Compressing after the rewrite gets the same result in one step without a decompress → rewrite → recompress round trip.

Effect: the ~3.2 MB entry bundle drops to roughly 1 MB on the wire (~3x), so first paint on marginal uplinks goes from a 30s timeout to ~10s; the compression itself costs tens of milliseconds on the user's machine.

Tests: the existing tunnel end-to-end case is extended in place (test count unchanged): small bodies stay uncompressed and the `Accept-Encoding` strip is asserted unchanged; a large JS body asserts `Content-Encoding: gzip`, a Content-Length matching the gzipped bytes, and a gunzip equal to the rewritten body; a large binary body stays uncompressed. Locally: `packages/remote-control` 19/19 green, typecheck and oxlint clean. Remotely on m0-dev: `@moonshot-ai/remote-control`, `@moonshot-ai/kap-server`, and `@moonshot-ai/kimi-code` suites all green.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
