### PR TITLE
fix(remote-control): validate tunnel base64 linearly to avoid V8 regexp stack overflow

### DIFF
--- a/.changeset/rc-tunnel-base64-linear-check.md
+++ b/.changeset/rc-tunnel-base64-linear-check.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix Remote Control uploads larger than ~3.5MB always failing with a 400 error.

--- a/packages/remote-control/src/remote-control.ts
+++ b/packages/remote-control/src/remote-control.ts
@@ -541,7 +541,12 @@ class RemoteControlClient {
       ) {
         throw new SyntaxError('invalid HTTP tunnel request message');
       }
-      const chunk = decodeBase64(parsed['body_base64']);
+      const bodyBase64 = parsed['body_base64'];
+      const minDecodedBytes = Math.floor(bodyBase64.length / 4) * 3 - 2;
+      if (this.pendingHttpBytes + minDecodedBytes > MAX_HTTP_REQUEST_BYTES) {
+        throw new SyntaxError('HTTP tunnel request exceeds 10 MiB');
+      }
+      const chunk = decodeBase64(bodyBase64);
       const pending = this.pendingHttpRequests.get(requestId) ?? { chunks: [], size: 0 };
       if (this.pendingHttpBytes + chunk.length > MAX_HTTP_REQUEST_BYTES) {
         throw new SyntaxError('HTTP tunnel request exceeds 10 MiB');
@@ -557,7 +562,8 @@ class RemoteControlClient {
     } catch (error) {
       if (requestId !== undefined) {
         this.clearPendingHttpRequest(requestId);
-        this.sendHttpResponse(requestId, buildErrorResponse(400));
+        const status = error instanceof SyntaxError ? 400 : 502;
+        this.sendHttpResponse(requestId, buildErrorResponse(status));
       }
       this.stderr.write(`Remote Control HTTP message error: ${errorMessage(error)}\n`);
     }
@@ -1023,7 +1029,30 @@ function stringField(
 }
 
 function decodeBase64(value: string): Buffer {
-  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+  if (value.length % 4 !== 0) {
+    throw new SyntaxError('invalid HTTP tunnel request base64');
+  }
+  let paddingStart = -1;
+  for (let i = 0; i < value.length; i++) {
+    const c = value.codePointAt(i)!;
+    if (c === 0x3d) {
+      if (paddingStart === -1) paddingStart = i;
+      continue;
+    }
+    if (paddingStart !== -1) {
+      throw new SyntaxError('invalid HTTP tunnel request base64');
+    }
+    const ok =
+      (c >= 0x41 && c <= 0x5a) ||
+      (c >= 0x61 && c <= 0x7a) ||
+      (c >= 0x30 && c <= 0x39) ||
+      c === 0x2b ||
+      c === 0x2f;
+    if (!ok) {
+      throw new SyntaxError('invalid HTTP tunnel request base64');
+    }
+  }
+  if (paddingStart !== -1 && value.length - paddingStart > 2) {
     throw new SyntaxError('invalid HTTP tunnel request base64');
   }
   return Buffer.from(value, 'base64');

--- a/packages/remote-control/test/remote-control.test.ts
+++ b/packages/remote-control/test/remote-control.test.ts
@@ -273,6 +273,7 @@ describe('Remote Control tunnel', () => {
     );
 
     let localHttpRequest: IncomingMessage | undefined;
+    let localHttpBodyBytes = 0;
     let localWsRequest: IncomingMessage | undefined;
     const localWsServer = new WebSocketServer({ noServer: true });
     const assetJs = `const boot = "/assets/boot.js";\n${'const chunk = "/assets/chunk.js";\n'.repeat(120)}`;
@@ -307,13 +308,20 @@ describe('Remote Control tunnel', () => {
         response.end(assetText);
         return;
       }
-      response.writeHead(200, {
-        'Content-Type': 'text/html',
-        'Cache-Control': 'public, max-age=31536000, immutable',
-        Connection: 'X-Remove',
-        'X-Remove': 'gone',
+      let bodyBytes = 0;
+      request.on('data', (chunk: Buffer) => {
+        bodyBytes += chunk.length;
       });
-      response.end('<html><head></head><script src="/boot.js"></script></html>');
+      request.on('end', () => {
+        localHttpBodyBytes = bodyBytes;
+        response.writeHead(200, {
+          'Content-Type': 'text/html',
+          'Cache-Control': 'public, max-age=31536000, immutable',
+          Connection: 'X-Remove',
+          'X-Remove': 'gone',
+        });
+        response.end('<html><head></head><script src="/boot.js"></script></html>');
+      });
     });
     localServer.on('upgrade', (request, socket, head) => {
       localWsRequest = request;
@@ -546,6 +554,25 @@ describe('Remote Control tunnel', () => {
     expect(rangeHead).toContain('Content-Range: bytes 0-2047/4096');
     expect(rangeHead).not.toContain('Content-Encoding');
     expect(rangeResponse.subarray(rangeSeparator + 4).toString()).toBe(assetText);
+
+    const largeBody = Buffer.alloc(4 * 1024 * 1024 + 512 * 1024, 0x61);
+    const largeRequest = Buffer.concat([
+      Buffer.from(`POST /upload HTTP/1.1\r\nHost: relay.test\r\nContent-Length: ${largeBody.length}\r\n\r\n`),
+      largeBody,
+    ]);
+    const largeResponsePromise = nextJsonMessage(httpConnections[0]!);
+    httpConnections[0]!.send(
+      JSON.stringify({
+        request_id: 'request-8',
+        type: 'request',
+        is_last: true,
+        body_base64: largeRequest.toString('base64'),
+      }),
+    );
+    const largeResponseMessage = await largeResponsePromise;
+    const largeResponse = Buffer.from(largeResponseMessage['body_base64'] as string, 'base64').toString();
+    expect(largeResponse).toContain('HTTP/1.1 200 OK');
+    expect(localHttpBodyBytes).toBe(largeBody.length);
 
     managementConnections[0]!.send(
       JSON.stringify({


### PR DESCRIPTION
## Related Issue

Reported internally with a full root-cause analysis: Remote Control tunnel uploads larger than ~3.5MB always fail with HTTP 400 and an empty response body.

## Problem

When uploading a file larger than ~3.5MB through the Remote Control web page (e.g. a 4.3MB image), the request always fails: the relay logs `status:400` with an empty body and the web client reports a generic "cannot connect" error. Smaller uploads work.

The Remote Control HTTP tunnel client validates every base64 tunnel message with a backtracking regular expression (`/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/`). V8's Irregexp engine implements the `(?:...)*` group with backtracking, pushing one backtrack point per iteration; a ~5.8MB base64 message (a 4.3MB request) needs ~1.45M iterations and exhausts the regexp backtracking stack, throwing `RangeError: Maximum call stack size exceeded` on completely valid input. The catch-all in `handleHttpMessage` then maps every error to `buildErrorResponse(400)` with an empty body, so a server-side bug is disguised as a client error. LAN `kimi web` is unaffected because it never goes through the tunnel path.

## What changed

- `decodeBase64` now validates input with an O(n) character check (length mod 4 plus per-character code-point validation) instead of the backtracking regex, so arbitrarily large valid base64 messages no longer crash. Invalid input still throws the same `SyntaxError`.
- Oversize requests are rejected from the base64 length (decoded ≈ len×3/4) before decoding, avoiding a large decode for requests that will be rejected by the 10 MiB cap anyway; the exact check after decoding is kept.
- The `handleHttpMessage` catch now maps `SyntaxError` to 400 and any other (internal) error to 502, matching the existing semantics of `forwardHttpRequest`, instead of reporting everything as 400.
- Regression coverage: the end-to-end tunnel test now also forwards a POST with a 4.5MB body (base64 ~6MB, over the crash threshold) and asserts it reaches the local server intact.
