### PR TITLE
feat(kap-server): move compacting from session.state to agent.state turn

### DIFF
--- a/packages/kap-server/src/protocol/messages/agent-state.ts
+++ b/packages/kap-server/src/protocol/messages/agent-state.ts
@@ -25,7 +25,7 @@ export const agentStateOriginSchema = z.discriminatedUnion('kind', [
 export type AgentStateOrigin = z.infer<typeof agentStateOriginSchema>;
 
 export const agentStateTurnSchema = z.object({
-  status: z.enum(['thinking', 'retrying', 'acting', 'aborting']),
+  status: z.enum(['thinking', 'retrying', 'acting', 'aborting', 'compacting']),
 });
 
 export type AgentStateTurn = z.infer<typeof agentStateTurnSchema>;

--- a/packages/kap-server/src/protocol/messages/session-state.ts
+++ b/packages/kap-server/src/protocol/messages/session-state.ts
@@ -40,7 +40,7 @@ export type SessionStateModes = z.infer<typeof sessionStateModesSchema>;
 export const sessionStateMessageSchema = z.object({
   type: z.literal('session.state'),
   ...sessionMessageBase,
-  status: z.enum(['idle', 'running', 'compacting']),
+  status: z.enum(['idle', 'running']),
   pending_interaction: z.enum(['none', 'approval', 'question']).optional(),
   model: z.string().optional(),
   thinking_effort: z.string().optional(),

--- a/packages/kap-server/src/services/projection/agentState.ts
+++ b/packages/kap-server/src/services/projection/agentState.ts
@@ -16,6 +16,7 @@ export class AgentStateTracker {
   private endedAt: string | undefined;
   private status: AgentStatus = 'idle';
   private turn: AgentStateTurn | undefined;
+  private compacting = false;
 
   constructor(
     readonly agentId: string,
@@ -94,6 +95,22 @@ export class AgentStateTracker {
     if (this.status !== 'running') return false;
     this.status = 'idle';
     this.turn = undefined;
+    this.compacting = false;
+    return true;
+  }
+
+  compactionStarted(): boolean {
+    if (this.compacting) return false;
+    this.compacting = true;
+    if (this.status !== 'running' || this.turn === undefined) return false;
+    if (this.turn.status === 'compacting') return false;
+    this.turn = { status: 'compacting' };
+    return true;
+  }
+
+  compactionEnded(): boolean {
+    if (!this.compacting) return false;
+    this.compacting = false;
     return true;
   }
 
@@ -105,6 +122,7 @@ export class AgentStateTracker {
     if (this.status === status) return false;
     this.status = status;
     this.turn = undefined;
+    this.compacting = false;
     this.endedAt = endedAt;
     return true;
   }
@@ -113,6 +131,7 @@ export class AgentStateTracker {
     if (this.endedAt !== undefined) return false;
     this.endedAt = endedAt;
     this.turn = undefined;
+    this.compacting = false;
     if (TERMINAL_STATUSES.has(this.status)) return true;
     this.status = 'interrupted';
     return true;
@@ -125,17 +144,20 @@ export class AgentStateTracker {
       const changed = this.status === 'running' || this.turn !== undefined;
       if (this.status === 'running') this.status = 'idle';
       this.turn = undefined;
+      this.compacting = false;
       return changed;
     }
     if (this.status === 'idle') this.status = 'running';
     const next: AgentStateTurn = {
-      status: turn.ending
-        ? 'aborting'
-        : turn.phase === 'retrying'
-          ? 'retrying'
-          : turn.phase === 'tool_call'
-            ? 'acting'
-            : 'thinking',
+      status: this.compacting
+        ? 'compacting'
+        : turn.ending
+          ? 'aborting'
+          : turn.phase === 'retrying'
+            ? 'retrying'
+            : turn.phase === 'tool_call'
+              ? 'acting'
+              : 'thinking',
     };
     if (this.turn?.status === next.status) return false;
     this.turn = next;

--- a/packages/kap-server/src/services/projection/sessionProjection.ts
+++ b/packages/kap-server/src/services/projection/sessionProjection.ts
@@ -450,6 +450,20 @@ export class SessionProjection {
           if (!this.disposed) this.recomputeAgentTurn(agentId);
         });
         return;
+      case 'compaction.started': {
+        const tracker = this.agentStates.get(agentId);
+        if (tracker === undefined) return;
+        if (tracker.compactionStarted()) this.emitAgentState(agentId);
+        return;
+      }
+      case 'compaction.completed':
+      case 'compaction.cancelled': {
+        const tracker = this.agentStates.get(agentId);
+        if (tracker === undefined) return;
+        tracker.compactionEnded();
+        this.recomputeAgentTurn(agentId);
+        return;
+      }
       default:
         return;
     }

--- a/packages/kap-server/test/services/projection.test.ts
+++ b/packages/kap-server/test/services/projection.test.ts
@@ -1228,6 +1228,14 @@ describe('SessionProjection', () => {
       },
     };
     agent.bus.emit(ev({ type: 'tool.call.started', turnId: 1, toolCallId: 'call_1', name: 'Bash', args: '{}' }) as Event2<any>);
+    agent.bus.emit(ev({ type: 'compaction.blocked', turnId: 1 }) as Event2<any>);
+    agent.bus.emit(ev({ type: 'compaction.started', trigger: 'auto' }) as Event2<any>);
+    agent.bus.emit(
+      ev({
+        type: 'compaction.completed',
+        result: { summary: 'compacted', compactedCount: 3, tokensBefore: 10, tokensAfter: 5 },
+      }) as Event2<any>,
+    );
     agent.activity = {};
     agent.bus.emit(ev({ type: 'turn.ended', turnId: 1, reason: 'completed' }) as Event2<any>);
     agent.bus.emit(
@@ -1282,6 +1290,11 @@ describe('SessionProjection', () => {
         ),
       ).toBe(true);
     });
+    const mainStates = ofType(received, 'agent.state').filter((m) => m.agent_id === 'main');
+    const compactingStates = mainStates.filter((m) => m.turn?.status === 'compacting');
+    expect(compactingStates).toHaveLength(1);
+    const lastActingIndex = mainStates.findLastIndex((m) => m.turn?.status === 'acting');
+    expect(lastActingIndex).toBeGreaterThan(mainStates.indexOf(compactingStates[0]!));
     const mainIdle = ofType(received, 'agent.state')
       .filter((m) => m.agent_id === 'main')
       .at(-1)!;


### PR DESCRIPTION
## Related Issue

Follow-up to #3532 (flat entity message protocol). Internal protocol adjustment, no linked issue.

## Problem

The v3 protocol carried a `compacting` value on `session.state.status` that the projection never produced (session state is derived purely from busy → `idle | running`). Meanwhile, full compaction is an agent-level activity that happens inside a running turn, and subscribers had no way to observe it in real time — `compaction.started` / `compaction.completed` bus events existed but were not surfaced on any state entity.

## What changed

- `session.state.status` narrowed to `'idle' | 'running'`: the never-produced `'compacting'` value is removed from the schema. No runtime behavior change — the projection only ever emitted the two remaining values, so this is backward compatible for consumers.
- `agent.state.turn.status` gains `'compacting'` (now `'thinking' | 'retrying' | 'acting' | 'aborting' | 'compacting'`), an additive enum extension per the open-union evolution rule.
- The projection now produces it: `AgentStateTracker` holds a compacting flag driven by the per-agent `compaction.started` / `compaction.completed` / `compaction.cancelled` bus events (observable, already in the projection event union). While compacting, the flag takes precedence over the activity-snapshot phase mapping; when compaction ends the turn status recomputes back to the real phase. `compaction.blocked` never enters the compacting state. Compaction outside an active turn is not represented (the `turn` field only exists while running).
- agent-core-v2 is untouched: the signal is computed entirely at the kap-server projection layer from existing bus events.
- Tests: the main SessionProjection lifecycle case now drives a blocked → started → completed sequence and asserts compacting is emitted exactly once and the turn returns to `acting` afterwards (test count unchanged).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
