### PR TITLE
feat(kap-server): open the xstate debug ws by default behind a subscribe handshake

### DIFF
--- a/packages/kap-server/src/start.ts
+++ b/packages/kap-server/src/start.ts
@@ -482,7 +482,7 @@ export async function startServer(opts: ServerStartOptions): Promise<RunningServ
     broadcaster,
     logger,
   });
-  const wssDebug = debugEndpoints ? registerWsDebug() : undefined;
+  const wssDebug = registerWsDebug();
 
   const { wss: wssV3, hub: wsV3Hub } = registerWsV3(core, {
     registry: connectionRegistry,
@@ -574,7 +574,7 @@ export async function startServer(opts: ServerStartOptions): Promise<RunningServ
   app.addHook('onClose', async () => {
     connectionRegistry.closeAll('server shutting down');
     wssV1.close();
-    wssDebug?.close();
+    wssDebug.close();
     wssV3.close();
     wsV3Hub.dispose();
     await broadcaster.close();

--- a/packages/kap-server/src/transport/ws/debug/wsConnectionDebug.ts
+++ b/packages/kap-server/src/transport/ws/debug/wsConnectionDebug.ts
@@ -20,12 +20,13 @@ export interface WsConnectionDebugOptions {
 
 export class WsConnectionDebug {
   private readonly socket: WebSocket;
+  private readonly collector: XstateInspectionCollector;
   private readonly heartbeatIntervalMs: number;
   private readonly flushIntervalMs: number;
   private readonly highWaterMarkBytes: number;
-  private readonly unsubscribe: () => void;
 
   private closed = false;
+  private collectorUnsubscribe?: () => void;
   private outbound: XstateInspectionEnvelope[] = [];
   private flushTimer?: ReturnType<typeof setTimeout>;
   private heartbeatTimer?: ReturnType<typeof setInterval>;
@@ -33,6 +34,7 @@ export class WsConnectionDebug {
 
   constructor(opts: WsConnectionDebugOptions) {
     this.socket = opts.socket;
+    this.collector = opts.collector ?? xstateInspectionCollector;
     this.heartbeatIntervalMs = opts.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
     this.flushIntervalMs = opts.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
     this.highWaterMarkBytes = opts.highWaterMarkBytes ?? DEFAULT_HIGH_WATER_MARK_BYTES;
@@ -42,12 +44,38 @@ export class WsConnectionDebug {
     this.socket.on('pong', () => {
       this.lastPongAt = Date.now();
     });
-
-    const collector = opts.collector ?? xstateInspectionCollector;
-    this.unsubscribe = collector.subscribe((envelope) => this.onEnvelope(envelope));
+    this.socket.on('message', (data) => this.onMessage(data));
 
     this.heartbeatTimer = setInterval(() => this.onHeartbeat(), this.heartbeatIntervalMs);
     this.heartbeatTimer.unref?.();
+  }
+
+  private onMessage(data: unknown): void {
+    let frame: unknown;
+    try {
+      frame = JSON.parse(String(data));
+    } catch {
+      return;
+    }
+    if (frame === null || typeof frame !== 'object') return;
+    const type = (frame as Record<string, unknown>)['type'];
+    if (type === 'subscribe') {
+      this.subscribe();
+    } else if (type === 'unsubscribe') {
+      this.unsubscribe();
+    }
+  }
+
+  private subscribe(): void {
+    if (this.closed || this.collectorUnsubscribe !== undefined) return;
+    this.collectorUnsubscribe = this.collector.subscribe((envelope) => this.onEnvelope(envelope));
+  }
+
+  private unsubscribe(): void {
+    if (this.collectorUnsubscribe === undefined) return;
+    this.collectorUnsubscribe();
+    this.collectorUnsubscribe = undefined;
+    this.outbound = [];
   }
 
   private onEnvelope(envelope: XstateInspectionEnvelope): void {
@@ -109,6 +137,7 @@ export class WsConnectionDebug {
     if (this.flushTimer !== undefined) clearTimeout(this.flushTimer);
     if (this.heartbeatTimer !== undefined) clearInterval(this.heartbeatTimer);
     this.outbound = [];
-    this.unsubscribe();
+    this.collectorUnsubscribe?.();
+    this.collectorUnsubscribe = undefined;
   }
 }

--- a/packages/kap-server/test/wsUpgradeAuth.test.ts
+++ b/packages/kap-server/test/wsUpgradeAuth.test.ts
@@ -20,6 +20,24 @@ function rawToString(data: RawData): string {
   return Buffer.from(data as ArrayBuffer).toString('utf8');
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForFrame(
+  received: Record<string, unknown>[],
+  match: (frame: Record<string, unknown>) => boolean,
+  timeoutMs = 5000,
+): Promise<Record<string, unknown>> {
+  const start = Date.now();
+  for (;;) {
+    const found = received.find(match);
+    if (found !== undefined) return found;
+    if (Date.now() - start > timeoutMs) throw new Error('no matching frame within timeout');
+    await sleep(20);
+  }
+}
+
 interface ConnectOptions {
   readonly protocols?: string[];
   readonly headers?: Record<string, string>;
@@ -105,7 +123,7 @@ describe('WS upgrade auth', () => {
   });
 
   describe('/api/v1/debug/ws', () => {
-    it('streams xstate inspection envelopes to an authorized client', async () => {
+    it('streams xstate inspection envelopes to an authorized client only after subscribe', async () => {
       const home = await mkdtemp(join(tmpdir(), 'kimi-kap-debug-ws-'));
       const server = await startServer({
         hostIdentity: TEST_HOST_IDENTITY,
@@ -113,7 +131,6 @@ describe('WS upgrade auth', () => {
         port: 0,
         homeDir: home,
         logLevel: 'silent',
-        debugEndpoints: true,
         authTokenService: fixedTokenAuth(),
         seeds: [[IModelCatalog, fakeModelCatalog()]],
       });
@@ -122,34 +139,41 @@ describe('WS upgrade auth', () => {
       });
       sockets.push(ws);
       try {
-        const envelope = await new Promise<Record<string, unknown>>((resolve, reject) => {
-          const timer = setTimeout(
-            () => reject(new Error('no inspection envelope within timeout')),
-            5000,
-          );
-          ws.on('message', (data) => {
-            const frame = JSON.parse(rawToString(data)) as Record<string, unknown>;
-            if (frame['eventType'] === 'debug.probe') {
-              clearTimeout(timer);
-              resolve(frame);
-            }
-          });
-          ws.on('error', reject);
-          ws.once('open', () => {
-            const machine = setup({}).createMachine({
-              id: 'debugWsProbe',
-              initial: 'idle',
-              states: { idle: { on: { 'debug.probe': 'done' } }, done: {} },
-            });
-            const actor = createActor(machine);
-            actor.start();
-            actor.send({ type: 'debug.probe' });
-          });
+        const received: Record<string, unknown>[] = [];
+        ws.on('message', (data) => {
+          received.push(JSON.parse(rawToString(data)) as Record<string, unknown>);
         });
+        await new Promise<void>((resolve) => ws.once('open', resolve));
+        const probe = (): void => {
+          const machine = setup({}).createMachine({
+            id: 'debugWsProbe',
+            initial: 'idle',
+            states: { idle: { on: { 'debug.probe': 'done' } }, done: {} },
+          });
+          const actor = createActor(machine);
+          actor.start();
+          actor.send({ type: 'debug.probe' });
+        };
+        probe();
+        await sleep(200);
+        expect(received).toHaveLength(0);
+        ws.send(JSON.stringify({ type: 'subscribe' }));
+        await sleep(100);
+        probe();
+        const envelope = await waitForFrame(
+          received,
+          (frame) => frame['eventType'] === 'debug.probe',
+        );
         expect(envelope['type']).toBe('@xstate.event');
         expect(envelope['logicId']).toBe('debugWsProbe');
         expect(typeof envelope['actorId']).toBe('string');
         expect(typeof envelope['timestamp']).toBe('number');
+        ws.send(JSON.stringify({ type: 'unsubscribe' }));
+        await sleep(100);
+        received.length = 0;
+        probe();
+        await sleep(200);
+        expect(received).toHaveLength(0);
       } finally {
         await server.close();
         await rm(home, { recursive: true, force: true });
@@ -160,7 +184,5 @@ describe('WS upgrade auth', () => {
   it('rejects upgrades to a non-WS path', async () => {
     const badUrl = `${v1Url().replace('/api/v1/ws', '/api/v1/other')}`;
     await expectRejected(badUrl, { protocols: [`kimi-code.bearer.${token()}`] });
-    const debugUrl = `${v1Url().replace('/api/v1/ws', '/api/v1/debug/ws')}`;
-    await expectRejected(debugUrl, { protocols: [`kimi-code.bearer.${token()}`] });
   });
 });


### PR DESCRIPTION
## Related Issue

Internal feature request (no linked issue).

## Problem

The xstate inspection debug channel (`/api/v1/debug/ws`, introduced in #3687) only registers when the server is started with `--debug-endpoints`, and it starts streaming raw inspection envelopes to every client the moment it connects. Local observation tooling (kimi-code-harness) should not need a special flag to use the channel, and clients that connect but are not interested in the stream should not receive one unconditionally.

## What changed

- `/api/v1/debug/ws` now registers unconditionally (`start.ts`), independent of the `--debug-endpoints` flag and of the bind's exposure class. The flag keeps governing only the `/api/v1/debug/*` RPC surface, whose behavior is unchanged. The upgrade authentication pipeline (bearer header / subprotocol token) is unchanged.
- `WsConnectionDebug` no longer subscribes to the inspection collector on construction. A client starts the stream by sending `{type:'subscribe'}` and stops it with `{type:'unsubscribe'}` (other frames are ignored); disconnecting cleans up the subscription. Batching, high-water-mark drop, and heartbeat behavior are unchanged.
- Tests: the debug upgrade/stream case now runs without the flag and covers the full handshake (silent before subscribe, envelopes after subscribe, silent again after unsubscribe); the stale assertion that rejected `/api/v1/debug/ws` as a non-WS path is removed. Test count unchanged.

Compatibility note: clients from the #3687 era that never send `subscribe` will no longer receive envelopes; consumers must send the subscribe frame after connecting (kimi-code-harness is updated accordingly).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
