### PR TITLE
feat(agent-core-v2): allow rm -rf targeting only /tmp or /temp paths

### DIFF
--- a/.changeset/rm-rf-temp-paths.md
+++ b/.changeset/rm-rf-temp-paths.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Skip the confirmation prompt for rm -rf commands that target only /tmp or /temp paths.

--- a/packages/agent-core-v2/src/agent/permissionPolicy/policies/dangerous-command-ask.ts
+++ b/packages/agent-core-v2/src/agent/permissionPolicy/policies/dangerous-command-ask.ts
@@ -104,6 +104,15 @@ const DD_SAFE_DEVICE_TARGETS: ReadonlySet<string> = new Set([
   '/dev/stderr',
 ]);
 
+const RM_SAFE_TEMP_ROOTS: readonly string[] = ['/tmp', '/temp'];
+
+function isSafeTempRmOperand(operand: string): boolean {
+  for (const segment of operand.split('/')) {
+    if (segment === '..') return false;
+  }
+  return RM_SAFE_TEMP_ROOTS.some((root) => operand === root || operand.startsWith(`${root}/`));
+}
+
 type DangerousVerdict =
   | { readonly kind: 'dangerous'; readonly command: string }
   | { readonly kind: 'unanalyzable' };
@@ -273,8 +282,17 @@ function analyzeInvocation(
   if (name === 'rm') {
     let recursive = false;
     let force = false;
+    const operands: string[] = [];
+    let optionsEnded = false;
     for (const arg of args) {
-      if (arg === '--') break;
+      if (!optionsEnded && arg === '--') {
+        optionsEnded = true;
+        continue;
+      }
+      if (optionsEnded) {
+        operands.push(arg);
+        continue;
+      }
       if (arg === '--recursive') {
         recursive = true;
       } else if (arg === '--force') {
@@ -282,9 +300,16 @@ function analyzeInvocation(
       } else if (/^-[a-zA-Z]+$/.test(arg)) {
         if (/[rR]/.test(arg)) recursive = true;
         if (arg.includes('f')) force = true;
+      } else {
+        operands.push(arg);
       }
     }
-    if (recursive && force) return { kind: 'dangerous', command: 'rm -rf' };
+    if (recursive && force) {
+      if (!dropped && operands.length > 0 && operands.every(isSafeTempRmOperand)) {
+        return undefined;
+      }
+      return { kind: 'dangerous', command: 'rm -rf' };
+    }
     return dropped ? { kind: 'unanalyzable' } : undefined;
   }
   return undefined;

--- a/packages/agent-core-v2/test/agent/permissionPolicy/permissionPolicyService.test.ts
+++ b/packages/agent-core-v2/test/agent/permissionPolicy/permissionPolicyService.test.ts
@@ -274,13 +274,11 @@ describe('AgentPermissionPolicyService chain', () => {
     ['systemctl poweroff', 'systemctl poweroff'],
     ['systemctl --user reboot', 'systemctl reboot'],
     ['bash -c "shutdown now"', 'shutdown'],
-    ['rm -rf /tmp/build', 'rm -rf'],
+    ['rm -rf /tmp/build /root', 'rm -rf'],
     ['rm -fr dir', 'rm -rf'],
     ['rm -r -f dir', 'rm -rf'],
     ['rm -R --force dir', 'rm -rf'],
-    ['rm --recursive --force dir', 'rm -rf'],
     ['rm -rfv dir', 'rm -rf'],
-    ['sudo rm -rf dir', 'rm -rf'],
     ['sudo -u root rm --recursive --force dir', 'rm -rf'],
     ['echo ok && rm -rf dir', 'rm -rf'],
     ['env rm -rf dir', 'rm -rf'],
@@ -310,6 +308,21 @@ describe('AgentPermissionPolicyService chain', () => {
       result: { kind: 'ask', reason: { dangerous_command: matched } },
     });
   });
+
+  it.each(['rm -rf /tmp/build', 'rm -rf /temp/cache'])(
+    'approves `%s` in yolo mode',
+    async (command) => {
+      mode = 'yolo';
+
+      await expect(evaluate({
+        toolName: 'Bash',
+        args: { command, timeout: 60 },
+      })).resolves.toMatchObject({
+        policyName: 'yolo-mode-approve',
+        result: { kind: 'approve' },
+      });
+    },
+  );
 
   it.each([
     'init 3',


### PR DESCRIPTION
## Related Issue

Internal request (2026-09-10): `rm -rf` commands whose targets all live under `/tmp` or `/temp` should not be treated as dangerous.

## Problem

The dangerous command guard flags every recursive force `rm` as `rm -rf` and asks for confirmation, regardless of the target paths. Cleaning temporary directories (`rm -rf /tmp/build`) is a frequent, safe operation, and the confirmation prompt interrupts the flow every time.

## What changed

- `dangerous-command-ask` policy now collects the operands of an `rm` invocation (arguments after `--` count as operands). When `recursive && force` is detected, the command falls through without an ask if every operand is a literal path under `/tmp` or `/temp` (segment-level prefix match; paths containing `..` segments are rejected so `/tmp/../etc` cannot escape).
- Mixed targets (`rm -rf /tmp/a /root`), non-literal operands (`rm -rf /tmp/*`, `rm -rf $DIR`), and zero-operand invocations keep the existing dangerous verdict.
- Wrapper unwrapping (`sudo`, `env`, `bash -c`, `eval`, `busybox`, ...) is unchanged and routes into the same logic.
- Tests adjusted at constant count: the `/tmp/build` dangerous assertion became a mixed-target case, two redundant entries were removed, and yolo-mode allow cases for `/tmp/build` and `/temp/cache` were added.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
