### PR TITLE
fix(agent-core-v2): stop warning on unhandled store.changed events

### DIFF
--- a/.changeset/silence-store-changed-warning.md
+++ b/.changeset/silence-store-changed-warning.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Stop printing a spurious unhandled-event warning when sending messages.

--- a/.changeset/silence-store-changed-warning.md
+++ b/.changeset/silence-store-changed-warning.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Stop printing a spurious unhandled-event warning when sending messages.

--- a/packages/agent-core-v2/src/human/agent/machine.ts
+++ b/packages/agent-core-v2/src/human/agent/machine.ts
@@ -433,6 +433,7 @@ export function createAgentMachine({
       'store.error': {
         actions: 'forwardToParent',
       },
+      'store.changed': {},
       'tool.update': {
         actions: [emit(({ event }) => event), 'forwardToParent'],
       },

--- a/packages/agent-core-v2/src/human/test/agent/machine.test.ts
+++ b/packages/agent-core-v2/src/human/test/agent/machine.test.ts
@@ -713,6 +713,31 @@ describe('agent machine lifecycle', () => {
       'assistant:recovered',
     ]);
   });
+
+  it('persists turn events without reporting unhandled store.changed', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const requester = createStubRequester([
+        createAssistantMessage([{ type: 'text', text: 'hi' }]),
+      ]);
+      const store = await testStore();
+      const actor = createActor(createTestAgentMachine([], requester), {
+        input: { request: { model }, store },
+      });
+      actor.start();
+      actor.send({ type: 'input.submit', message: createUserMessage('hello') });
+      await waitFor(actor, (s) => s.matches('idle') && store.getState().history.length === 2, {
+        timeout: 5000,
+      });
+      await store.flush();
+      const unhandled = warn.mock.calls.filter(([message]) =>
+        String(message).includes('unhandled event "store.changed"'),
+      );
+      expect(unhandled).toEqual([]);
+    } finally {
+      warn.mockRestore();
+    }
+  });
 });
 
 describe('agent machine input.notify', () => {


### PR DESCRIPTION
## Related Issue

N/A — internal fix, no tracking issue. Problem explained below.

## Problem

Every message sent in the CLI prints console noise like
`[agent-core] unhandled event "store.changed" in actor "x:271"`.

The eventStore actor's publish fans each persisted event out two ways:
`emit` to external `.on()` subscribers (the real consumer path — works fine)
and a sendBack to the agent machine. The agent machine declares
`store.changed` in its event types but defines no transition for it, so the
xstate `reportUnhandled` hook warns on the resulting zero-transition
microstep. Pure noise, no functional impact.

## What changed

- Added a noop root-level `'store.changed': {}` transition in the agent
  machine (`packages/agent-core-v2/src/human/agent/machine.ts`), mirroring
  the existing `'store.reset': {}` noop in the session machine — the machine
  now explicitly acknowledges the event without reacting to it.
- Added a regression test covering that persisting events no longer produces
  an unhandled-event warning.
- Note: removing the sendBack from the storeActor was tried first and breaks
  xstate `waitFor` snapshot re-evaluation, so the noop-transition approach
  was chosen instead.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
