### PR TITLE
fix(agent-core-v2): keep late task settlement silent after agent teardown

### DIFF
--- a/packages/agent-core-v2/src/agent/task/taskService.ts
+++ b/packages/agent-core-v2/src/agent/task/taskService.ts
@@ -1066,10 +1066,11 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
   }
 
   private recordTaskStarted(info: AgentTaskInfo): void {
-    if (!this.lifecycleActive()) return;
-    void this.dispatcher.dispatch(
-      new TaskStarted({ agentId: this.scopeContext.agentId, info }),
-    );
+    if (this.lifecycleActive()) {
+      void this.dispatcher.dispatch(
+        new TaskStarted({ agentId: this.scopeContext.agentId, info }),
+      );
+    }
     this.telemetry.track2('background_task_created', {
       task_id: info.taskId,
       kind: info.kind === 'process' ? 'bash' : info.kind,
@@ -1077,10 +1078,11 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
   }
 
   private recordTaskTerminated(info: AgentTaskInfo, outputTail?: string): void {
-    if (!this.lifecycleActive()) return;
-    void this.dispatcher.dispatch(
-      new TaskTerminated({ agentId: this.scopeContext.agentId, info, outputTail }),
-    );
+    if (this.lifecycleActive()) {
+      void this.dispatcher.dispatch(
+        new TaskTerminated({ agentId: this.scopeContext.agentId, info, outputTail }),
+      );
+    }
     this.telemetry.track2('background_task_completed', {
       task_id: info.taskId,
       kind: info.kind,
@@ -1093,6 +1095,7 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
     if (!this.lifecycleActive()) return;
     const context = await this.buildAgentTaskNotificationContext(info);
     if (context === undefined) return;
+    if (!this.lifecycleActive()) return;
     const key = notificationKey(context.origin);
     if (this.deliveredNotificationKeys.has(key)) return;
     const handle = this.loop.notify({

--- a/packages/agent-core-v2/src/agent/task/taskService.ts
+++ b/packages/agent-core-v2/src/agent/task/taskService.ts
@@ -14,7 +14,7 @@ import {
 } from '#/_base/utils/abort';
 import { setClampedTimeout } from '#/_base/utils/timer';
 import { escapeXml, escapeXmlAttr, escapeXmlTags } from '#/_base/utils/xml-escape';
-import { IEventBus } from '#/app/event/eventBus';
+import { IEventBus, ISessionEventBus } from '#/app/event/eventBus';
 import { Error2, ErrorCodes } from '#/errors';
 import { z } from 'zod';
 import {
@@ -220,6 +220,7 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
     @IAgentScopeContext private readonly scopeContext: IAgentScopeContext,
     @ITaskService private readonly taskService: ITaskService,
     @IEventBus private readonly eventBus: IEventBus,
+    @ISessionEventBus private readonly sessionEventBus: ISessionEventBus,
     @IEventDispatcher private readonly dispatcher: IEventDispatcher,
     @IAgentReminderService private readonly reminder: IAgentReminderService,
     @IAgentLoopService private readonly loop: IAgentLoopService,
@@ -829,6 +830,10 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
     return resolveAgentTaskConfig(this.config)?.keepAliveOnExit === true;
   }
 
+  private lifecycleActive(): boolean {
+    return this.sessionEventBus.isAgentActive(this.scopeContext.agentContext);
+  }
+
   async wait(
     taskId: string,
     timeoutMs = 30_000,
@@ -1061,6 +1066,7 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
   }
 
   private recordTaskStarted(info: AgentTaskInfo): void {
+    if (!this.lifecycleActive()) return;
     void this.dispatcher.dispatch(
       new TaskStarted({ agentId: this.scopeContext.agentId, info }),
     );
@@ -1071,6 +1077,7 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
   }
 
   private recordTaskTerminated(info: AgentTaskInfo, outputTail?: string): void {
+    if (!this.lifecycleActive()) return;
     void this.dispatcher.dispatch(
       new TaskTerminated({ agentId: this.scopeContext.agentId, info, outputTail }),
     );
@@ -1083,6 +1090,7 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
   }
 
   private async notifyAgentTask(info: AgentTaskInfo): Promise<void> {
+    if (!this.lifecycleActive()) return;
     const context = await this.buildAgentTaskNotificationContext(info);
     if (context === undefined) return;
     const key = notificationKey(context.origin);
@@ -1275,6 +1283,7 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
   }
 
   private fireNotificationHook(notification: AgentTaskNotification): void {
+    if (!this.lifecycleActive()) return;
     void this.dispatcher.dispatch(
       new TaskNotified({
         agentId: this.scopeContext.agentId,

--- a/packages/agent-core-v2/src/app/event/eventBus.ts
+++ b/packages/agent-core-v2/src/app/event/eventBus.ts
@@ -18,6 +18,7 @@ export const IEventBus: ServiceIdentifier<IEventBus> = createDecorator<IEventBus
 export interface ISessionEventBus extends IEventBus {
   activateAgent(agent: AgentContext): void;
   deactivateAgent(agent: AgentContext): void;
+  isAgentActive(agent: AgentContext): boolean;
   sourceOf(event: Event2<any>): AgentContext | undefined;
   onAgent<P extends AgentDomainTrait, E extends Event2<P>>(
     agent: AgentContext,

--- a/packages/agent-core-v2/src/app/event/eventBusService.ts
+++ b/packages/agent-core-v2/src/app/event/eventBusService.ts
@@ -25,6 +25,10 @@ export class EventBusService extends Service implements ISessionEventBus {
     if (this.agents.get(agent.agentId) === agent) this.agents.delete(agent.agentId);
   }
 
+  isAgentActive(agent: AgentContext): boolean {
+    return this.agents.get(agent.agentId) === agent;
+  }
+
   publish(event: Event2<any>, agent?: AgentContext): void {
     const cls = event.constructor as Event2Class;
     if (cls.agentDomain) {

--- a/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
+++ b/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
@@ -388,7 +388,6 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
     managed.closing = true;
     this.onWillCloseEmitter.fire(agent);
     const handle = managed.handle;
-    await handle.accessor.get(IAgentTaskService).stopAllOnExit('Session closed');
     const loop = handle.accessor.get(IAgentLoopService);
     const compaction = handle.accessor.get(IAgentFullCompactionService).compacting;
     const compactionSettled = compaction?.promise.catch(() => undefined) ?? Promise.resolve();
@@ -428,6 +427,7 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
       await new Promise((resolve) => setTimeout(resolve, REMOVE_PROMPT_QUIESCE_POLL_MS));
     }
     try {
+      await handle.accessor.get(IAgentTaskService).stopAllOnExit('Session closed');
       await handle.accessor.get(IEventDispatcher).flush().catch(onUnexpectedError);
       managed.killSpace();
       await handle.dispose();

--- a/packages/agent-core-v2/test/agent/task/taskService.test.ts
+++ b/packages/agent-core-v2/test/agent/task/taskService.test.ts
@@ -643,7 +643,8 @@ describe('AgentTaskService', () => {
     expect(forceStop).not.toHaveBeenCalled();
   });
 
-  it('scope disposal leaves a process running when keepAliveOnExit is set', async () => {
+  it('scope disposal leaves a process running when keepAliveOnExit is set, and its late settle stays silent after deactivation', async () => {
+    const { records } = capturingWire();
     stubTaskConfig({ keepAliveOnExit: true });
     const stdout = new Readable({ read() {} });
     const stderr = new Readable({ read() {} });
@@ -662,7 +663,8 @@ describe('AgentTaskService', () => {
       dispose: vi.fn().mockResolvedValue(undefined),
     } as unknown as IHostProcess;
     const svc = ix.get(IAgentTaskService);
-    svc.registerTask(new ProcessTask(proc, 'keep-running', 'long-running process'));
+    const taskId = svc.registerTask(new ProcessTask(proc, 'keep-running', 'long-running process'));
+    const agentContext = ix.get(IAgentScopeContext).agentContext;
     await Promise.resolve();
 
     disposables.dispose();
@@ -671,10 +673,14 @@ describe('AgentTaskService', () => {
     expect(proc.kill).not.toHaveBeenCalled();
     expect(proc.dispose).not.toHaveBeenCalled();
 
+    eventBus.deactivateAgent(agentContext);
     stdout.push(null);
     stderr.push(null);
     resolveWait(0);
-    await Promise.resolve();
+    await waitForCondition(() => svc.getTask(taskId)?.status === 'completed');
+
+    expect(svc.getTask(taskId)?.status).toBe('completed');
+    expect(records.filter((record) => record['type'] === 'task.terminated')).toHaveLength(0);
   });
 
   it('stop requests force-stop when killGracePeriodMs is zero', async () => {

--- a/packages/agent-core-v2/test/agent/task/taskService.test.ts
+++ b/packages/agent-core-v2/test/agent/task/taskService.test.ts
@@ -645,6 +645,8 @@ describe('AgentTaskService', () => {
 
   it('scope disposal leaves a process running when keepAliveOnExit is set, and its late settle stays silent after deactivation', async () => {
     const { records } = capturingWire();
+    const track2 = vi.fn();
+    ix.stub(ITelemetryService, { track2 });
     stubTaskConfig({ keepAliveOnExit: true });
     const stdout = new Readable({ read() {} });
     const stderr = new Readable({ read() {} });
@@ -681,6 +683,10 @@ describe('AgentTaskService', () => {
 
     expect(svc.getTask(taskId)?.status).toBe('completed');
     expect(records.filter((record) => record['type'] === 'task.terminated')).toHaveLength(0);
+    expect(track2.mock.calls.map(([event]) => event)).toEqual([
+      'background_task_created',
+      'background_task_completed',
+    ]);
   });
 
   it('stop requests force-stop when killGracePeriodMs is zero', async () => {

--- a/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
+++ b/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
@@ -709,6 +709,9 @@ describe('AgentLifecycleService', () => {
 
     expect(stopAllOnExit).toHaveBeenCalledWith('Session closed');
     expect(promptDrain).toHaveBeenCalledOnce();
+    expect(stopAllOnExit.mock.invocationCallOrder[0]).toBeGreaterThan(
+      promptDrain.mock.invocationCallOrder[0]!,
+    );
   });
 
   it('remove waits for prompt intake to drain before disposing the agent scope', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue — reported directly: archiving a session with running background tasks (bash, subagents) throws `Agent event 'task.terminated' has no active lifecycle context` as an unhandled rejection.

## Problem

When a session is archived (or closed) while background tasks are still running, task settlement is driven by the process lifecycle and can legitimately land after the agent's lifecycle context has been torn down. Three concrete paths lead there:

- `keepAliveOnExit` is designed to let tasks outlive the session, so their settlement necessarily happens after teardown;
- `AgentTaskService.dispose()` aborts live tasks without awaiting their settlement, so the SIGTERM → process-exit → settle chain completes after the scope is disposed;
- `AgentLifecycleService.remove()` ran `stopAllOnExit` before silencing the loop, so a still-running turn could register a new task during teardown that escaped the stop sweep.

In all three cases the late `settleTask` dispatched `task.terminated` through the event bus, whose lifecycle guard throws for any agent-domain event published after `deactivateAgent`. The dispatch call site is fire-and-forget (`void`), so the throw surfaced as an unhandled promise rejection.

## What changed

- `ISessionEventBus` gains `isAgentActive(agent)` (implemented by `EventBusService` against the same `agents` map the publish guard reads, so the check cannot race the throw).
- `AgentTaskService` now guards every event-bus side effect — `recordTaskStarted`, `recordTaskTerminated`, `notifyAgentTask`, `fireNotificationHook` — on that activity check: once the agent's lifecycle context is gone, terminal events and notifications are skipped, while state migration and terminal-state persistence in `settleTask` still run, so a reopened session reads the correct terminal state from disk.
- `AgentLifecycleService.remove()` now silences the loop/prompt intake first and calls `stopAllOnExit` afterwards (before dispatcher flush and scope disposal), closing the window where a running turn registers new tasks mid-teardown.
- Tests: extended the existing `keepAliveOnExit` disposal test to cover late settlement after deactivation (no throw, no `task.terminated` wire record, terminal status still persisted), and the existing remove test to assert `stopAllOnExit` runs after prompt drain. Test count unchanged.

The publish guard itself is unchanged — publishing agent events outside an active lifecycle context still throws for every other domain.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
