### PR TITLE
feat(remote-control): cache rewritten tunnel responses with ETag validation

### DIFF
--- a/.changeset/rc-tunnel-cache.md
+++ b/.changeset/rc-tunnel-cache.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Cache rewritten Remote Control tunnel responses with ETag validation.

--- a/.changeset/rc-tunnel-cache.md
+++ b/.changeset/rc-tunnel-cache.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Cache rewritten Remote Control tunnel responses with ETag validation.
+Reuse unchanged Remote Control assets across page loads instead of retransferring them.

--- a/packages/remote-control/src/remote-control.ts
+++ b/packages/remote-control/src/remote-control.ts
@@ -261,7 +261,9 @@ function requestMatchesETag(
   for (const [name, value] of headers) {
     if (name.toLowerCase() !== 'if-none-match') continue;
     for (const token of value.split(',')) {
-      if (candidates.includes(token.trim())) return true;
+      const candidate = token.trim();
+      if (candidate === '*') return true;
+      if (candidates.includes(candidate)) return true;
     }
   }
   return false;
@@ -878,7 +880,12 @@ function requestLocalHttp(
             if (rewritten) {
               const etag = rewrittenResponseETag(body);
               headers.push('Cache-Control', 'no-cache', 'ETag', etag);
-              if (requestMatchesETag(parsed.headers, etag)) {
+              const statusCode = response.statusCode ?? 502;
+              const revalidatable =
+                (parsed.method === 'GET' || parsed.method === 'HEAD') &&
+                statusCode >= 200 &&
+                statusCode < 300;
+              if (revalidatable && requestMatchesETag(parsed.headers, etag)) {
                 return Buffer.from(`HTTP/1.1 304 Not Modified\r\n${headerLines(headers)}\r\n\r\n`);
               }
             }

--- a/packages/remote-control/src/remote-control.ts
+++ b/packages/remote-control/src/remote-control.ts
@@ -250,14 +250,14 @@ function isGzipCompressibleType(contentType: string): boolean {
 }
 
 function rewrittenResponseETag(body: Buffer): string {
-  return `"${createHash('sha256').update(body).digest('hex')}"`;
+  return `W/"${createHash('sha256').update(body).digest('hex')}"`;
 }
 
 function requestMatchesETag(
   headers: readonly [string, string][],
   etag: string,
 ): boolean {
-  const candidates = [etag, `W/${etag}`];
+  const candidates = [etag, etag.replace(/^W\//, '')];
   for (const [name, value] of headers) {
     if (name.toLowerCase() !== 'if-none-match') continue;
     for (const token of value.split(',')) {
@@ -879,7 +879,6 @@ function requestLocalHttp(
               const etag = rewrittenResponseETag(body);
               headers.push('Cache-Control', 'no-cache', 'ETag', etag);
               if (requestMatchesETag(parsed.headers, etag)) {
-                headers.push('Content-Length', '0');
                 return Buffer.from(`HTTP/1.1 304 Not Modified\r\n${headerLines(headers)}\r\n\r\n`);
               }
             }

--- a/packages/remote-control/src/remote-control.ts
+++ b/packages/remote-control/src/remote-control.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { hostname, platform } from 'node:os';
 import { join } from 'node:path';
 import { request as httpRequest, validateHeaderName, validateHeaderValue } from 'node:http';
@@ -246,6 +247,24 @@ function acceptsGzipEncoding(headers: readonly [string, string][]): boolean {
 function isGzipCompressibleType(contentType: string): boolean {
   const mime = contentType.split(';', 1)[0]!.trim().toLowerCase();
   return mime.startsWith('text/') || GZIP_COMPRESSIBLE_TYPES.has(mime);
+}
+
+function rewrittenResponseETag(body: Buffer): string {
+  return `"${createHash('sha256').update(body).digest('hex')}"`;
+}
+
+function requestMatchesETag(
+  headers: readonly [string, string][],
+  etag: string,
+): boolean {
+  const candidates = [etag, `W/${etag}`];
+  for (const [name, value] of headers) {
+    if (name.toLowerCase() !== 'if-none-match') continue;
+    for (const token of value.split(',')) {
+      if (candidates.includes(token.trim())) return true;
+    }
+  }
+  return false;
 }
 
 export async function startRemoteControl(
@@ -856,7 +875,14 @@ function requestLocalHttp(
                 : receivedBody;
             const rewritten = body !== receivedBody;
             const headers = filterResponseHeaders(response.rawHeaders, rewritten);
-            if (rewritten) headers.push('Cache-Control', 'no-cache');
+            if (rewritten) {
+              const etag = rewrittenResponseETag(body);
+              headers.push('Cache-Control', 'no-cache', 'ETag', etag);
+              if (requestMatchesETag(parsed.headers, etag)) {
+                headers.push('Content-Length', '0');
+                return Buffer.from(`HTTP/1.1 304 Not Modified\r\n${headerLines(headers)}\r\n\r\n`);
+              }
+            }
             const negotiated =
               response.headers['content-encoding'] === undefined &&
               response.statusCode !== 206 &&
@@ -877,9 +903,6 @@ function requestLocalHttp(
             if (negotiated && acceptsGzipEncoding(parsed.headers)) {
               body = await gzipAsync(body);
               headers.push('Content-Encoding', 'gzip');
-              for (let index = headers.length - 2; index >= 0; index -= 2) {
-                if (headers[index]!.toLowerCase() === 'etag') headers.splice(index, 2);
-              }
             }
             headers.push('Content-Length', String(body.length));
             const statusCode = response.statusCode ?? 502;
@@ -898,7 +921,7 @@ function requestLocalHttp(
   });
 }
 
-function filterResponseHeaders(rawHeaders: readonly string[], blockCacheControl = false): string[] {
+function filterResponseHeaders(rawHeaders: readonly string[], blockCacheValidators = false): string[] {
   const connectionHeaders = new Set<string>();
   for (let index = 0; index < rawHeaders.length; index += 2) {
     if (rawHeaders[index]!.toLowerCase() === 'connection') {
@@ -914,7 +937,12 @@ function filterResponseHeaders(rawHeaders: readonly string[], blockCacheControl 
     if (BLOCKED_RESPONSE_HEADERS.has(lower) || connectionHeaders.has(lower)) {
       continue;
     }
-    if (blockCacheControl && lower === 'cache-control') continue;
+    if (
+      blockCacheValidators &&
+      (lower === 'cache-control' || lower === 'etag' || lower === 'last-modified')
+    ) {
+      continue;
+    }
     result.push(name, rawHeaders[index + 1]!);
   }
   return result;

--- a/packages/remote-control/test/remote-control.test.ts
+++ b/packages/remote-control/test/remote-control.test.ts
@@ -455,11 +455,36 @@ describe('Remote Control tunnel', () => {
     expect(gzipHead).toContain('HTTP/1.1 200 OK');
     expect(gzipHead).toContain('Content-Encoding: gzip');
     expect(gzipHead).toContain('Vary: Accept-Encoding');
-    expect(gzipHead).not.toContain('ETag');
+    expect(gzipHead).toContain('Cache-Control: no-cache');
+    const rewrittenETag = /ETag: "([0-9a-f]{64})"/.exec(gzipHead)?.[0];
+    expect(rewrittenETag).toBeDefined();
     expect(gzipHead).toContain(`Content-Length: ${gzipBody.length}`);
     expect(gunzipSync(gzipBody).toString()).toBe(
       assetJs.replaceAll('"/assets/', `"/coding-relay/devices/${handle.deviceId}/assets/`),
     );
+
+    const revalidateResponsePromise = nextJsonMessage(httpConnections[0]!);
+    httpConnections[0]!.send(
+      JSON.stringify({
+        request_id: 'request-3b',
+        type: 'request',
+        is_last: true,
+        body_base64: Buffer.from(
+          `GET /assets/index.js HTTP/1.1\r\nHost: relay.test\r\nAccept-Encoding: br, gzip\r\nIf-None-Match: ${rewrittenETag!.replace('ETag: ', '')}\r\n\r\n`,
+        ).toString('base64'),
+      }),
+    );
+    const revalidateResponse = Buffer.from(
+      (await revalidateResponsePromise)['body_base64'] as string,
+      'base64',
+    );
+    const revalidateHead = revalidateResponse
+      .subarray(0, revalidateResponse.indexOf('\r\n\r\n'))
+      .toString('latin1');
+    expect(revalidateHead).toContain('HTTP/1.1 304 Not Modified');
+    expect(revalidateHead).toContain('Cache-Control: no-cache');
+    expect(revalidateHead).toContain(rewrittenETag!);
+    expect(revalidateHead).not.toContain('Content-Encoding');
 
     const binaryResponsePromise = nextJsonMessage(httpConnections[0]!);
     httpConnections[0]!.send(
@@ -501,7 +526,8 @@ describe('Remote Control tunnel', () => {
     const excludedHead = excludedResponse.subarray(0, excludedSeparator).toString('latin1');
     expect(excludedHead).not.toContain('Content-Encoding');
     expect(excludedHead).toContain('Vary: Accept-Encoding');
-    expect(excludedHead).toContain('ETag: "v1"');
+    expect(excludedHead).toContain(rewrittenETag!);
+    expect(excludedHead).not.toContain('ETag: "v1"');
     expect(excludedResponse.subarray(excludedSeparator + 4).toString()).toBe(
       assetJs.replaceAll('"/assets/', `"/coding-relay/devices/${handle.deviceId}/assets/`),
     );

--- a/packages/remote-control/test/remote-control.test.ts
+++ b/packages/remote-control/test/remote-control.test.ts
@@ -456,7 +456,7 @@ describe('Remote Control tunnel', () => {
     expect(gzipHead).toContain('Content-Encoding: gzip');
     expect(gzipHead).toContain('Vary: Accept-Encoding');
     expect(gzipHead).toContain('Cache-Control: no-cache');
-    const rewrittenETag = /ETag: "([0-9a-f]{64})"/.exec(gzipHead)?.[0];
+    const rewrittenETag = /ETag: (W\/"[0-9a-f]{64}")/.exec(gzipHead)?.[0];
     expect(rewrittenETag).toBeDefined();
     expect(gzipHead).toContain(`Content-Length: ${gzipBody.length}`);
     expect(gunzipSync(gzipBody).toString()).toBe(
@@ -485,6 +485,7 @@ describe('Remote Control tunnel', () => {
     expect(revalidateHead).toContain('Cache-Control: no-cache');
     expect(revalidateHead).toContain(rewrittenETag!);
     expect(revalidateHead).not.toContain('Content-Encoding');
+    expect(revalidateHead).not.toContain('Content-Length');
 
     const binaryResponsePromise = nextJsonMessage(httpConnections[0]!);
     httpConnections[0]!.send(


### PR DESCRIPTION
## Related Issue

Remote Control Web UI 静态资源每次打开都通过隧道全量重拉（chunk 拆分调研的附带发现，单独立项修复）。

## Problem

隧道转发时对被 URL 重写的响应（HTML/JS/CSS）强制 `Cache-Control: no-cache` 且不生成 ETag：本地服务对内容被改写的资源给出的 ETag 已不匹配改写后的内容，被直接剥掉。浏览器因此无法使用协商缓存，每次打开 Remote Control 都要经隧道重新传输全部 JS/CSS bundle——在 feat-187 gzip 压缩后仍要付一次完整的上行传输和 30s 超时风险。

## What changed

在隧道 client（`packages/remote-control`）为被重写的响应生成内容寻址 ETag 并支持协商缓存：

- 对改写后的 body 计算 `sha256` 弱 ETag（`W/"…"`，gzip 与 identity 变体共用）返回给浏览器（替代不再匹配的源站 ETag）；保留 `Cache-Control: no-cache`（语义为每次 revalidate，内容变更即刻生效，不会缓存过期内容）。
- GET/HEAD 且上游 2xx 时，请求的 `If-None-Match`（含 `*` 通配）与改写后内容的 ETag 匹配则直接回 `304 Not Modified`，不再传输 body——静态内容未变时第二次打开 Remote Control 的资源传输接近零（304 帧仅几百字节）。
- 被重写响应同时剥离源站 `Last-Modified`，避免基于改写前文件 mtime 的验证器造成缓存不一致。
- gzip 协商路径不再删 ETag：验证器按未压缩的改写后内容计算并标记为弱验证器，gzip 与 identity 两种变体都能正确 revalidate。

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

