### PR TITLE
fix(agent-core-v2): resolve reopened agents to their roster branch

### DIFF
--- a/packages/agent-core-v2/src/human/session/stores.ts
+++ b/packages/agent-core-v2/src/human/session/stores.ts
@@ -3,6 +3,7 @@ import type { ExternalEvent } from '#/eventStore/events';
 import { journalFromBranch } from '#/eventStore/journal';
 import { agentSlices, type AgentEventStore } from '#/agent/slices';
 import type { StoreBackend } from '#/store/backend/backend';
+import type { Branch } from '#/store/branch';
 import { StoreError, type BranchRef } from '#/store/types';
 import type { Tree } from '#/store/tree';
 
@@ -74,17 +75,26 @@ export class SessionStores {
     if (existing !== undefined) {
       return existing;
     }
-    const existed = this.tree.has(agentId);
-    const branch = existed
-      ? this.tree.openBranch(agentId)
-      : this.tree.createBranch(agentId, opts?.from !== undefined ? { from: opts.from } : undefined);
+    const session = await this.session();
+    const registered = session.getState().roster.agents[agentId];
+    let branch: Branch;
+    if (registered !== undefined) {
+      branch = this.tree.openBranch(registered);
+    } else if (this.tree.has(agentId)) {
+      branch = this.tree.openBranch(agentId);
+    } else {
+      branch = this.tree.createBranch(
+        agentId,
+        opts?.from !== undefined ? { from: opts.from } : undefined,
+      );
+    }
     const engine = await createEventStore({
       journal: journalFromBranch(branch, this.tree),
       slices: agentSlices,
     });
     this.agents.set(agentId, engine);
-    if (!existed) {
-      await (await this.session()).dispatch(agentOpened({ agentId, branch: branch.name }));
+    if (registered === undefined) {
+      await session.dispatch(agentOpened({ agentId, branch: branch.name }));
     }
     return engine;
   }

--- a/packages/agent-core-v2/src/human/test/session/migrate-v2.test.ts
+++ b/packages/agent-core-v2/src/human/test/session/migrate-v2.test.ts
@@ -604,6 +604,13 @@ describe('migrateV2Session', () => {
     const roster = (await second.stores.session()).getState().roster.agents;
     expect(Object.keys(roster)).toEqual([MAIN]);
     expect(roster[MAIN]).toBe('main~2');
+    const reopenedAgent = await second.stores.open(MAIN);
+    expect(reopenedAgent.ref.branch).toBe('main~2');
+    expect(reopenedAgent.getState().history.map((entry) => extractText(entry.message))).toEqual([
+      'first',
+      'first-reply',
+      'again',
+    ]);
     const names = await readdir(dir);
     expect(names.filter((name) => name.startsWith('.migrate'))).toEqual([]);
     expect(names).toContain('state.json');

--- a/packages/agent-core-v2/src/human/test/session/stores.test.ts
+++ b/packages/agent-core-v2/src/human/test/session/stores.test.ts
@@ -185,16 +185,18 @@ describe('SessionStores reopen', () => {
     await runTurn(forkActor, fork, 'fork-hi', 6);
     forkActor.stop();
     actor.stop();
+    await env.stores.undo('main', 1);
 
     const restored = await reopen(env);
 
     expect((await restored.stores.session()).getState().roster.agents).toEqual({
       fork: 'fork',
-      main: 'main',
+      main: 'main~2',
     });
     const restoredMain = await restored.stores.open('main');
-    expect(historyTexts(restoredMain)).toEqual(['first', 'echo:first', 'second', 'echo:second']);
-    expect(restoredMain.getState().turnIndex.nextTurnId).toBe(2);
+    expect(restoredMain.ref.branch).toBe('main~2');
+    expect(historyTexts(restoredMain)).toEqual(['first', 'echo:first', 'second']);
+    expect(restoredMain.getState().turnIndex.nextTurnId).toBe(1);
     const restoredFork = await restored.stores.open('fork');
     expect(historyTexts(restoredFork)).toEqual([
       'first',
@@ -207,16 +209,15 @@ describe('SessionStores reopen', () => {
     expect(restoredFork.getState().turnIndex.nextTurnId).toBe(3);
 
     const actor2 = startAgent(restoredMain);
-    await runTurn(actor2, restoredMain, 'again', 6);
+    await runTurn(actor2, restoredMain, 'again', 5);
     expect(historyTexts(restoredMain)).toEqual([
       'first',
       'echo:first',
       'second',
-      'echo:second',
       'again',
       'echo:again',
     ]);
-    expect(restoredMain.getState().turnIndex.nextTurnId).toBe(3);
+    expect(restoredMain.getState().turnIndex.nextTurnId).toBe(2);
 
     actor2.stop();
   });


### PR DESCRIPTION
## Related Issue

Internal bug report (no public issue): reopening an agent after undo + process restart resurrects the undone turns.

## Problem

`SessionStores` manages one branch per agent plus a `_session` branch whose `agent.opened` / `agent.switched` / `agent.closed` events fold into a roster mapping each agent to its current branch. This roster must exist because undo is non-destructive: `undo('main', 1)` forks a new branch `main~2` and switches to it, while the old `main` branch keeps its full pre-undo history.

The read side had a gap: `open()` resolved branches purely by agent name (`tree.has(agentId)` → open the same-named branch) and never consulted the roster. Within the same process this went unnoticed (the in-memory store was already reset), but after a process restart `open('main')` opened the stale pre-undo branch and every undone turn came back. The migrate-v2 end-to-end test asserted only the roster contents after a restart, never the history the reopened agent actually sees — exactly the gap.

## What changed

- `SessionStores.open()` now treats the roster as authoritative: it reads the folded roster first and opens the registered branch when an entry exists (a roster entry pointing at a missing branch fails loudly via `openBranch` — corrupted data, no silent fallback). Without an entry it keeps the existing fallback — open the same-named branch (covers the crash window between `createBranch` and the persisted `agent.opened`) or create one from `opts.from` — and dispatches `agent.opened` to backfill the registration whenever it opens a branch with no roster entry, so first open and crash-window repair share one registration path.
- Tests extended with zero net test-count change: the stores reopen case now undoes before reopening and asserts the restored agent follows the roster (`main~2`, post-undo history) while the fork branch keeps its own full history; the migrate-v2 end-to-end case now also opens the agent after the simulated restart and asserts `ref.branch` and the folded history, not just the roster contents.
- No changeset: `SessionStores` is only consumed by `human/` tests and `persist/open.ts` so far — production DI wiring lands in a follow-up task, so the fix is not user-perceivable yet.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
