### PR TITLE
fix(oauth): record max_output_size from custom-registry model limits

### DIFF
--- a/.changeset/custom-registry-max-output-size.md
+++ b/.changeset/custom-registry-max-output-size.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix 400 "Invalid max_tokens" errors for models imported from a custom registry (api.json) by recording each model's advertised output token limit.

--- a/packages/oauth/src/custom-registry.ts
+++ b/packages/oauth/src/custom-registry.ts
@@ -294,6 +294,14 @@ function resolveMaxContextSize(model: CustomRegistryModelEntry): number {
   return CUSTOM_REGISTRY_DEFAULT_MAX_CONTEXT;
 }
 
+function resolveMaxOutputSize(model: CustomRegistryModelEntry): number | undefined {
+  const output = model.limit?.output;
+  if (typeof output === 'number' && Number.isInteger(output) && output > 0) {
+    return output;
+  }
+  return undefined;
+}
+
 function resolveCapabilities(model: CustomRegistryModelEntry): string[] {
   if (hasRichCapabilityHints(model)) {
     return capabilitiesFromCustomEntry(model);
@@ -340,6 +348,7 @@ export function applyCustomRegistryProvider(
   for (const [modelKey, model] of Object.entries(entry.models)) {
     const aliasKey = `${providerKey}/${modelKey}`;
     const maxContextSize = resolveMaxContextSize(model);
+    const maxOutputSize = resolveMaxOutputSize(model);
     const capabilities = resolveCapabilities(model);
     const displayName =
       typeof model.name === 'string' && model.name.length > 0 ? model.name : model.id;
@@ -351,6 +360,7 @@ export function applyCustomRegistryProvider(
       maxContextSize,
       capabilities,
       displayName,
+      maxOutputSize,
       ...(model.support_efforts !== undefined ? { supportEfforts: model.support_efforts } : {}),
       ...(model.default_effort !== undefined ? { defaultEffort: model.default_effort } : {}),
     };

--- a/packages/oauth/src/model-alias-merge.ts
+++ b/packages/oauth/src/model-alias-merge.ts
@@ -18,6 +18,7 @@ export const CUSTOM_REGISTRY_MODEL_FIELDS: ReadonlySet<string> = new Set([
   'provider',
   'model',
   'maxContextSize',
+  'maxOutputSize',
   'capabilities',
   'displayName',
   'supportEfforts',

--- a/packages/oauth/test/custom-registry.test.ts
+++ b/packages/oauth/test/custom-registry.test.ts
@@ -177,7 +177,7 @@ describe('fetchCustomRegistry', () => {
     const error = await fetchCustomRegistry(
       KOKUB_SOURCE,
       { fetchImpl: fetchMock as unknown as typeof fetch },
-    ).catch((caught: unknown) => caught);
+    ).catch((error: unknown) => error);
 
     expect(error).toBeInstanceOf(CustomRegistryApiError);
     expect((error as CustomRegistryApiError).status).toBe(401);
@@ -330,6 +330,31 @@ describe('applyCustomRegistryProvider', () => {
     expect(alias.capabilities).not.toContain('image_out');
   });
 
+  it('maps limit.output onto the model alias maxOutputSize', () => {
+    const config: ManagedKimiConfigShape = { providers: {} };
+
+    applyCustomRegistryProvider(
+      config,
+      {
+        id: 'registry_chat-completions',
+        name: 'Sample Registry (chat completions)',
+        api: 'https://registry.example.test/v1',
+        type: 'openai_responses',
+        models: {
+          'deepseek-flash': {
+            id: 'deepseek-flash',
+            name: 'DeepSeek Flash',
+            limit: { context: 1000000, output: 393216 },
+          },
+        },
+      },
+      KOKUB_SOURCE,
+    );
+
+    const alias = config.models?.['registry_chat-completions/deepseek-flash'];
+    expect(alias?.['maxOutputSize']).toBe(393216);
+  });
+
   it('clears stale aliases for the same provider before re-populating', () => {
     const config: ManagedKimiConfigShape = {
       providers: {
@@ -462,6 +487,37 @@ describe('applyCustomRegistryProvider', () => {
     expect(alias['supportEfforts']).toEqual(['low', 'high', 'max']);
   });
 
+  it('drops a stale maxOutputSize when a refresh no longer declares limit.output', () => {
+    const config: ManagedKimiConfigShape = {
+      providers: {},
+      models: {
+        'registry_chat-completions/gpt-5.5': {
+          provider: 'registry_chat-completions',
+          model: 'gpt-5.5',
+          maxContextSize: 131072,
+          maxOutputSize: 8192,
+        } as Record<string, unknown>,
+      },
+    };
+
+    applyCustomRegistryProvider(
+      config,
+      {
+        id: 'registry_chat-completions',
+        name: 'Sample Registry (chat completions)',
+        api: 'https://registry.example.test/v1',
+        type: 'openai',
+        models: {
+          'gpt-5.5': { id: 'gpt-5.5', name: 'GPT 5.5' },
+        },
+      },
+      KOKUB_SOURCE,
+    );
+
+    const alias = config.models?.['registry_chat-completions/gpt-5.5'];
+    expect(alias?.['maxOutputSize']).toBeUndefined();
+  });
+
   it('drops stale effort fields when a refresh no longer declares them', () => {
     const config: ManagedKimiConfigShape = {
       providers: {},
@@ -580,7 +636,7 @@ describe('applyCustomRegistryEntries', () => {
     applyCustomRegistryEntries(config, entries, source);
     applyCustomRegistryEntries(config, entries, source);
 
-    expect(Object.keys(config.providers).sort()).toEqual(['a', 'b', 'c']);
+    expect(Object.keys(config.providers).toSorted()).toEqual(['a', 'b', 'c']);
     expect(config.models?.['a/m1']).toBeDefined();
     expect(config.models?.['b/m1']).toBeDefined();
     expect(config.models?.['c/m1']).toBeDefined();


### PR DESCRIPTION
## Related Issue

Resolve #3732

## Problem

See linked issue. In short: models imported from a custom registry (`api.json`) ignore the advertised `limit.output`, so the alias never records `maxOutputSize`. The completion-budget cap then falls back to the model's full context size and goes out as the protocol's output-token field (`max_output_tokens` for `openai_responses`, `max_completion_tokens`/`max_tokens` for `openai`, `max_tokens` for `anthropic` — which additionally falls back to a 128k provider default). Any registry model with a smaller real output cap rejects the request with a 400 (e.g. "Invalid max_output_tokens").

## What changed

- `packages/oauth/src/custom-registry.ts`: read `limit.output` (validated as a positive integer) from each registry model entry into the alias `maxOutputSize` — mirroring how `limit.context` → `maxContextSize` is already handled, and matching the existing models.dev integration's convention for the same field.
- `packages/oauth/src/model-alias-merge.ts`: add `maxOutputSize` to `CUSTOM_REGISTRY_MODEL_FIELDS` so registry refreshes keep the field in sync — new values applied, stale values dropped when the registry stops declaring it, user `overrides` preserved.
- Tests: cover the `limit.output` → `maxOutputSize` mapping and the stale-drop-on-refresh case.
- Changeset included (`@moonshot-ai/kimi-code`, patch).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PR — awaiting the maintainer's `/approve` on the issue per policy).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No doc update needed: the docs do not document registry `limit` fields, and this change makes behavior match the data registries already advertise.)
